### PR TITLE
[#570] Fix filter "exactly matches" for numeric columns

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,14 @@
 
 Date 2017-02-17
 
+## 0.5.3
+
+Date 2017-02-08
+
+### Bugfixes
+
+* Visualisation filters now work correctly for numeric columns and "exactly matches" filter
+
 ## 0.5.2
 
 Date 2017-02-08

--- a/client/src/utilities/chart.js
+++ b/client/src/utilities/chart.js
@@ -9,8 +9,23 @@ const getFilterArray = (filters, columns) => {
 
   for (let i = 0; i < filters.length; i += 1) {
     const filter = filters[i];
-    const testValue = filter.value;
     const columnIndex = columns.findIndex(col => col.get('columnName') === filter.column);
+    const columnType = columns.getIn([columnIndex, 'type']);
+    let testValue;
+    switch (columnType) {
+      case 'date':
+        testValue = parseInt(filter.value, 10);
+        break;
+      case 'number':
+        testValue = parseFloat(filter.value);
+        break;
+      case 'text':
+        testValue = filter.value;
+        break;
+      default:
+        throw new Error(`Invalid column type: ${columnType}`);
+    }
+
 
     switch (filter.strategy) {
       case 'isHigher':


### PR DESCRIPTION
* We use `===` when comparing so we need to parse the test value to a float
  for numbers and to an int for dates.

- [ ] Update release notes
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
