### PR TITLE
[#1320] Rollback changes made in a1243d4

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,7 +1,6 @@
 FROM nginx:1.13.8-alpine
 MAINTAINER Akvo Foundation <devops@akvo.org>
 
-RUN sed -i -e '/.*access_log.*main;$/d' /etc/nginx/nginx.conf;
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY favicon.ico /usr/share/nginx/html/favicon.ico
 COPY dist/* /usr/share/nginx/html/assets/

--- a/client/default.conf
+++ b/client/default.conf
@@ -18,13 +18,6 @@ gzip_types
     text/css
     text/plain;
 
-map $http_user_agent $loggable {
-  ~^GoogleHC 0;
-  default 1;
-}
-
-access_log  /var/log/nginx/access.log  main if=$loggable;
-
 log_format without_url '$remote_addr - $remote_user [$time_local] "$request_method $obfuscated_url" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';


### PR DESCRIPTION
We know now that `GoogleHC` was not the cause of the high CPU usage on fluentd pod.
See: https://github.com/kubernetes/dashboard/issues/2723