### PR TITLE
[#661] Let text entities scroll on published dashboards

### DIFF
--- a/client/src/components/dashboard/DashboardViewerItem.jsx
+++ b/client/src/components/dashboard/DashboardViewerItem.jsx
@@ -60,7 +60,7 @@ export default class DashboardViewerItem extends Component {
 
     return (
       <div
-        className="DashboardViewerItem DashboardCanvasItem"
+        className={`DashboardViewerItem DashboardCanvasItem ${this.props.item.type}`}
         style={style}
       >
         {this.props.item.type === 'visualisation' &&

--- a/client/src/styles/DashboardViewerItem.scss
+++ b/client/src/styles/DashboardViewerItem.scss
@@ -7,6 +7,10 @@
   background-color: white;
   border: 0.1rem solid $midGrey;
 
+  &.text {
+    overflow-y: auto;
+  }
+
   .itemContainer {
     &.text {
       line-height: 1.4rem;


### PR DESCRIPTION
When the text of a text entity is too big to fit in a shared dashboard, allow the entity to scroll vertically so the reader can see all the text

#661 

- [ ] Update release notes
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
