### PR TITLE
Issue/1320 nginx logging

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:1.13.8-alpine
 MAINTAINER Akvo Foundation <devops@akvo.org>
 
+RUN sed -i -e '/.*access_log.*main;$/d' /etc/nginx/nginx.conf;
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY favicon.ico /usr/share/nginx/html/favicon.ico
 COPY dist/* /usr/share/nginx/html/assets/

--- a/client/default.conf
+++ b/client/default.conf
@@ -19,6 +19,13 @@ gzip_types
     text/plain
     text/html;
 
+map $http_user_agent $loggable {
+  ~^GoogleHC 0;
+  default 1;
+}
+
+access_log  /var/log/nginx/access.log  main if=$loggable;
+
 log_format without_url '$remote_addr - $remote_user [$time_local] "$request_method $obfuscated_url" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';

--- a/client/default.conf
+++ b/client/default.conf
@@ -16,8 +16,7 @@ gzip_types
     image/svg+xml
     image/x-icon
     text/css
-    text/plain
-    text/html;
+    text/plain;
 
 map $http_user_agent $loggable {
   ~^GoogleHC 0;


### PR DESCRIPTION

* Disable logging when user-agent starts with `GoogleHC`
  * We need to modify the main `nginx.conf` and move the `access_log` directive to `default.conf`, since `map` directive doesn't work in `server` scope
* Currently there is a StackDriver checks, but those are going to be disabled soon
* Fix a warning by nginx since `text/html` is always added as mime-type to be gzipped