### PR TITLE
[#1157] Add buffer to windshaft tiles so points on tile boundaries di…

### DIFF
--- a/backend/src/akvo/lumen/lib/visualisation/map_config.clj
+++ b/backend/src/akvo/lumen/lib/visualisation/map_config.clj
@@ -67,6 +67,11 @@
                             (get layer "popup"))
         point-color-column (get layer "pointColorColumn")]
     {"version" "1.6.0"
+     "buffersize" {
+      "png" 8
+      "grid.json" 8
+      "mvt" 0
+     }
      "layers" [{"type" "mapnik"
                 "options" {"cartocss" (trim-css (cartocss (get layer "pointSize")
                                                           (get layer "pointColorColumn")


### PR DESCRIPTION
…splay correctly

[#1157]

Release notes: `Bugfix: Fixed bug where map markers would appear cut off when they were near a tile boundary`
- [x] **Update release notes if necessary**
