### PR TITLE
[#650] Fix operator precedence issues in aggregate filters

### DIFF
--- a/backend/src/akvo/lumen/lib/aggregation/filter.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/filter.clj
@@ -92,4 +92,5 @@
     "TRUE"
     (let [filters (map #(assoc % "column" (find-column columns (get % "column")))
                        filters)]
-      (str/join " AND " (map filter-sql filters)))))
+      (str/join " AND " (map #(format "(%s)" (filter-sql %))
+                             filters)))))


### PR DESCRIPTION
RELEASE_NOTES: `Fix bug where multiple numeric filters would fail to filter the data correctly`

- [ ] Update release notes
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
