### PR TITLE
[#1229] Always use *current* spec for visualisation config menu

### DIFF
--- a/client/src/components/visualisation/VisualisationEditor.jsx
+++ b/client/src/components/visualisation/VisualisationEditor.jsx
@@ -283,7 +283,7 @@ export default class VisualisationEditor extends Component {
     return (
       <div className="VisualisationEditor">
         <VisualisationConfig
-          visualisation={visualisation}
+          visualisation={props.visualisation}
           metadata={metadata}
           datasets={props.datasets}
           onChangeVisualisationType={props.onChangeVisualisationType}


### PR DESCRIPTION
#1229

RELEASE_NOTES: `Fix bug where new layers could not be added to old maps`
- [ ] **Update release notes if necessary**
