### PR TITLE
[#1127] First pass at updating container with pointColorMapping

### DIFF
--- a/client/src/components/visualisation/VisualisationEditor.jsx
+++ b/client/src/components/visualisation/VisualisationEditor.jsx
@@ -185,6 +185,21 @@ export default class VisualisationEditor extends Component {
     };
 
     const updateMapVisualisation = ({ layerGroupId, metadata }) => {
+      const needPointColorMapping = visualisation.spec.layers[0].pointColorColumn;
+      const havePointColorMapping = checkUndefined(metadata, 'pointColorMapping', 'length') > 0;
+      const parentHasPointColorMapping = visualisation.spec.layers[0].pointColorMapping.length > 0;
+
+      if (needPointColorMapping && havePointColorMapping && !parentHasPointColorMapping) {
+        const clonedLayer = Object.assign(
+          {},
+          this.props.visualisation.spec.layers[0],
+          { pointColorMapping: metadata.pointColorMapping });
+
+        const layers = this.props.visualisation.spec.layers.slice(0);
+        layers[0] = clonedLayer;
+        this.props.onChangeVisualisationSpec({ layers });
+      }
+
       this.setState({
         visualisation: Object.assign(
           {},


### PR DESCRIPTION
#1127

- [x] **Update release notes if necessary**

To test: create a new map, add a pointColorMapping, save the visualisation (i.e. save it for the first time) and then verify that the point color inputs don't disappear and remain functional