### PR TITLE
[#621] pivot column names

### DIFF
--- a/client/src/components/charts/PivotTable.jsx
+++ b/client/src/components/charts/PivotTable.jsx
@@ -6,6 +6,14 @@ require('../../styles/PivotTable.scss');
 const meanPixelsPerChar = 7.5; // Used for calculating min-widths for columns
 const defaultCategoryWidth = 100; // Number of pixels to wrap category columns at
 
+const formatTitle = (title) => {
+  const maxTitleLength = 64;
+  if (!title) return title;
+  if (title.toString().length <= maxTitleLength) return title;
+
+  return `${title.toString().substring(0, maxTitleLength - 1)}…`;
+};
+
 const getColumnHeaderClassname = (cell, index, spec) => {
   if (index === 0) {
     if (spec.rowColumn !== null) {
@@ -17,6 +25,15 @@ const getColumnHeaderClassname = (cell, index, spec) => {
   }
   return 'uniqueColumnValue';
 };
+
+const getColumnHeaderBody = (cell, index, spec) => {
+  if (index > 0) {
+    return formatTitle(replaceLabelIfValueEmpty(cell.title));
+  }
+
+  return formatTitle(spec.rowTitle ? spec.rowTitle : cell.title);
+};
+
 
 /* Returns the min column width that will limit wrapping to two lines.
 /* This is not currently possible with a stylesheet-only approach. */
@@ -40,16 +57,8 @@ const formatCell = (index, cell, spec, columns) => {
   return cell;
 };
 
-const formatTitle = (title) => {
-  const maxTitleLength = 64;
-  if (!title) return title;
-  if (title.toString().length <= maxTitleLength) return title;
-
-  return `${title.toString().substring(0, maxTitleLength - 1)}…`;
-};
-
 export default function PivotTable({ width, height, visualisation }) {
-  const data = visualisation.data;
+  const { data, spec } = visualisation;
 
   if (!data) {
     return (
@@ -90,7 +99,8 @@ export default function PivotTable({ width, height, visualisation }) {
                 className="categoryColumnTitle"
               >
                 <span>
-                  {data.metadata.categoryColumnTitle}
+                  {spec.categoryTitle ?
+                    spec.categoryTitle : data.metadata.categoryColumnTitle}
                 </span>
               </th>
             </tr>
@@ -109,7 +119,7 @@ export default function PivotTable({ width, height, visualisation }) {
                     )),
                   }}
                 >
-                  {formatTitle(index === 0 ? cell.title : replaceLabelIfValueEmpty(cell.title))}
+                  {getColumnHeaderBody(cell, index, spec)}
                 </span>
               </th>
             )}

--- a/client/src/components/visualisation/VisualisationEditor.jsx
+++ b/client/src/components/visualisation/VisualisationEditor.jsx
@@ -59,7 +59,32 @@ export default class VisualisationEditor extends Component {
           });
         }
         if (visualisation.datasetId && specIsValidForApi(visualisation.spec)) {
-          this.fetchAggregatedData(visualisation);
+          const lastSpec = this.lastPivotRequested && this.lastPivotRequested.spec ?
+            this.lastPivotRequested.spec : {};
+          const lastDataset = this.lastPivotRequested ?
+            this.lastPivotRequested.datasetId : null;
+          const spec = visualisation.spec;
+
+          // Only fetch new aggregated data if a relevant part of the spec has changed
+          const shouldRequestNewData = Boolean(
+            visualisation.datasetId !== lastDataset ||
+            spec.aggregation !== lastSpec.aggregation ||
+            spec.valueColumn !== lastSpec.valueColumn ||
+            spec.categoryColumn !== lastSpec.categoryColumn ||
+            spec.rowColumn !== lastSpec.rowColumn
+          );
+          if (shouldRequestNewData) {
+            this.fetchAggregatedData(visualisation);
+          } else {
+            // Update children without requesting new aggregated data
+            this.setState({
+              visualisation:
+                Object.assign({}, visualisation, { data: this.state.visualisation.data }),
+            });
+          }
+
+          // Store a copy of this visualisation to compare against on next update
+          this.lastPivotRequested = Object.assign({}, visualisation);
         }
         break;
 

--- a/client/src/components/visualisation/VisualisationEditor.jsx
+++ b/client/src/components/visualisation/VisualisationEditor.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import isEqual from 'lodash/isEqual';
 import VisualisationConfig from './VisualisationConfig';
 import VisualisationPreview from './VisualisationPreview';
 import * as api from '../../api';
@@ -71,7 +72,8 @@ export default class VisualisationEditor extends Component {
             spec.aggregation !== lastSpec.aggregation ||
             spec.valueColumn !== lastSpec.valueColumn ||
             spec.categoryColumn !== lastSpec.categoryColumn ||
-            spec.rowColumn !== lastSpec.rowColumn
+            spec.rowColumn !== lastSpec.rowColumn ||
+            !isEqual(spec.filters, lastSpec.filters)
           );
           if (shouldRequestNewData) {
             this.fetchAggregatedData(visualisation);

--- a/client/src/components/visualisation/configMenu/FilterMenu.jsx
+++ b/client/src/components/visualisation/configMenu/FilterMenu.jsx
@@ -197,7 +197,7 @@ export default class FilterMenu extends Component {
               {(!filters || filters.length === 0) ?
                 <div className="noFilters">No filters</div> : <div className="filterListContainer">
                   <ol className="filterList">
-                    {filters.map((filter, index) =>
+                    {filters.filter(item => item.origin === 'filterMenu').map((filter, index) =>
                       <li
                         key={index}
                         className="filterListItem"

--- a/client/src/components/visualisation/configMenu/PivotTableConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/PivotTableConfigMenu.jsx
@@ -132,7 +132,7 @@ export default class PivotTableConfigMenu extends Component {
         {spec.categoryColumn !== null &&
           <UniqueValueMenu
             tableData={visualisation.data}
-            dimension="category"
+            dimension="column"
             collapsed={this.state.catValMenuCollapsed}
             onChangeSpec={this.props.onChangeSpec}
             column={spec.categoryColumn}

--- a/client/src/components/visualisation/configMenu/PivotTableConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/PivotTableConfigMenu.jsx
@@ -111,10 +111,10 @@ export default class PivotTableConfigMenu extends Component {
           }
         </div>
         <hr />
-        <Subtitle>Categories</Subtitle>
+        <Subtitle>Columns</Subtitle>
         <SelectInput
-          placeholder="Select a category column"
-          labelText="Category column"
+          placeholder="Select a column"
+          labelText="Columns"
           choice={spec.categoryColumn !== null ? spec.categoryColumn.toString() : null}
           name="categoryColumnInput"
           options={columnOptions}

--- a/client/src/components/visualisation/configMenu/PivotTableConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/PivotTableConfigMenu.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import SelectInput from './SelectInput';
+import LabelInput from './LabelInput';
 import Subtitle from './Subtitle';
 import UniqueValueMenu from './UniqueValueMenu';
 
@@ -125,22 +126,40 @@ export default class PivotTableConfigMenu extends Component {
               change.aggregation = 'count';
               change.valueColumn = null;
             }
+            if (value !== spec.categoryColumn) {
+              change.categoryTitle = null;
+            }
             onChangeSpec(change);
           }}
           clearable
         />
         {spec.categoryColumn !== null &&
-          <UniqueValueMenu
-            tableData={visualisation.data}
-            dimension="column"
-            collapsed={this.state.catValMenuCollapsed}
-            onChangeSpec={this.props.onChangeSpec}
-            column={spec.categoryColumn}
-            filters={spec.filters}
-            toggleCollapsed={() =>
-              this.setState({ catValMenuCollapsed: !this.state.catValMenuCollapsed })
-            }
-          />
+          <div>
+            <UniqueValueMenu
+              tableData={visualisation.data}
+              dimension="column"
+              collapsed={this.state.catValMenuCollapsed}
+              onChangeSpec={this.props.onChangeSpec}
+              column={spec.categoryColumn}
+              filters={spec.filters}
+              toggleCollapsed={() =>
+                this.setState({ catValMenuCollapsed: !this.state.catValMenuCollapsed })
+              }
+            />
+            <LabelInput
+              value={
+                spec.categoryTitle === null ?
+                  columnOptions.find(item => item.value === spec.categoryColumn).title
+                  :
+                  spec.categoryTitle.toString()
+              }
+              placeholder="Columns title"
+              name="categoryTitle"
+              onChange={event => onChangeSpec({
+                categoryTitle: event.target.value.toString(),
+              })}
+            />
+          </div>
         }
         <hr />
         <Subtitle>Rows</Subtitle>
@@ -157,22 +176,40 @@ export default class PivotTableConfigMenu extends Component {
               change.aggregation = 'count';
               change.valueColumn = null;
             }
+            if (value !== spec.rowColumn) {
+              change.rowTitle = null;
+            }
             onChangeSpec(change);
           }}
           clearable
         />
         {spec.rowColumn !== null &&
-          <UniqueValueMenu
-            tableData={visualisation.data}
-            dimension="row"
-            collapsed={this.state.rowValMenuCollapsed}
-            onChangeSpec={this.props.onChangeSpec}
-            column={spec.rowColumn}
-            filters={spec.filters}
-            toggleCollapsed={() =>
-              this.setState({ rowValMenuCollapsed: !this.state.rowValMenuCollapsed })
-            }
-          />
+          <div>
+            <UniqueValueMenu
+              tableData={visualisation.data}
+              dimension="row"
+              collapsed={this.state.rowValMenuCollapsed}
+              onChangeSpec={this.props.onChangeSpec}
+              column={spec.rowColumn}
+              filters={spec.filters}
+              toggleCollapsed={() =>
+                this.setState({ rowValMenuCollapsed: !this.state.rowValMenuCollapsed })
+              }
+            />
+            <LabelInput
+              value={
+                spec.rowTitle == null ?
+                  columnOptions.find(item => item.value === spec.rowColumn).title
+                  :
+                  spec.rowTitle.toString()
+              }
+              placeholder="Row column title"
+              name="rowTitle"
+              onChange={event => onChangeSpec({
+                rowTitle: event.target.value.toString(),
+              })}
+            />
+          </div>
         }
       </div>
     );

--- a/client/src/components/visualisation/configMenu/UniqueValueMenu.jsx
+++ b/client/src/components/visualisation/configMenu/UniqueValueMenu.jsx
@@ -37,7 +37,7 @@ export default function UniqueValueMenu(props) {
   const uniqueValues = [];
 
   switch (dimension) {
-    case 'category':
+    case 'column':
       for (let i = 1; i < tableData.columns.length; i += 1) {
         uniqueValues.push(tableData.columns[i].title);
       }
@@ -88,7 +88,7 @@ export default function UniqueValueMenu(props) {
 
 UniqueValueMenu.propTypes = {
   tableData: PropTypes.object,
-  dimension: PropTypes.oneOf(['category', 'row']).isRequired,
+  dimension: PropTypes.oneOf(['column', 'row']).isRequired,
   filters: PropTypes.array.isRequired,
   column: PropTypes.string.isRequired,
   onChangeSpec: PropTypes.func.isRequired,

--- a/client/src/containers/Visualisation/pivotTableSpecTemplate.js
+++ b/client/src/containers/Visualisation/pivotTableSpecTemplate.js
@@ -4,9 +4,9 @@ const pivotTableSpec = {
   aggregation: 'count',
   valueColumn: null,
   categoryColumn: null,
-  categoryColumnLabel: null,
+  categoryTitle: null,
   rowColumn: null,
-  rowColumnLabel: null,
+  rowTitle: null,
   decimalPlaces: 3,
 };
 

--- a/client/src/containers/Visualisation/pivotTableSpecTemplate.js
+++ b/client/src/containers/Visualisation/pivotTableSpecTemplate.js
@@ -4,7 +4,9 @@ const pivotTableSpec = {
   aggregation: 'count',
   valueColumn: null,
   categoryColumn: null,
+  categoryColumnLabel: null,
   rowColumn: null,
+  rowColumnLabel: null,
   decimalPlaces: 3,
 };
 

--- a/doc/spec/visualisations.md
+++ b/doc/spec/visualisations.md
@@ -93,6 +93,23 @@
 
 ```
 
+### Pivot table
+
+```
+{
+  version: 1,
+  filters: [],
+  aggregation: 'count',
+  valueColumn: null, // required if aggregation is other than 'count'
+  categoryColumn: null, // required
+  categoryTitle: null, // required
+  rowColumn: null, // Optional, will use categoryColumn title if ommited
+  rowTitle: null, // Optional, will use rowColumn title if ommited
+  decimalPlaces: 3, // Only used at render-time
+}
+
+```
+
 ### Filter array (used for all visualisation types)
 
 ```


### PR DESCRIPTION
#621 

I added some update logic so we only hit the `pivot` api when we expect the aggregated data to have changed. If we don't do anything, we'll hit the api on every `onChange` event for the text inputs for the new `rowTitle` and `categoryTitle` fields on the spec.

- [ ] Update release notes
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
