### PR TITLE
[#1163] Add padding to shared visualisations and reduce branding size

### DIFF
--- a/client/src/components/common/LumenBranding.jsx
+++ b/client/src/components/common/LumenBranding.jsx
@@ -1,13 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 require('./LumenBranding.scss');
 
-export default function LumenBranding() {
+export default function LumenBranding({ size = 'large' }) {
   return (
-    <div className="LumenBranding">
+    <div className={`LumenBranding ${size}`}>
       <span>
         Built with <span className="logoColor">Akvo Lumen</span>
       </span>
     </div>
   );
 }
+
+LumenBranding.propTypes = {
+  size: PropTypes.string,
+};

--- a/client/src/components/common/LumenBranding.scss
+++ b/client/src/components/common/LumenBranding.scss
@@ -1,15 +1,23 @@
 @import "../../styles/modules/importAll";
 
 .LumenBranding {
+    .logoColor {
+        color: $lumenGreen;
+    }
     position: fixed;
-    bottom: 1rem;
-    right: 2.5rem;
-    padding: 1rem;
     background-color: rgba(255, 255, 255, 0.4);
     pointer-events: none;
     z-index: 2;
 
-    .logoColor {
-        color: $lumenGreen;
+    &.large {
+        bottom: 1rem;
+        right: 2.5rem;
+        padding: 1rem;
+    }
+    &.small {
+        bottom: 0.5rem;
+        right: 0.5rem;
+        padding: 0.25rem 0.5rem;
+        font-size: 0.8rem;
     }
 }

--- a/client/src/components/visualisation/VisualisationViewerContainer.jsx
+++ b/client/src/components/visualisation/VisualisationViewerContainer.jsx
@@ -25,8 +25,8 @@ export default class VisualisationViewerContainer extends Component {
   }
 
   handleResize() {
-    const height = this.VisualisationViewerContainer.clientHeight;
-    const width = this.VisualisationViewerContainer.clientWidth;
+    const height = this.sizeNode.clientHeight;
+    const width = this.sizeNode.clientWidth;
 
     this.setState({
       clientHeight: height,
@@ -37,16 +37,18 @@ export default class VisualisationViewerContainer extends Component {
   render() {
     const { datasets, visualisation } = this.props;
     return (
-      <div
-        className="VisualisationViewerContainer"
-        ref={(ref) => { this.VisualisationViewerContainer = ref; }}
-      >
-        <AsyncVisualisationViewer
-          datasets={datasets}
-          visualisation={visualisation}
-          height={this.state.clientHeight}
-          width={this.state.clientWidth}
-        />
+      <div className="VisualisationViewerContainer">
+        <div
+          className="sizeNode"
+          ref={(ref) => { this.sizeNode = ref; }}
+        >
+          <AsyncVisualisationViewer
+            datasets={datasets}
+            visualisation={visualisation}
+            height={this.state.clientHeight}
+            width={this.state.clientWidth}
+          />
+        </div>
       </div>
     );
   }

--- a/client/src/components/visualisation/VisualisationViewerContainer.scss
+++ b/client/src/components/visualisation/VisualisationViewerContainer.scss
@@ -1,5 +1,11 @@
 .VisualisationViewerContainer {
   width: 100%;
   height: 100%;
+  padding: 1rem 1rem 2rem 1rem;
   overflow: hidden;
+
+  .sizeNode {
+    width: 100%;
+    height: 100%;
+  }
 }

--- a/client/src/index-pub.jsx
+++ b/client/src/index-pub.jsx
@@ -36,7 +36,9 @@ function renderSuccessfulShare(data) {
           datasets={immutableDatasets}
         />
       }
-      <LumenBranding />
+      <LumenBranding
+        size={data.dashboards ? 'large' : 'small'}
+      />
     </div>,
     rootElement
   );


### PR DESCRIPTION
#1163 
- [ ] **Update release notes if necessary**

Resizing strategy for visualisations remains the same, but now we add padding to the parent div and measure the size of a new child div to pass down to children