### PR TITLE
[#688] Truncate long column names in map popup text menu

### DIFF
--- a/client/src/components/visualisation/configMenu/LayerConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/LayerConfigMenu.jsx
@@ -209,8 +209,13 @@ export default class LayerConfigMenu extends Component {
                   </span>
                   <span
                     className="columnLabelContainer"
+                    title={option.label}
                   >
-                    {option.label}
+                    {(option.label && option.label.length > 128) ?
+                      `${option.label.substring(0, 128)}...`
+                      :
+                      option.label
+                    }
                   </span>
                 </div>
               )}

--- a/client/src/styles/LayerConfigMenu.scss
+++ b/client/src/styles/LayerConfigMenu.scss
@@ -67,7 +67,8 @@
     .optionContainer {
       display: flex;
       flex: 1;
-      height: 2.5rem;
+      min-height: 2.5rem;
+      line-height: 1.25rem;
       flex-direction: row;
       justify-content: space-between;
       align-items: center;


### PR DESCRIPTION
#688 

Truncate column names longer than 128 chars in the popup menu editor for map visualisations

RELEASE_NOTES: `Fixed bug where long column names would overlap in the Popup editor for map visualisations`

- [ ] Update release notes
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
