### PR TITLE
[#600] Show percentage values in pie and donut chart hover labels

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 
 * Fix bug where pie and donut chart labels would not show percentage values
+* Fix bug where pie and donut segments would not show "hover" color when cursor hovered label
 
 ## 0.6.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 # Release Notes
 
-## 0.6.0 (Unreleased)
+## 2017-03-10 (Unreleased)
+
+### Bugfixes
+
+* Fix bug where pie and donut chart labels would not show percentage values
+
+## 0.6.0
 
 Date 2017-02-17
 

--- a/client/src/utilities/vega-specs/Pie.js
+++ b/client/src/utilities/vega-specs/Pie.js
@@ -106,15 +106,16 @@ export default function getVegaPieSpec(visualisation, data, containerHeight, con
             },
           },
           update: {
-            fill: {
-              scale: 'c',
-              field: segmentLabelField,
-            },
-          },
-          hover: {
-            fill: {
-              value: 'pink',
-            },
+            fill: [
+              {
+                test: 'datum._id == tooltip._id || datum._id == textTooltip._id',
+                value: 'pink',
+              },
+              {
+                scale: 'c',
+                field: segmentLabelField,
+              },
+            ],
           },
         },
       },

--- a/client/src/utilities/vega-specs/Pie.js
+++ b/client/src/utilities/vega-specs/Pie.js
@@ -2,9 +2,6 @@ export default function getVegaPieSpec(visualisation, data, containerHeight, con
   const chartRadius = containerHeight < containerWidth ? containerHeight / 3 : containerWidth / 3;
   const innerRadius = visualisation.visualisationType === 'donut' ?
     Math.floor(chartRadius / 1.75) : 0;
-
-  const hasAggregation = Boolean(visualisation.spec.bucketColumn &&
-    visualisation.spec.metricAggregation);
   const dataArray = data.map(item => item);
 
   const layoutTransform = {
@@ -192,15 +189,9 @@ export default function getVegaPieSpec(visualisation, data, containerHeight, con
                 align: {
                   value: 'left',
                 },
-                text: hasAggregation ?
-                  {
-                    template: `{{datum[${segmentLabelField}]}}: {{datum.rounded_percentage}}% ({{datum.rounded_value}})`,
-                  }
-                  :
-                  {
-                    field: fieldY,
-                  }
-                ,
+                text: {
+                  template: `{{datum[${segmentLabelField}]}}: {{datum.rounded_value}} ({{datum.rounded_percentage}}%)`,
+                },
               }
               :
               {
@@ -230,15 +221,9 @@ export default function getVegaPieSpec(visualisation, data, containerHeight, con
                 align: {
                   value: 'center',
                 },
-                text: hasAggregation ?
-                  {
-                    template: '{{datum.rounded_percentage}}% ({{datum.rounded_value}})',
-                  }
-                  :
-                  {
-                    field: fieldY,
-                  }
-                ,
+                text: {
+                  template: '{{datum.rounded_value}} ({{datum.rounded_percentage}}%)',
+                },
               }
             ,
         },


### PR DESCRIPTION
#600 

This also fixes a small visual bug where the highlight color for segments that are being hovered over would not show correctly when the cursor was over the label text part of the segment

- [ ] Update release notes
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
