### PR TITLE
[#1066] Set isUnsavedChanges to false when opening an existing dashboard

### DIFF
--- a/client/src/containers/Dashboard.jsx
+++ b/client/src/containers/Dashboard.jsx
@@ -78,6 +78,7 @@ class Dashboard extends Component {
     }
 
     if (isEditingExistingDashboard) {
+      this.setState({ isUnsavedChanges: false });
       const dashboardId = this.props.params.dashboardId;
       const existingDashboardLoaded =
         isLibraryLoaded && !isEmpty(this.props.library.dashboards[dashboardId].layout);


### PR DESCRIPTION
- [x] **Update release notes if necessary**

`RELEASE_NOTES (bug)` Fixed bug where it was not possible to immediately share an existing dashboard

#1066 