### PR TITLE
[#246] Permalinks for visualisations and visualisation/create

### DIFF
--- a/client/src/reducers/visualisations.js
+++ b/client/src/reducers/visualisations.js
@@ -31,6 +31,11 @@ function saveVisualisation(state, vis) {
   const id = vis.id;
   const spec = vis.spec;
   const existingVis = state[id];
+  if (existingVis == null) {
+    return Object.assign({}, state, {
+      [id]: Object.assign({}, vis, { type: 'visualisation', status: 'OK' }),
+    });
+  }
   return update(state, {
     [id]: {
       $set: update(existingVis, { $merge: spec }),


### PR DESCRIPTION
@gabemart I hope I didn't break something but can you quickly test

* Creating a new visualisation by selecting New->Dataset in the UI
* Creating a new visualisation by going directly to the url `/visualisation/create`
* Open and edit an existing visualisation via the UI
* Go directly to a visualisation via `/visualisation/<some-valid-uuid>` and edit/save.