### PR TITLE
Add GET /api/multiple-column/ endpoint

### DIFF
--- a/backend/resources/akvo/lumen/system.edn
+++ b/backend/resources/akvo/lumen/system.edn
@@ -20,6 +20,7 @@
   :invite-verify #var akvo.lumen.endpoint.invite/verify-endpoint
   :job-execution #var akvo.lumen.endpoint.job-execution/endpoint
   :library #var akvo.lumen.endpoint.library/endpoint
+  :multiple-column #var akvo.lumen.endpoint.multiple-column/endpoint
   :public #var akvo.lumen.endpoint.public/endpoint
   :resource #var akvo.lumen.endpoint.resource/endpoint
   :root #var akvo.lumen.endpoint.root/endpoint
@@ -32,7 +33,7 @@
  {:http [:app]
   :app [:aggregation :collection :dashboard :dataset :raster :env :emailer :files :healthz
         :invite :invite-verify :job-execution :library :public :resource :root :share
-        :tier :transformation :user :visualisation]
+        :tier :transformation :user :visualisation :multiple-column]
   :tenant-manager [:config :db]
   :aggregation [:tenant-manager]
   :collection [:tenant-manager]
@@ -45,6 +46,7 @@
   :invite-verify [:keycloak :tenant-manager :config]
   :job-execution [:tenant-manager]
   :library [:tenant-manager]
+  :multiple-column [:caddisfly]
   :public [:tenant-manager :config]
   :resource [:tenant-manager]
   :root [:tenant-manager]

--- a/backend/src/akvo/lumen/endpoint/multiple_column.clj
+++ b/backend/src/akvo/lumen/endpoint/multiple_column.clj
@@ -1,0 +1,10 @@
+(ns akvo.lumen.endpoint.multiple-column
+  (:require [akvo.lumen.lib.multiple-column :as multiple-column]
+            [cheshire.core :as json]
+            [compojure.core :refer :all]))
+
+(defn endpoint [{:keys [caddisfly tenant-manager]}]
+  (context "/api/multiple-column" {:keys [query-params] :as request}
+           (GET "/" _
+                (let [query (json/parse-string (get query-params "query") keyword)]
+                  (multiple-column/details {:caddisfly caddisfly} (:multipleType query) (:multipleId query))))))

--- a/backend/src/akvo/lumen/lib/multiple_column.clj
+++ b/backend/src/akvo/lumen/lib/multiple_column.clj
@@ -1,0 +1,25 @@
+(ns akvo.lumen.lib.multiple-column
+  (:require [clojure.tools.logging :as log]
+            [ring.util.response :refer [response not-found]]))
+
+(defn- extract
+  [caddisfly id]
+  (when id
+    (if-let [schema (get (:schema caddisfly) id)]
+      (let [res (select-keys schema [:hasImage])]
+        (assoc res :columns (map (fn [r]
+                                   {:id   (:id r)
+                                    :name (str (:name r) " :: " (:unit r))
+                                    :type "text" ;; TODO will be improved after design discussions 
+                                    }) (:results schema)))))))
+
+(defn details
+  "depending of type of multiple columns we dispatch to different logic impls"
+  [{:keys [caddisfly] :as deps} multiple-type multiple-id]
+  (log/debug ::all :multiple-type multiple-type :multiple-id multiple-id)
+  (condp = multiple-type
+    "caddisfly" (if-let [res (extract caddisfly multiple-id)]
+                  (response res)
+                  (not-found {:message "caddisfly id not found"
+                              :multiple-id multiple-id}))
+    (not-found {:type multiple-type})))

--- a/backend/test/akvo/lumen/component/caddisfly_test.clj
+++ b/backend/test/akvo/lumen/component/caddisfly_test.clj
@@ -3,16 +3,24 @@
             [clojure.test :refer :all]
             [com.stuartsierra.component :as component]))
 
+(defn caddisfly
+  ([]
+   (caddisfly :dev))
+  ([type]
+   (if (= type :prod)
+     (-> {:schema-uri "https://akvoflow-public.s3.amazonaws.com/caddisfly-tests.json"}
+         c/caddisfly
+         component/start)
+     (-> {:local-schema-uri "./caddisfly/tests-schema.json"}
+         c/dev-caddisfly
+         component/start))))
+
+
+
 (deftest component-versions-test
   (testing "prod component version"
-    (let [caddisfly-prod (-> {:schema-uri "https://akvoflow-public.s3.amazonaws.com/caddisfly-tests.json"}
-                             c/caddisfly
-                             component/start)]
-      (is (= (-> caddisfly-prod :schema first val keys)
-             '(:name :uuid :brand :hasImage :results)))))
+    (is (= (-> (caddisfly :prod) :schema first val keys)
+           '(:name :uuid :brand :hasImage :results))))
   (testing "dev component version"
-    (let [caddisfly-dev (-> {:local-schema-uri "./caddisfly/tests-schema.json"}
-                            c/dev-caddisfly
-                            component/start)]
-      (is (= (-> caddisfly-dev :schema first val keys)
-             '(:name :uuid :brand :hasImage :results))))))
+    (is (= (-> (caddisfly :dev) :schema first val keys)
+           '(:name :uuid :brand :hasImage :results)))))

--- a/backend/test/akvo/lumen/lib/multiple_column_test.clj
+++ b/backend/test/akvo/lumen/lib/multiple_column_test.clj
@@ -1,0 +1,12 @@
+(ns akvo.lumen.lib.multiple-column-test
+  (:require [akvo.lumen.lib.multiple-column :as multiple-column]
+            [akvo.lumen.component.caddisfly-test :refer (caddisfly)]
+            [clojure.test :refer :all]))
+
+(deftest details-test
+  (testing "get multiple column details"
+    (let [multiple-type "caddisfly"
+          multiple-id "0b4a0aaa-f556-4c11-a539-c4626582cca6"]
+      (is (= 200 (:status (multiple-column/details {:caddisfly (caddisfly)} multiple-type multiple-id))))
+      (is (= 404 (:status (multiple-column/details {} "other" multiple-id))))
+      (is (= 404 (:status (multiple-column/details {:caddisfly (caddisfly)} multiple-type "not-found")))))))


### PR DESCRIPTION
retrieving details for multiple column

so far only `caddisfly` multipleType is implemented

example request:
`/api/multiple-column?query=%7B%22multipleType%22%3A%22caddisfly%22%2C%22multipleId%22%3A%2280697cd1-acc9-4a15-8358-f32b4257dfaf%22%7D`

parsed values `query: {"multipleType":"caddisfly","multipleId":"80697cd1-acc9-4a15-8358-f32b4257dfaf"}`

- [ ] **Update release notes if necessary**
