### PR TITLE
[#1161] Catch Throwable to handle possible OutOfMemoryError

### DIFF
--- a/backend/src/akvo/lumen/lib/raster_impl.clj
+++ b/backend/src/akvo/lumen/lib/raster_impl.clj
@@ -104,7 +104,7 @@
                                          (.setValue (json/generate-string metadata)))
                              :raster-table table-name})
         (update-successful-job-execution conn {:id job-execution-id})))
-    (catch Exception e
+    (catch Throwable e
       (update-failed-job-execution conn {:id job-execution-id
                                          :reason (.getMessage e)}))))
 


### PR DESCRIPTION
Catch a `java.lang.Throwable` to handle potential `OutOfMemoryError` when importing large raster files