### PR TITLE
[#1125] Avoid treating null as a string in cartocss

### DIFF
--- a/backend/src/akvo/lumen/lib/visualisation/map_config.clj
+++ b/backend/src/akvo/lumen/lib/visualisation/map_config.clj
@@ -16,9 +16,9 @@
     (for [{:strs [value color]} point-color-mapping]
       (format "[ %s = %s ] { marker-fill: %s }"
               point-color-column
-              (if (number? value)
-                value
-                (format "'%s'" value))
+              (if (string? value)
+                (format "'%s'" value)
+                value)
               (pr-str color)))))
 
 (defn cartocss [point-size point-color-column point-color-mapping]


### PR DESCRIPTION
#1125 

It's not working at the moment because `null` is not a number so the value that gets into the cartocss is `"null"` instead of `null`. 

Another approach would be adding an explicit null check

- [x] **Update release notes if necessary**
