### PR TITLE
[#849] Disable SSO Idle Timeout by bumping the timeout every 10 minutes

### DIFF
--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -12,6 +12,11 @@ function initAuthenticated(profile, env) {
   const store = configureStore(initialState);
   const history = syncHistoryWithStore(browserHistory, store);
   const rootElement = document.querySelector('#root');
+
+  // Refreshing the token on a fixed schedule (every 10 minutes)
+  // will disable SSO Idle Timeout
+  setInterval(auth.token, 1000 * 60 * 10);
+
   render(<Root store={store} history={history} />, rootElement);
 }
 


### PR DESCRIPTION
`RELEASE_NOTES`: Fixed bug where the user would stop being authenticated after keeping lumen open but not using it for 30 minutes.

- [ ] Update release notes
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
