### PR TITLE
[#1336] Decrypt the service account credentials just before using it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
   - "$HOME/.lein"
   - "${HOME}/google-cloud-sdk"
 before_install:
-- openssl aes-256-cbc -K $encrypted_13abf95e958f_key -iv $encrypted_13abf95e958f_iv
-  -in ci/gcloud-service-account.json.enc -out ci/gcloud-service-account.json -d
 - if [[ ! -d "$HOME/.m2" ]]; then mkdir "$HOME/.m2"; fi;
 - if [[ ! -d "$HOME/.lein" ]]; then mkdir "$HOME/.lein"; fi;
 - echo "HOST_UID=$(id -u)" >> .env

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -23,6 +23,8 @@ gcloud version
 which gcloud kubectl
 
 log Authentication with gcloud and kubectl
+openssl aes-256-cbc -K $encrypted_13abf95e958f_key -iv $encrypted_13abf95e958f_iv \
+	-in ci/gcloud-service-account.json.enc -out ci/gcloud-service-account.json -d
 gcloud auth activate-service-account --key-file ci/gcloud-service-account.json
 gcloud config set project akvo-lumen
 gcloud config set container/cluster europe-west1-d


### PR DESCRIPTION
- We moved the setup of the service account credentials to the last moment to allow builds from external forks
- We know that we're not going to deploy from an external fork, only from `develop` or `master` in the main repo
