### PR TITLE
Add new `multiple` lumen type

### DIFF
--- a/backend/src/akvo/lumen/import.clj
+++ b/backend/src/akvo/lumen/import.clj
@@ -37,14 +37,16 @@
                                   :table-name table-name
                                   :imported-table-name imported-table-name
                                   :version 1
-                                  :columns (mapv (fn [{:keys [title id type key] :as columns}]
-                                                   (cond-> {:type (name type)
-                                                            :title (string/trim title)
-                                                            :columnName (name id)
-                                                            :sort nil
-                                                            :direction nil
-                                                            :hidden false}
-                                                     (contains? columns :key) (assoc :key (boolean key))))
+                                  :columns (mapv (fn [{:keys [title id type key multiple-type multiple-id]}]
+                                                   {:columnName (name id)
+                                                    :direction nil
+                                                    :hidden false
+                                                    :key (boolean key)
+                                                    :multipleId multiple-id
+                                                    :multipleType multiple-type
+                                                    :sort nil
+                                                    :title (string/trim title)
+                                                    :type (name type)})
                                                  columns)
                                   :transformations []})
     (update-successful-job-execution conn {:id job-execution-id})))

--- a/backend/src/akvo/lumen/import/common.clj
+++ b/backend/src/akvo/lumen/import/common.clj
@@ -78,6 +78,7 @@
                                           ;; Note not `POLYGON` so we can support `MULTIPOLYGON` as well
                                           :geoshape "geometry(GEOMETRY, 4326)"
                                           :geopoint "geometry(POINT, 4326)"
+                                          :multiple "text"
                                           :text "text")))
                               columns))))
 

--- a/backend/src/akvo/lumen/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/import/flow_v3.clj
@@ -10,6 +10,7 @@
     "NUMBER" :number
     "DATE" :date
     "GEO" :geopoint
+    "CADDISFLY" :multiple
     :text))
 
 (defn dataset-columns
@@ -25,9 +26,16 @@
            {:title "Submitted at" :type :date :id :submitted_at}
            {:title "Surveyal time" :type :number :id :surveyal_time}]
           (map (fn [question]
-                 {:title (:name question)
-                  :type (question-type->lumen-type question)
-                  :id (keyword (format "c%s" (:id question)))})
+                 (let[column-type (question-type->lumen-type question)]
+                   (merge {:title (:name question)
+                           :type column-type
+                           :id (keyword (format "c%s" (:id question)))}
+                          (when (= column-type :multiple)
+                            (if (:caddisflyResourceUuid question)
+                              {:multiple-type :caddisfly
+                               :multiple-id (:caddisflyResourceUuid question)}
+                              {:multiple :unknown
+                               :multiple-id nil})))))
                questions))))
 
 (defn render-response

--- a/backend/src/akvo/lumen/update.clj
+++ b/backend/src/akvo/lumen/update.clj
@@ -39,14 +39,15 @@
 
 (defn apply-transformation-log [conn table-name columns transformations]
   (let [;; Translate columns vector into a form that the transformation engine understands
-        columns (mapv (fn [{:keys [title id type key] :as column}]
+        columns (mapv (fn [{:keys [title id type key caddisflyResourceUuid] :as column}]
                         (cond-> {"type" (name type)
                                  "title" title
                                  "columnName" (name id)
                                  "sort" nil
                                  "direction" nil
                                  "hidden" false}
-                          (contains? column :key) (assoc "key" (boolean key))) )
+                          key (assoc "key" (boolean key))
+                          caddisflyResourceUuid (assoc "caddisflyResourceUuid" caddisflyResourceUuid)))
                       columns)]
     (loop [transformations transformations columns columns]
       (if-let [transformation (first transformations)]
@@ -65,8 +66,8 @@
                                          :title (string/trim (get column "title"))}
                                   (contains? column "key") (assoc :key (boolean (get column "key")))))
                               imported-columns)]
-    (set/subset? (set imported-columns)
-                 (set columns))))
+    (set/subset? (set (map #(select-keys % [:id :type :title]) imported-columns))
+                 (set (map #(select-keys % [:id :type :title]) columns)))))
 
 (defn do-update [conn config dataset-id data-source-id job-execution-id data-source-spec]
   (try

--- a/client/src/components/dataset/context-menus/ColumnContextMenu.jsx
+++ b/client/src/components/dataset/context-menus/ColumnContextMenu.jsx
@@ -116,6 +116,7 @@ const dataTypeOptions = {
   number: [],
   date: [],
   geopoint: [],
+  multiple: [],
 };
 
 export default function ColumnContextMenu({

--- a/client/src/translations/en.json
+++ b/client/src/translations/en.json
@@ -145,6 +145,7 @@
   "merged_dataset": "Merged columns from {title}",
   "metric_column": "Metric column",
   "min": "Min",
+  "multiple": "Multiple",
   "must_choose_bucket_column_first": "Must choose bucket column first",
   "must_choose_x_axis_column_first": "Must choose X-axis column first",
   "name": "Name",

--- a/client/src/translations/es.json
+++ b/client/src/translations/es.json
@@ -144,6 +144,7 @@
   "merged_dataset": "Unir columnas desde {title}",
   "metric_column": "Columna métrica",
   "min": "Mínimo",
+  "multiple": "Múltiple",
   "must_choose_bucket_column_first": "Debe elegir primero la columna cubo",
   "must_choose_x_axis_column_first": "Debe elegir primero la columna del eje x",
   "name": "Nombre",

--- a/client/src/translations/fr.json
+++ b/client/src/translations/fr.json
@@ -140,6 +140,7 @@
   "merged_dataset": "Fusionner les colonnes depuis {title}",
   "metric_column": "Colonne numérique",
   "min": "Min",
+  "multiple": "Multiple",
   "must_choose_bucket_column_first": "Doit choisir la colonne contenant d'abord",
   "must_choose_x_axis_column_first": "Doit choisir l'axe-x d'abord",
   "name": "Nom",


### PR DESCRIPTION
Multiple means that columns with this type contain multiple values that could be
extracted to multiple columns

so far, and internally, this `multiple` type is only taken by caddisfly data imported by flow

- [ ] **Update release notes if necessary**
