### PR TITLE
[#1217] Update to latest Windshaft container

### DIFF
--- a/windshaft/Dockerfile
+++ b/windshaft/Dockerfile
@@ -1,3 +1,3 @@
-FROM akvo/akvo-maps:03ff24db
+FROM akvo/akvo-maps:da60926a
 
 ADD ./config/prod /config/


### PR DESCRIPTION
New image is backwards compatible and requires no changes in Lumen.

Changes that affect Lumen:
1. Smaller container image (from 1gb to 256mb)
2. Fixed performance issue with stats collection. Minor impact for Lumen.

Other changes that do not affect Lumen, but maybe interesting:
1. Added health check endpoint
2. Added a statds-to-prometheus sidecar for monitoring