### PR TITLE
[#811] [#775] Auto-dismiss context menus

### DIFF
--- a/client/src/components/common/ContextMenu.jsx
+++ b/client/src/components/common/ContextMenu.jsx
@@ -29,30 +29,20 @@ const getArrowStyle = (className, offset = '0px') => {
 };
 
 export default class ContextMenu extends Component {
-
-  constructor() {
-    super();
-    this.state = {
-      windowListener: null,
-      mountingClickReceived: false, // the click that caused this component to mount
-    };
-  }
-
   componentDidMount() {
     if (this.props.onWindowClick) {
-      this.windowListener = () => {
-        if (!this.state.mountingClickReceived) {
-          this.setState({ mountingClickReceived: true });
-        } else {
-          this.props.onWindowClick();
-        }
-      };
-      window.addEventListener('click', this.windowListener);
+      this.windowListener = () => this.props.onWindowClick();
+      /* Wrapping in a setTimeout prevents the case where the same click event that caused the
+      ** context menu to be mounted is also immediately heard by the new event listener, closing
+      ** the menu instantly */
+      setTimeout(() => {
+        window.addEventListener('click', this.windowListener);
+      }, 0);
     }
   }
 
   componentWillUnmount() {
-    if (this.props.onWindowClick) {
+    if (this.windowListener) {
       window.removeEventListener('click', this.windowListener);
     }
   }
@@ -104,7 +94,7 @@ export default class ContextMenu extends Component {
 
 ContextMenu.propTypes = {
   onOptionSelected: PropTypes.func.isRequired,
-  onWindowClick: PropTypes.func,
+  onWindowClick: PropTypes.func.isRequired,
   style: PropTypes.object,
   options: PropTypes.array.isRequired,
   selected: PropTypes.string,

--- a/client/src/components/dataset/DatasetControls.jsx
+++ b/client/src/components/dataset/DatasetControls.jsx
@@ -32,7 +32,7 @@ export default class DatasetControls extends Component {
               className="datasetEditorToggle clickable"
               onClick={() => this.onEditorToggleClick()}
             >
-            Dataset editor
+            + Transform
             </button>
             {this.state.editorMenuActive &&
               <ContextMenu
@@ -69,6 +69,7 @@ export default class DatasetControls extends Component {
                   left: 0,
                   width: '16rem',
                 }}
+                onWindowClick={this.onEditorToggleClick}
               />
             }
           </span>

--- a/client/src/components/dataset/DatasetTable.jsx
+++ b/client/src/components/dataset/DatasetTable.jsx
@@ -42,6 +42,9 @@ export default class DatasetTable extends Component {
     this.handleDataTypeContextMenuClicked = this.handleDataTypeContextMenuClicked.bind(this);
     this.handleColumnContextMenuClicked = this.handleColumnContextMenuClicked.bind(this);
 
+    this.dismissDataTypeContextMenu = this.dismissDataTypeContextMenu.bind(this);
+    this.dismissColumnContextMenu = this.dismissColumnContextMenu.bind(this);
+
     this.handleToggleTransformationLog = this.handleToggleTransformationLog.bind(this);
     this.handleToggleCombineColumnSidebar = this.handleToggleCombineColumnSidebar.bind(this);
     this.handleToggleDeriveColumnSidebar = this.handleToggleDeriveColumnSidebar.bind(this);
@@ -248,6 +251,14 @@ export default class DatasetTable extends Component {
     });
   }
 
+  dismissDataTypeContextMenu() {
+    this.setState({ activeDataTypeContextMenu: null });
+  }
+
+  dismissColumnContextMenu() {
+    this.setState({ activeColumnContextMenu: null });
+  }
+
   render() {
     const { rows, columns, pendingTransformations, transformations } = this.props;
     const {
@@ -335,12 +346,14 @@ export default class DatasetTable extends Component {
                 column={activeDataTypeContextMenu.column}
                 dimensions={activeDataTypeContextMenu.dimensions}
                 onContextMenuItemSelected={this.handleDataTypeContextMenuClicked}
+                onWindowClick={this.dismissDataTypeContextMenu}
               />}
             {activeColumnContextMenu &&
               <ColumnContextMenu
                 column={activeColumnContextMenu.column}
                 dimensions={activeColumnContextMenu.dimensions}
                 onContextMenuItemSelected={this.handleColumnContextMenuClicked}
+                onWindowClick={this.dismissColumnContextMenu}
               />}
             <Table
               headerHeight={60}

--- a/client/src/components/dataset/context-menus/ColumnContextMenu.jsx
+++ b/client/src/components/dataset/context-menus/ColumnContextMenu.jsx
@@ -116,7 +116,12 @@ const dataTypeOptions = {
   date: [],
 };
 
-export default function ColumnContextMenu({ column, dimensions, onContextMenuItemSelected }) {
+export default function ColumnContextMenu({
+  column,
+  dimensions,
+  onContextMenuItemSelected,
+  onWindowClick,
+}) {
   return (
     <ContextMenu
       options={commonOptions.concat(dataTypeOptions[column.get('type')])}
@@ -131,6 +136,7 @@ export default function ColumnContextMenu({ column, dimensions, onContextMenuIte
         column,
         action: actions.get(op).setIn(['args', 'columnName'], column.get('columnName')),
       })}
+      onWindowClick={onWindowClick}
     />
   );
 }
@@ -143,4 +149,5 @@ ColumnContextMenu.propTypes = {
     left: PropTypes.number.isRequired,
   }).isRequired,
   onContextMenuItemSelected: PropTypes.func.isRequired,
+  onWindowClick: PropTypes.func.isRequired,
 };

--- a/client/src/components/dataset/context-menus/DataTypeContextMenu.jsx
+++ b/client/src/components/dataset/context-menus/DataTypeContextMenu.jsx
@@ -18,7 +18,12 @@ const options = [
 ];
 
 /* "The job of a context menu is to create props for the sidebar" */
-export default function DataTypeContextMenu({ column, dimensions, onContextMenuItemSelected }) {
+export default function DataTypeContextMenu({
+  column,
+  dimensions,
+  onContextMenuItemSelected,
+  onWindowClick,
+}) {
   return (
     <ContextMenu
       options={options}
@@ -37,6 +42,7 @@ export default function DataTypeContextMenu({ column, dimensions, onContextMenuI
         })}
       arrowClass="topLeft"
       arrowOffset="15px"
+      onWindowClick={onWindowClick}
     />
   );
 }
@@ -48,4 +54,5 @@ DataTypeContextMenu.propTypes = {
     left: PropTypes.number.isRequired,
   }).isRequired,
   onContextMenuItemSelected: PropTypes.func.isRequired,
+  onWindowClick: PropTypes.func.isRequired,
 };

--- a/client/src/components/library/CheckboxEntityMenu.jsx
+++ b/client/src/components/library/CheckboxEntityMenu.jsx
@@ -62,7 +62,7 @@ export default class CheckboxEntityMenu extends Component {
                     marginTop: '-1em',
                   }}
                   onOptionSelected={this.handleAddEntitiesToCollection}
-                  onWindowClick={() => this.setState({ menuActive: !this.state.menuActive })}
+                  onWindowClick={() => this.setState({ menuActive: false })}
                   options={[
                     ...Object.keys(collections).map(key => ({
                       value: key,

--- a/client/src/components/library/LibraryListingItem.jsx
+++ b/client/src/components/library/LibraryListingItem.jsx
@@ -33,7 +33,12 @@ function getCollectionContextMenuItem(collections, currentCollection) {
   });
 }
 
-function LibraryListingItemContextMenu({ onClick, collections = {}, currentCollection }) {
+function LibraryListingItemContextMenu({
+  onClick,
+  collections = {},
+  currentCollection,
+  onWindowClick,
+}) {
   return (
     <ContextMenu
       style={{ width: 200 }}
@@ -63,6 +68,7 @@ function LibraryListingItemContextMenu({ onClick, collections = {}, currentColle
           value: 'delete',
         },
       ]}
+      onWindowClick={onWindowClick}
     />
   );
 }
@@ -101,6 +107,7 @@ LibraryListingItemContextMenu.propTypes = {
   onClick: PropTypes.func.isRequired,
   collections: PropTypes.object.isRequired,
   currentCollection: PropTypes.object,
+  onWindowClick: PropTypes.func.isRequired,
 };
 
 export default class LibraryListingItem extends Component {
@@ -183,6 +190,7 @@ export default class LibraryListingItem extends Component {
                 this.setState({ contextMenuVisible: false });
                 onEntityAction(actionType, getType(entity), getId(entity));
               }}
+              onWindowClick={() => this.setState({ contextMenuVisible: false })}
             />}
         </div>
       </li>

--- a/client/src/components/visualisation/configMenu/LayerMenuItem.jsx
+++ b/client/src/components/visualisation/configMenu/LayerMenuItem.jsx
@@ -86,10 +86,7 @@ export default class LayerMenuItem extends Component {
               <button
                 className={`clickable overflowButton noSelect
                   ${this.state.showOverflow ? 'active' : 'inactive'}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  this.setState({ showOverflow: true });
-                }}
+                onClick={() => this.setState({ showOverflow: true })}
               >
                 ● ● ●
               </button>

--- a/client/src/components/visualisation/configMenu/LayerMenuItem.jsx
+++ b/client/src/components/visualisation/configMenu/LayerMenuItem.jsx
@@ -86,7 +86,10 @@ export default class LayerMenuItem extends Component {
               <button
                 className={`clickable overflowButton noSelect
                   ${this.state.showOverflow ? 'active' : 'inactive'}`}
-                onClick={() => this.setState({ showOverflow: true })}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  this.setState({ showOverflow: true });
+                }}
               >
                 ● ● ●
               </button>


### PR DESCRIPTION
#811 

I had to touch the same file as #775 refers to, so I made an additional one-line change to also resolve that issue

RELEASE_NOTES: `Renamed "Dataset Editor" menu to "+ Transform"`

(I don't think the context menu change warrants a mention in release notes)

- [ ] Update release notes
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
