### PR TITLE
[#1098] Run lein commands as with host's user and group id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ npm-debug.log
 client/dist
 client/yarn.lock
 
+# docker-compose
+.env
+
 # Backend
 backend/target
 backend/classes

--- a/README.dev.md
+++ b/README.dev.md
@@ -13,7 +13,7 @@ This Docker Compose environment will have:
 - A Redis DB
 
 ## Hosts
-Akvo Lumen is a multi tenant system and to do enable local routing to the tenants 
+Akvo Lumen is a multi tenant system and to do enable local routing to the tenants
 the following hosts must be defined in your /etc/hosts file:
 
 ``` sh
@@ -23,19 +23,26 @@ the following hosts must be defined in your /etc/hosts file:
 ```
 Or just
 
-``` sh
-sudo sh -c 'echo "127.0.0.1 t1.lumen.localhost t2.lumen.localhost auth.lumen.localhost" >> /etc/hosts'
-```
+
+    sudo sh -c 'echo "127.0.0.1 t1.lumen.localhost t2.lumen.localhost auth.lumen.localhost" >> /etc/hosts'
+
 
 ## Start development environment
 
 Before starting the following ports that must be free: 8080, 3000, 3030, 47480, 5432
 
+Setup your environment user and group id (only needs to be done once):
+
+
+    echo "HOST_UID=$(id -u)" >> .env
+    echo "HOST_GID=$(id -g)" >> .env
+
+
 To start:
 
-``sh
-docker-compose -f docker-compose.yml up -d ; docker-compose logs -f --tail=10
-``
+
+    docker-compose -f docker-compose.yml up -d ; docker-compose logs -f --tail=10
+
 
 ## Keycloak
 
@@ -70,7 +77,7 @@ The Akvo Lumen UI should be accessible at:
  - http://t1.lumen.localhost:3030/
  - http://t2.lumen.localhost:3030/
 
-The Docker Compose file mounts the "client" directory, so any changes in the source directory should 
+The Docker Compose file mounts the "client" directory, so any changes in the source directory should
 be picked up automatically by the Webpack server.
 
 
@@ -111,7 +118,7 @@ psql --host=akvolumen_postgres_1 --port=5432 --dbname=lumen_tenant_1 --username=
 
 This container has a development version of the Windshaft container, with plenty of hardcoded assumptions.
 
-The Windshaft server is not exposed directly to the external world, but it is proxied by the Webpack server 
+The Windshaft server is not exposed directly to the external world, but it is proxied by the Webpack server
 on the url http://t1.lumen.localhost:3030/maps/**. That url forwards the requests to "windshaft:4000".
 
 ## Legal

--- a/backend/Dockerfile-dev
+++ b/backend/Dockerfile-dev
@@ -1,7 +1,6 @@
-FROM clojure:lein-2.7.1
+FROM clojure:lein-2.7.1-alpine
 MAINTAINER Akvo Foundation <devops@akvo.org>
 
 WORKDIR /app
-COPY import-and-run.sh /app
-RUN chmod 777 /app/import-and-run.sh
-CMD ./import-and-run.sh
+
+CMD ["./import-and-run.sh"]

--- a/backend/import-and-run.sh
+++ b/backend/import-and-run.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 
-keytool -import -trustcacerts -keystore /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts -storepass changeit -noprompt -alias postgrescert -file /pg-certs/server.crt
+keytool -import -trustcacerts -keystore /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts -storepass changeit -noprompt -alias postgrescert -file /pg-certs/server.crt
 
-lein repl :headless
+./run-as-user.sh 'lein repl :headless'

--- a/backend/run-as-user.sh
+++ b/backend/run-as-user.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+USER_EXISTS=$(awk -F ':' '$3 ~ /^'${HOST_UID}'$/' /etc/passwd)
+GROUP_EXISTS=$(awk -F ':' '$3 ~ /^'${HOST_GID}'$/' /etc/group)
+
+if [ -z "${GROUP_EXISTS}" ]; then
+    addgroup -g "${HOST_GID}" akvo
+else
+    sed -i -e "s/\(.*\):\(.*\):${HOST_GID}:\(.*\)/akvo:\2:${HOST_GID}:\3/" /etc/group
+fi
+
+if [ -z "${USER_EXISTS}" ]; then
+    adduser -h /home/akvo \
+	    -s /bin/sh \
+	    -G akvo \
+	    -D \
+	    -u "${HOST_UID}" \
+	    akvo
+else
+    sed -i -e "s|^\(.*\):\(.*\):${HOST_UID}:\(.*\)$|akvo:x:${HOST_UID}:${HOST_UID}:akvo:/home/akvo:/bin/bash|" /etc/passwd
+fi
+
+su akvo -c "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,17 @@ services:
      dockerfile: Dockerfile-dev
    volumes:
       - ./backend:/app
-      - ~/.m2:/root/.m2
-      - ~/.lein:/root/.lein
+      - ~/.m2:/home/akvo/.m2
+      - ~/.lein:/home/akvo/.lein
       - ./postgres/provision:/pg-certs
    links:
       - keycloak:auth.lumen.localhost
    ports:
       - "47480:47480"
       - "3000:3000"
+   environment:
+     - HOST_UID
+     - HOST_GID
  client:
    build:
      context: ./client


### PR DESCRIPTION
* Setup an .env file with the host's user and group id
* Use lein image based on Alpine linux: 96MB (lein-2.7.1-alpine) vs 313MB (lein-2.7.1)
* The `run-as-user` makes sure the `akvo` user and group exists
  with the hosts UID and GID
* docker-compose file adjustments to use .env settings