### PR TITLE
[#170] Store imported data twice

### DIFF
--- a/backend/resources/org/akvo/dash/migrations_tenants/005-dataset-version.up.sql
+++ b/backend/resources/org/akvo/dash/migrations_tenants/005-dataset-version.up.sql
@@ -5,6 +5,8 @@ CREATE TABLE dataset_version (
     version smallint NOT NULL,
     -- The name of the data table
     table_name text UNIQUE NOT NULL,
+    -- The name of the data table that holds imported (non-transformed) data
+    imported_table_name text UNIQUE NOT NULL,
     columns jsonb NOT NULL DEFAULT '[]'::jsonb,
     created timestamptz DEFAULT now(),
     modified timestamptz DEFAULT now(),

--- a/backend/src/org/akvo/dash/import.clj
+++ b/backend/src/org/akvo/dash/import.clj
@@ -14,16 +14,22 @@
 
 (hugsql/def-db-fns "org/akvo/dash/import.sql")
 
+(defn gen-table-name [prefix]
+  (str prefix "_" (str/replace (java.util.UUID/randomUUID) "-" "_")))
+
 (defn successful-import [conn job-execution-id table-name status spec]
-  (let [dataset-id (squuid)]
+  (let [dataset-id (squuid)
+        imported-table-name (gen-table-name "imported")]
     (insert-dataset conn {:id dataset-id
                           :title (get spec "name") ;; TODO Consistent naming. Change on client side?
                           :description (get spec "description" "")})
-
+    (clone-data-table conn {:from-table table-name
+                            :to-table imported-table-name})
     (insert-dataset-version conn {:id (squuid)
                                   :dataset-id dataset-id
                                   :job-execution-id job-execution-id
                                   :table-name table-name
+                                  :imported-table-name imported-table-name
                                   :version 1
                                   :columns (mapv (fn [{:keys [title column-name type]}]
                                                    {:type type
@@ -33,6 +39,7 @@
                                                     :direction nil
                                                     :hidden false})
                                                  (:columns status))})
+
     (update-successful-job-execution conn {:id job-execution-id})))
 
 (defn failed-import [conn job-execution-id reason]
@@ -41,7 +48,7 @@
 
 (defn do-import [conn config job-execution-id]
   (try
-    (let [table-name (str "ds_" (str/replace (java.util.UUID/randomUUID) "-" "_"))
+    (let [table-name (gen-table-name "ds")
           spec (:spec (data-source-spec-by-job-execution-id conn {:job-execution-id job-execution-id}))
           status (import/make-dataset-data-table conn config table-name (get spec "source"))]
       (if (:success? status)

--- a/backend/src/org/akvo/dash/import.sql
+++ b/backend/src/org/akvo/dash/import.sql
@@ -18,7 +18,7 @@ VALUES (:id, :dataset-id, :job-execution-id, :table-name, :imported-table-name, 
 
 -- :name clone-data-table :! :n
 -- :doc Clone a data table
-CREATE TABLE :i:to-table AS SELECT * FROM :i:from-table
+CREATE TABLE :i:to-table AS TABLE :i:from-table
 
 -- :name data-source-spec-by-job-execution-id :? :1
 -- :doc Get the data source spec by job execution id

--- a/backend/src/org/akvo/dash/import.sql
+++ b/backend/src/org/akvo/dash/import.sql
@@ -13,8 +13,12 @@ VALUES (:id, :title, :description)
 
 -- :name insert-dataset-version :! :n
 -- :doc Insert new dataset version
-INSERT INTO dataset_version(id, dataset_id, job_execution_id, table_name, version, columns)
-VALUES (:id, :dataset-id, :job-execution-id, :table-name, :version, :columns)
+INSERT INTO dataset_version(id, dataset_id, job_execution_id, table_name, imported_table_name, version, columns)
+VALUES (:id, :dataset-id, :job-execution-id, :table-name, :imported-table-name, :version, :columns)
+
+-- :name clone-data-table :! :n
+-- :doc Clone a data table
+CREATE TABLE :i:to-table AS SELECT * FROM :i:from-table
 
 -- :name data-source-spec-by-job-execution-id :? :1
 -- :doc Get the data source spec by job execution id


### PR DESCRIPTION
* In addition to creating the ds_<uuid> table on import we need another copy
  of the exact same data in another table (called imported_<uuid>). This table
  will be used when re-applying the transformation log from the beginning, for
  example in an undo operation.
* Later, in the case of updating datasets (refetching from the data source)
  it will be essential to be able to get back to the data that was successfully
  reimported but failed the subsequent automatic transform operation