### PR TITLE
Move postgres independent logic outside aggregation domain

### DIFF
--- a/backend/src/akvo/lumen/lib/aggregation/bar.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/bar.clj
@@ -1,6 +1,6 @@
 (ns akvo.lumen.lib.aggregation.bar
   (:require [akvo.lumen.lib :as lib]
-            [akvo.lumen.lib.aggregation.filter :as filter]
+            [akvo.lumen.postgres.filter :as filter]
             [akvo.lumen.lib.aggregation.utils :as utils]
             [clojure.java.jdbc :as jdbc]))
 

--- a/backend/src/akvo/lumen/lib/aggregation/line.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/line.clj
@@ -1,6 +1,6 @@
 (ns akvo.lumen.lib.aggregation.line
   (:require [akvo.lumen.lib :as lib]
-            [akvo.lumen.lib.aggregation.filter :as filter]
+            [akvo.lumen.postgres.filter :as filter]
             [akvo.lumen.lib.aggregation.utils :as utils]
             [clojure.java.jdbc :as jdbc]))
 

--- a/backend/src/akvo/lumen/lib/aggregation/pie.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/pie.clj
@@ -1,6 +1,6 @@
 (ns akvo.lumen.lib.aggregation.pie
   (:require [akvo.lumen.lib :as lib]
-            [akvo.lumen.lib.aggregation.filter :as filter]
+            [akvo.lumen.postgres.filter :as filter]
             [akvo.lumen.lib.aggregation.utils :as utils]
             [clojure.java.jdbc :as jdbc]))
 

--- a/backend/src/akvo/lumen/lib/aggregation/pivot.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/pivot.clj
@@ -1,7 +1,7 @@
 (ns akvo.lumen.lib.aggregation.pivot
   (:require [akvo.commons.psql-util]
             [akvo.lumen.lib :as lib]
-            [akvo.lumen.lib.aggregation.filter :as filter]
+            [akvo.lumen.postgres.filter :as filter]
             [akvo.lumen.lib.aggregation.utils :as utils]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]

--- a/backend/src/akvo/lumen/lib/aggregation/scatter.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/scatter.clj
@@ -1,6 +1,6 @@
 (ns akvo.lumen.lib.aggregation.scatter
   (:require [akvo.lumen.lib :as lib]
-            [akvo.lumen.lib.aggregation.filter :as filter]
+            [akvo.lumen.postgres.filter :as filter]
             [akvo.lumen.lib.aggregation.utils :as utils]
             [clojure.java.jdbc :as jdbc]))
 

--- a/backend/src/akvo/lumen/lib/visualisation/map_config.clj
+++ b/backend/src/akvo/lumen/lib/visualisation/map_config.clj
@@ -1,5 +1,5 @@
 (ns akvo.lumen.lib.visualisation.map-config
-  (:require [akvo.lumen.lib.aggregation.filter :as filter]
+  (:require [akvo.lumen.postgres.filter :as filter]
             [clojure.string :as str]
             [hugsql.core :as hugsql]))
 

--- a/backend/src/akvo/lumen/lib/visualisation/maps.clj
+++ b/backend/src/akvo/lumen/lib/visualisation/maps.clj
@@ -1,6 +1,6 @@
 (ns akvo.lumen.lib.visualisation.maps
   (:require [akvo.lumen.lib :as lib]
-            [akvo.lumen.lib.aggregation.filter :as filter]
+            [akvo.lumen.postgres.filter :as filter]
             [akvo.lumen.lib.visualisation.map-config :as map-config]
             [akvo.lumen.lib.visualisation.map-metadata :as map-metadata]
             [akvo.lumen.transformation.engine :as engine]

--- a/backend/src/akvo/lumen/postgres.clj
+++ b/backend/src/akvo/lumen/postgres.clj
@@ -1,0 +1,8 @@
+(ns akvo.lumen.postgres
+  (:require [clojure.string :as str]))
+
+(defn escape-string [s]
+  (when-not (nil? s)
+    (when-not (string? s)
+      (throw (ex-info "Not a string" {:s s})))
+    (str/replace s "'" "''")))

--- a/backend/src/akvo/lumen/postgres/filter.clj
+++ b/backend/src/akvo/lumen/postgres/filter.clj
@@ -1,5 +1,5 @@
-(ns akvo.lumen.lib.aggregation.filter
-  (:require [akvo.lumen.transformation.engine :as engine]
+(ns akvo.lumen.postgres.filter
+  (:require [akvo.lumen.postgres :as core]
             [clojure.string :as str])
   (:import [java.sql.Timestamp]))
 
@@ -74,7 +74,7 @@
       "text" (format "coalesce(%1$s, '') %2$s '%3$s'"
                      column-name
                      op
-                     (engine/pg-escape-string value))
+                     (core/escape-string value))
       (invalid-filter "Type not supported" {:type column-type}))))
 
 (defmethod filter-sql "isEmpty"

--- a/backend/src/akvo/lumen/transformation/change_datatype.clj
+++ b/backend/src/akvo/lumen/transformation/change_datatype.clj
@@ -1,5 +1,6 @@
 (ns akvo.lumen.transformation.change-datatype
   (:require [akvo.lumen.transformation.engine :as engine]
+            [akvo.lumen.postgres :as postgres]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -66,7 +67,7 @@
         on-error (engine/error-strategy op-spec)
         {column-name "columnName"
          default-value "defaultValue"} (engine/args op-spec)
-        default-value (engine/pg-escape-string default-value)
+        default-value (postgres/escape-string default-value)
         alter-table (format-sql table-name column-name "text")
         alter-table-sql (condp = on-error
                           "fail" (alter-table "%s(%s)" type-conversion column-name)
@@ -81,7 +82,7 @@
         {column-name "columnName"
          default-value "defaultValue"
          parse-format "parseFormat"} (engine/args op-spec)
-        parse-format (engine/pg-escape-string parse-format)
+        parse-format (postgres/escape-string parse-format)
         alter-table (format-sql table-name column-name "timestamptz")
         alter-table-sql (condp = (from-type columns op-spec)
                           "text" (condp = on-error

--- a/backend/src/akvo/lumen/transformation/engine.clj
+++ b/backend/src/akvo/lumen/transformation/engine.clj
@@ -47,12 +47,6 @@
       {:success? false
        :message (format "Failed to transform: %s" (.getMessage e))})))
 
-(defn pg-escape-string [s]
-  (when-not (nil? s)
-    (when-not (string? s)
-      (throw (ex-info "Not a string" {:s s})))
-    (str/replace s "'" "''")))
-
 (defn ensure-number [n]
   (when-not (or (nil? n)
                 (number? n))


### PR DESCRIPTION
IMO makes sense to put in its own namespace `akvo.lumen.postgres` the postgres code that could be used in any akvo project. I found that `akvo.lumen.lib.aggregation.filter` could perfectly extracted 

Maybe this is the beginning of taking out reusable postgres logic from other lib namespaces too 

- [ ] **Update release notes if necessary**
