### PR TITLE
[#1020] Expand bounding box if min/max are equal

### DIFF
--- a/client/src/components/charts/MapVisualisation.jsx
+++ b/client/src/components/charts/MapVisualisation.jsx
@@ -35,6 +35,19 @@ const calculateBounds = (layerArray) => {
     maxLong = Math.max(maxLong, maxArray[1]);
   });
 
+  /*
+   * If there's a single geo point (or if all the geo points happens to overlap) the min/max
+   * coordinates will be the same. Expand them so that we get a sensible bounding box.
+   */
+  if (minLat === maxLat) {
+    minLat -= 1;
+    maxLat += 1;
+  }
+  if (minLong === maxLong) {
+    minLong -= 1;
+    maxLong += 1;
+  }
+
   return [[minLat, minLong], [maxLat, maxLong]];
 };
 
@@ -229,7 +242,7 @@ export default function MapVisualisation({ visualisation, datasets, width, heigh
       </h2>
       <Map
         center={[0, 0]}
-        {... bounds ? { bounds } : {}} // Don't set a bounds prop if we have no bounds
+        {... bounds ? { bounds } : {}} // Do not set a bounds prop if we have no bounds
         zoom={2}
         scrollWheelZoom={false}
         key={width}

--- a/client/src/utilities/chart.js
+++ b/client/src/utilities/chart.js
@@ -628,4 +628,3 @@ export function processPivotData(data, spec) {
 
   return out;
 }
-


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

`RELEASE_NOTES (bug fix)`: Resolved issue where map rendering would fail if there's only a single geo point