### PR TITLE
[#1026] Allow bucket column to be picked before metric column (withou…

### DIFF
--- a/client/src/components/visualisation/configMenu/BarConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/BarConfigMenu.jsx
@@ -29,7 +29,7 @@ const handleChangeSpec = (change, oldSpec, onChangeSpec, columnOptions) => {
     onChangeSpec(change);
   }
 
-  let autoAxisLabelY = getColumnTitle(newSpec.metricColumnY, columnOptions);
+  let autoAxisLabelY = newSpec.metricColumnY ? getColumnTitle(newSpec.metricColumnY, columnOptions) : '';
   let autoAxisLabelX = newSpec.bucketColumn ? getColumnTitle(newSpec.bucketColumn, columnOptions) : '';
 
   if (newSpec.bucketColumn !== null) {


### PR DESCRIPTION
…t error)

- [x] **Update release notes if necessary**

`RELEASE_NOTES (bug)`: Resolve issue in the bar chart editor where if the user picks the bucket column before the metric column an error (unseen to the user) was raised.