### PR TITLE
Allow backend/Dockerfile to build a production image

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,2 +1,2 @@
 target/*
-
+!target/uberjar/akvo-lumen.jar

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ RUN set -ex; apt-get update && \
 
 WORKDIR /app
 
-COPY akvo-lumen.jar /app/akvo-lumen.jar
+COPY target/uberjar/akvo-lumen.jar /app/akvo-lumen.jar
 
 COPY maybe-import-and-java-jar.sh /app/maybe-import-and-java-jar.sh
 RUN chmod 777 /app/maybe-import-and-java-jar.sh


### PR DESCRIPTION
Steps to build a production image of the backend, before this change:
1. `lein uberjar`
2. `cp target/uberjar/akvo-lumen.jar .`
3. `docker build .`

After this change:
1. `lein uberjar`
2. `docker build .`