### PR TITLE
[#337] Migrate on init

### DIFF
--- a/backend/src/org/akvo/lumen/config.clj
+++ b/backend/src/org/akvo/lumen/config.clj
@@ -1,0 +1,10 @@
+(ns org.akvo.lumen.config
+  (:require [environ.core :refer [env]]))
+
+(def bindings
+  {'db-uri (:lumen-db-url env "jdbc:postgresql://localhost/lumen?user=lumen&password=password")
+   'http-port (Integer/parseInt (:port env "3000"))
+   'keycloak-realm "akvo"
+   'keycloak-url (:lumen-keycloak-url env "http://localhost:8080/auth")
+   'flow-report-database-url (env :lumen-flow-report-database-url)
+   'file-upload-path (env :lumen-file-upload-path)})

--- a/backend/src/org/akvo/lumen/migrate.clj
+++ b/backend/src/org/akvo/lumen/migrate.clj
@@ -4,7 +4,7 @@
    [duct.util.system :refer [read-config]]
    [environ.core :refer [env]]
    [hugsql.core :as hugsql]
-   [org.akvo.lumen.main :refer [bindings]]
+   [org.akvo.lumen.config :refer [bindings]]
    [meta-merge.core :refer [meta-merge]]
    [ragtime
     [jdbc :as ragtime-jdbc]


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation

We should run migrations on app init to make sure we progress the db on
deployments. Bindings had to be moved to a separate namespace to
circumvent circular dependencies.