### PR TITLE
[#258] [#303] Lumen now pass correct issuer to wrap-jwt-claims

### DIFF
--- a/backend/src/org/akvo/lumen/auth.clj
+++ b/backend/src/org/akvo/lumen/auth.clj
@@ -42,4 +42,4 @@
       (jwt/wrap-jwt-claims handler (jwt/rsa-key certs 0) issuer))
     (catch Exception e
       (println "Could not get cert from Keycloak")
-      (.printStackTrace e))))
+      (throw e))))

--- a/backend/src/org/akvo/lumen/auth.clj
+++ b/backend/src/org/akvo/lumen/auth.clj
@@ -1,9 +1,9 @@
-(ns org.akvo.lumen.middleware
+(ns org.akvo.lumen.auth
   (:require [akvo.commons.jwt :as jwt]
+            [cheshire.core :as json]
             [clj-http.client :as client]
             [clojure.string :as s]
-            [ring.util.response :as response])
-  (:import [java.sql SQLException]))
+            [ring.util.response :as response]))
 
 
 (defn wrap-auth
@@ -33,13 +33,13 @@
 (defn wrap-jwt
   "Go get cert from Keycloak and feed it to wrap-jwt-claims. Keycloak url can
   be configured via the KEYCLOAK_URL env var."
-  [handler issuer]
+  [handler keycloak-url realm]
   (try
-    (let [certs (-> (str issuer "/realms/akvo/protocol/openid-connect/certs")
+    (let [issuer (str keycloak-url "/realms/" realm)
+          certs (-> (str issuer "/protocol/openid-connect/certs")
                     client/get
                     :body)]
       (jwt/wrap-jwt-claims handler (jwt/rsa-key certs 0) issuer))
     (catch Exception e
-      (.printStackTrace e)
-      (when (isa? SQLException (type e))
-        (.printStackTrace (.getNextException ^SQLException e))))))
+      (println "Could not get cert from Keycloak")
+      (.printStackTrace e))))

--- a/backend/src/org/akvo/lumen/config.clj
+++ b/backend/src/org/akvo/lumen/config.clj
@@ -9,4 +9,5 @@
    :db   {:uri  (env :database-url)}
    :flow-report-database-url (env :flow-report-database-url)
    :file-upload-path (env :file-upload-path)
-   :app {:keycloak-url (env :lumen-keycloak-url)}})
+   :app {:keycloak-url (env :lumen-keycloak-url)
+         :keycloak-realm "akvo"}})

--- a/backend/src/org/akvo/lumen/system.clj
+++ b/backend/src/org/akvo/lumen/system.clj
@@ -25,7 +25,7 @@
              [visualisation :as visualisation]
              [transformation :as transformation]
              [job-execution :as job-execution]]
-            [org.akvo.lumen.middleware :refer [wrap-auth wrap-jwt]]
+            [org.akvo.lumen.auth :refer [wrap-auth wrap-jwt]]
             [ring.middleware
              [defaults :refer [api-defaults wrap-defaults]]
              [json :refer [wrap-json-body wrap-json-response]]]))
@@ -41,7 +41,7 @@
                         [wrap-route-aliases :aliases]
                         wrap-json-body
                         wrap-auth
-                        [wrap-jwt :keycloak-url]
+                        [wrap-jwt :keycloak-url :keycloak-realm]
                         tm/wrap-label-tenant]
          :not-found    (io/resource "org/akvo/lumen/errors/404.html")
          :defaults     (meta-merge api-defaults

--- a/backend/test/org/akvo/lumen/auth_test.clj
+++ b/backend/test/org/akvo/lumen/auth_test.clj
@@ -1,5 +1,5 @@
-(ns org.akvo.lumen.middleware-test
-  (:require [org.akvo.lumen.middleware :as m]
+(ns org.akvo.lumen.auth-test
+  (:require [org.akvo.lumen.auth :as m]
             [org.akvo.lumen.system :as system]
             [clojure.test :refer [deftest testing is]]
             [ring.mock.request :as mock]))


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation

Also renamed middleware namespace to auth.