### PR TITLE
[#559] Sort pointColorMapping before render so order is constant

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 0.5.2 (Unreleased)
+
+Date 2017-02-17
+
+### Bugfixes
+
+* The color key for maps is now always presented in the same order
+
 ## 0.5.1
 
 Date 2017-02-07

--- a/client/src/components/charts/MapVisualisation.jsx
+++ b/client/src/components/charts/MapVisualisation.jsx
@@ -45,10 +45,15 @@ const getDataLayers = (layers, datasets) => {
 
       if (chartData) {
         const chartValues = chartData.values;
-        const pointColorMapping = Object.keys(chartData.metadata.pointColorMapping).map(value => ({
-          value,
-          color: chartData.metadata.pointColorMapping[value],
-        }));
+        const sortFunc = chartData.metadata.pointColorColumnType === 'text' ?
+          (a, b) => a.value > b.value : (a, b) => parseFloat(a.value) - parseFloat(b.value);
+        const pointColorMapping =
+          Object.keys(chartData.metadata.pointColorMapping).map(value => ({
+            value,
+            color: chartData.metadata.pointColorMapping[value],
+          }))
+          .sort(sortFunc);
+
         const bounds = chartData.metadata.bounds;
 
         displayLayers.push(Object.assign({}, layer, {

--- a/client/src/components/visualisation/configMenu/LayerConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/LayerConfigMenu.jsx
@@ -295,6 +295,13 @@ export default class LayerConfigMenu extends Component {
       legend = Object.assign({}, this.props.layer.legend, { title: null });
     }
 
+    let sortFunc;
+
+    if (columnOption != null) {
+      sortFunc = columnOption.type === 'text' ?
+      (a, b) => a.value > b.value : (a, b) => parseFloat(a.value) - parseFloat(b.value);
+    }
+
     this.props.onChangeMapLayer(this.props.layerIndex, {
       legend,
       pointColorColumn: columnName,
@@ -304,6 +311,7 @@ export default class LayerConfigMenu extends Component {
           value,
           color: defaultColors[index] || '#000000',
         }))
+        .sort(sortFunc)
         :
         []
       ,

--- a/client/src/utilities/chart.js
+++ b/client/src/utilities/chart.js
@@ -313,6 +313,8 @@ export function getMapData(layer, datasets) {
         [maxLat, maxLong],
       ],
       pointColorMapping: filteredPointColorMapping,
+      pointColorColumnType: pointColorIndex > -1 ?
+        dataset.get('columns').get(pointColorIndex).get('type') : null,
     },
   });
 }


### PR DESCRIPTION
#559 

- [ ] Update release notes
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
