### PR TITLE
[#578] Compare bucket labels to empty value string instead of null

### DIFF
--- a/client/src/utilities/chart.js
+++ b/client/src/utilities/chart.js
@@ -217,8 +217,9 @@ export function getPieData(visualisation, datasets) {
     .execute(valueArray)
     .sort((a, b) => {
       if (bucketColumnType === 'text') {
-        const valA = a.bucketValue || lastValueAlphabetically;
-        const valB = b.bucketValue || lastValueAlphabetically;
+        const emptyValueText = replaceLabelIfValueEmpty(null);
+        const valA = a.bucketValue === emptyValueText ? lastValueAlphabetically : a.bucketValue;
+        const valB = b.bucketValue === emptyValueText ? lastValueAlphabetically : b.bucketValue;
 
         return valA.localeCompare(valB);
       }


### PR DESCRIPTION
Fixes https://github.com/akvo/akvo-lumen/pull/624#issuecomment-284686517

#578 

- [ ] Update release notes
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
