### PR TITLE
Fix CIDER find-var, can't jump to definition with a docker-nrepl connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ backend/*.jar
 backend/*.class
 backend/.lein-*
 backend/.nrepl-*
-backend/.dir-locals.el
 backend/profiles.clj
 backend/dev/resources/local.edn
 backend/dev/src/local.clj

--- a/backend/.dir-locals.el
+++ b/backend/.dir-locals.el
@@ -1,0 +1,21 @@
+;; using docker-compose up, we loose the cider ability to navigate definitions with `C - .` due the source of current (docker) nrepl is under a different path `/app/src` instead of akvo-lumen local git repo
+;; so the trick is to replace docker source paths by user-local-paths. 
+((nil . ((eval . (defun to-local-paths (info)
+		   "adapt src and .m2 docker paths to local paths"
+		   (let* ((file (nrepl-dict-get info "file"))
+			  (res-0 (progn
+				   (replace-regexp-in-string  "/app/" (clojure-project-dir) file))))
+		     (replace-regexp-in-string  "/home/akvo/.m2/"
+						(concat (getenv "HOME") "/.m2/")
+						res-0))))
+	 (eval . (defun cider--jump-to-loc-from-info (info &optional other-window)
+		   ""
+		   (let* ((line (nrepl-dict-get info "line"))
+			  (file (to-local-paths info))
+			  (name (nrepl-dict-get info "name"))
+			  ;; the filename might actually be a REPL buffer name
+			  (buffer (cider--find-buffer-for-file file)))
+		     (if buffer
+			 (cider-jump-to buffer (if line (cons line nil) name) other-window)
+		       (error (concat "No source location..." file)))))))))
+


### PR DESCRIPTION
Fix #1383 

Relevant installation info in #1383  specially this [one](https://github.com/akvo/akvo-lumen/issues/1383#issuecomment-383894327)



