### PR TITLE
[#229] Catch and return original dataset if the error strategy is 'fail'

### DIFF
--- a/client/src/components/dataset/sidebars/ChangeDataType.jsx
+++ b/client/src/components/dataset/sidebars/ChangeDataType.jsx
@@ -93,7 +93,7 @@ const errorOptions = [
   },
   {
     value: 'fail',
-    label: 'Let the transform fail',
+    label: 'Abort transformation',
   },
   {
     value: 'delete-row',

--- a/client/src/reducers/transform.js
+++ b/client/src/reducers/transform.js
@@ -30,9 +30,16 @@ function updateTransformationLog(dataset, transformation) {
 }
 
 export default function applyTransformation(dataset, transformation) {
-  const transformedDataset = availableTransforms[transformation.op](dataset, transformation);
-  if (transformedDataset === dataset) {
-    return dataset;
+  try {
+    const transformedDataset = availableTransforms[transformation.op](dataset, transformation);
+    if (transformedDataset === dataset) {
+      return dataset;
+    }
+    return updateTransformationLog(recordHistory(dataset, transformedDataset), transformation);
+  } catch (e) {
+    if (transformation.onError === 'fail') {
+      return dataset;
+    }
+    throw e;
   }
-  return updateTransformationLog(recordHistory(dataset, transformedDataset), transformation);
 }


### PR DESCRIPTION
* We need to figure out how to communicate to the user that a transformation
  was aborted (as requested by the user).