### PR TITLE
[#238] Resolve library sorting by name

### DIFF
--- a/client/src/components/library/LibraryListing.jsx
+++ b/client/src/components/library/LibraryListing.jsx
@@ -29,7 +29,8 @@ const filterEntities = (library, filterBy, searchString) => {
   } else {
     // Basic, proof-of-concept string matching for search function
     unsearchedEntities.forEach(entity => {
-      if (entity.name.toLowerCase().indexOf(searchString.toLowerCase()) > -1) {
+      const entityTitle = entity.name || entity.title;
+      if (entityTitle.toLowerCase().indexOf(searchString.toLowerCase()) > -1) {
         searchedEntities.push(entity);
       }
     });
@@ -43,7 +44,8 @@ const groupEntities = (entities, sortOrder) => {
 
   if (sortOrder === 'name') {
     entities.forEach(entity => {
-      const key = entity.name.toLowerCase().charAt(0);
+      const entityTitle = entity.name || entity.title;
+      const key = entityTitle.toLowerCase().charAt(0);
 
       listGroups[key] = listGroups[key] || { listGroupName: key, entities: [] };
       listGroups[key].entities.push(entity);


### PR DESCRIPTION
* Datasets & visualisations have `name` property while
  dashboards have `title` property instead
* We'll move to using `title` everywhere later, both on
  the client and on the backend.