### PR TITLE
[#1456] Add rounding heuristic for chart display values

### DIFF
--- a/client/src/components/charts/LineChart.jsx
+++ b/client/src/components/charts/LineChart.jsx
@@ -11,7 +11,7 @@ import { GridRows, GridColumns } from '@vx/grid';
 import itsSet from 'its-set';
 
 import { sortChronologically, filterNullData } from '../../utilities/utils';
-import { round } from '../../utilities/chart';
+import { heuristicRound } from '../../utilities/chart';
 import ResponsiveWrapper from '../common/ResponsiveWrapper';
 import ColorPicker from '../common/ColorPicker';
 import ChartLayout from './ChartLayout';
@@ -118,7 +118,7 @@ export default class LineChart extends Component {
       tooltipVisible: true,
       tooltipItems: [
         { key: xLabel, value: x },
-        { key: yLabel, value: round(y, 4) },
+        { key: yLabel, value: heuristicRound(y) },
       ],
       tooltipPosition,
     });

--- a/client/src/components/charts/ScatterChart.jsx
+++ b/client/src/components/charts/ScatterChart.jsx
@@ -13,6 +13,7 @@ import ColorPicker from '../common/ColorPicker';
 import ResponsiveWrapper from '../common/ResponsiveWrapper';
 import Tooltip from './Tooltip';
 import ChartLayout from './ChartLayout';
+import { heuristicRound } from '../../utilities/chart';
 
 const startAxisFromZero = (axisExtent, type) => {
   // Returns an educated guess on if axis should start from zero or not
@@ -140,8 +141,8 @@ export default class ScatterChart extends Component {
     if (!interactive || print) return;
     this.handleShowTooltip(event, [
       { key: label, color },
-      { key: yAxisLabel || 'y', value: y },
-      { key: xAxisLabel || 'x', value: x },
+      { key: yAxisLabel || 'y', value: heuristicRound(y) },
+      { key: xAxisLabel || 'x', value: heuristicRound(x) },
     ]);
     this.setState({ hoveredNode: key });
   }

--- a/client/src/components/charts/SimpleBarChart.jsx
+++ b/client/src/components/charts/SimpleBarChart.jsx
@@ -10,7 +10,7 @@ import { Portal } from 'react-portal';
 import merge from 'lodash/merge';
 import { GridRows } from '@vx/grid';
 
-import { replaceLabelIfValueEmpty } from '../../utilities/chart';
+import { heuristicRound, replaceLabelIfValueEmpty } from '../../utilities/chart';
 import Legend from './Legend';
 import ResponsiveWrapper from '../common/ResponsiveWrapper';
 import ColorPicker from '../common/ColorPicker';
@@ -152,7 +152,7 @@ export default class SimpleBarChart extends Component {
     if (this.state.isPickingColor) return;
     const { interactive, print, colors } = this.props;
     if (!interactive || print) return;
-    this.handleShowTooltip(event, { key, color: colors[key], value });
+    this.handleShowTooltip(event, { key, color: colors[key], value: heuristicRound(value) });
     this.setState({ hoveredNode: key });
   }
 

--- a/client/src/components/charts/StackedBarChart.jsx
+++ b/client/src/components/charts/StackedBarChart.jsx
@@ -11,7 +11,7 @@ import merge from 'lodash/merge';
 import { stack } from 'd3-shape';
 import { GridRows } from '@vx/grid';
 
-import { replaceLabelIfValueEmpty } from '../../utilities/chart';
+import { heuristicRound, replaceLabelIfValueEmpty } from '../../utilities/chart';
 import Legend from './Legend';
 import ResponsiveWrapper from '../common/ResponsiveWrapper';
 import ColorPicker from '../common/ColorPicker';
@@ -139,7 +139,7 @@ export default class StackedBarChart extends Component {
     if (!interactive || print) return;
     this.handleShowTooltip(event, [
       { key: seriesKey, color: this.getColor(seriesKey, seriesIndex), value: valueKey },
-      { key: yAxisLabel || 'y', value: node.values[seriesKey] },
+      { key: yAxisLabel || 'y', value: heuristicRound(node.values[seriesKey]) },
     ]);
     this.setState({ hoveredNode: { seriesKey, valueKey } });
   }

--- a/client/src/utilities/chart.js
+++ b/client/src/utilities/chart.js
@@ -443,9 +443,53 @@ export function getMapData(layer, datasets) {
   });
 }
 
-export const round = (num, places) =>
-    // eslint-disable-next-line no-restricted-properties
-    Math.round(num * Math.pow(10, places)) / Math.pow(10, places);
+export const round = (input, places) => {
+  let num;
+  if (typeof input === 'number') {
+    num = input;
+  } else {
+    num = Number(input);
+    if (isNaN(num)) {
+      return input;
+    }
+  }
+  // eslint-disable-next-line no-restricted-properties
+  return Math.round(num * Math.pow(10, places)) / Math.pow(10, places);
+}
+
+export const heuristicRound = (input) => {
+  let num;
+  if (typeof input === 'number') {
+    num = input;
+  } else {
+    num = Number(input);
+    if (isNaN(num)) {
+      return input;
+    }
+  }
+
+  let places;
+
+  if (num < 0.0000001) {
+    places = 10;
+  } else if (num < 0.000001) {
+    places = 9;
+  } else if (num < 0.00001) {
+    places = 8;
+  } else if (num < 0.00001) {
+    places = 7;
+  } else if (num < 0.0001) {
+    places = 6;
+  } else if (num < 0.001) {
+    places = 5;
+  } else if (num < 0.01) {
+    places = 4;
+  } else {
+    places = 2;
+  }
+
+  return round(num, places);
+}
 
 const percentageRow = (rows, spec) => {
   const totalsRowIndex = rows.length - 1;


### PR DESCRIPTION
#1456

For chart types where we show a tooltip, and where the user has chosen an aggregation (e.g. mean, q1 etc) then we should display the aggregated value to an appropriate number of decimal places
