### PR TITLE
[#1439] Using IGNORE_EXISTING when importing

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -8,4 +8,4 @@ ENV KEYCLOAK_PASSWORD=admin
 CMD ["-b", "0.0.0.0", "-Dkeycloak.migration.action=import", \
      "-Dkeycloak.migration.provider=singleFile", \
      "-Dkeycloak.migration.file=/tmp/akvo.json", \
-     "-Dkeycloak.migration.strategy=OVERWRITE_EXISTING"]
+     "-Dkeycloak.migration.strategy=IGNORE_EXISTING"]


### PR DESCRIPTION
It means that if the default akvo.json is changed the KC container must
be recreated (or the whole dev env) but it also means that any change
in the realm is not lost when restarting the container, which is more
in line with how the Postgres DB actually works.

Fixes #1439