### PR TITLE
Add core/extract-multiple transformation op 

### DIFF
--- a/backend/resources/akvo/lumen/system.edn
+++ b/backend/resources/akvo/lumen/system.edn
@@ -50,7 +50,7 @@
   :root [:tenant-manager]
   :share [:tenant-manager :config]
   :tier [:tenant-manager]
-  :transformation [:tenant-manager]
+  :transformation [:tenant-manager :caddisfly]
   :user [:keycloak]
   :visualisation [:config :tenant-manager]}
  :config

--- a/backend/src/akvo/lumen/endpoint/transformation.clj
+++ b/backend/src/akvo/lumen/endpoint/transformation.clj
@@ -3,17 +3,17 @@
             [akvo.lumen.transformation :as t]
             [compojure.core :refer :all]))
 
-(defn endpoint [{:keys [tenant-manager]}]
+(defn endpoint [{:keys [tenant-manager caddisfly]}]
   (context "/api/transformations" {:keys [tenant] :as request}
     (let-routes [tenant-conn (connection tenant-manager tenant)]
       (context "/:dataset-id" [dataset-id]
         (POST "/transform" {:keys [body] :as request}
-              (t/apply {:tenant-conn tenant-conn}
+              (t/apply {:tenant-conn tenant-conn :caddisfly caddisfly}
                    dataset-id
                    {:type :transformation
                     :transformation body}))
 
         (POST "/undo" _
-              (t/apply {:tenant-conn tenant-conn}
+              (t/apply {:tenant-conn tenant-conn :caddisfly caddisfly}
                    dataset-id
                    {:type :undo}))))))

--- a/backend/src/akvo/lumen/endpoint/transformation.clj
+++ b/backend/src/akvo/lumen/endpoint/transformation.clj
@@ -7,14 +7,13 @@
   (context "/api/transformations" {:keys [tenant] :as request}
     (let-routes [tenant-conn (connection tenant-manager tenant)]
       (context "/:dataset-id" [dataset-id]
-
         (POST "/transform" {:keys [body] :as request}
-          (t/apply tenant-conn
+              (t/apply {:tenant-conn tenant-conn}
                    dataset-id
                    {:type :transformation
                     :transformation body}))
 
         (POST "/undo" _
-          (t/apply tenant-conn
+              (t/apply {:tenant-conn tenant-conn}
                    dataset-id
                    {:type :undo}))))))

--- a/backend/src/akvo/lumen/transformation.clj
+++ b/backend/src/akvo/lumen/transformation.clj
@@ -20,6 +20,7 @@
     akvo.lumen.transformation.delete-column
     akvo.lumen.transformation.geo
     akvo.lumen.transformation.merge-datasets
+    akvo.lumen.transformation.multiple-column
     akvo.lumen.transformation.reverse-geocode])
 
 ;; Load transformation namespaces

--- a/backend/src/akvo/lumen/transformation.sql
+++ b/backend/src/akvo/lumen/transformation.sql
@@ -52,3 +52,7 @@ INSERT INTO :i:dest-table SELECT * FROM :i:source-table;
 -- :name drop-table :!
 -- :doc Drop table
 DROP TABLE IF EXISTS :i:table-name CASCADE;
+
+-- :name select-rnum-and-column :?
+-- :doc Get only the column and the rnum
+SELECT rnum, :i:column-name FROM :i:table-name

--- a/backend/src/akvo/lumen/transformation/engine.clj
+++ b/backend/src/akvo/lumen/transformation/engine.clj
@@ -27,11 +27,11 @@
    - \"op\" : operation to perform
    - \"args\" : map with arguments to the operation
    - \"onError\" : Error strategy"
-  (fn [{:keys [tenant-conn]} table-name columns op-spec]
+  (fn [deps table-name columns op-spec]
     (keyword (get op-spec "op"))))
 
 (defmethod apply-operation :default
-  [{:keys [tenant-conn]} table-name columns op-spec]
+  [deps table-name columns op-spec]
   (let [msg (str "Unknown operation " (get op-spec "op"))]
     (log/debug msg)
     {:success? false
@@ -39,9 +39,9 @@
 
 (defn try-apply-operation
   "invoke apply-operation inside a try-catch"
-  [tenant-conn table-name columns op-spec]
+  [deps table-name columns op-spec]
   (try
-    (apply-operation {:tenant-conn tenant-conn} table-name columns op-spec)
+    (apply-operation deps table-name columns op-spec)
     (catch Exception e
       (log/debug e)
       {:success? false
@@ -144,12 +144,12 @@
             changed-columns)))
 
 (defn execute-transformation
-  [tenant-conn dataset-id job-execution-id transformation]
+  [{:keys [tenant-conn] :as deps} dataset-id job-execution-id transformation]
   (let [dataset-version (latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id})
         previous-columns (vec (:columns dataset-version))
         source-table (:table-name dataset-version)]
     (let [{:keys [success? message columns execution-log]}
-          (try-apply-operation tenant-conn source-table previous-columns transformation)]
+          (try-apply-operation deps source-table previous-columns transformation)]
       (when-not success?
         (log/errorf "Failed to transform: %s, columns: %s, execution-log: %s" message columns execution-log)
         (throw (ex-info "Failed to transform" {})))
@@ -170,7 +170,7 @@
           (touch-dataset tenant-conn {:id dataset-id})
           (lib/created next-dataset-version))))))
 
-(defn- apply-undo [tenant-conn dataset-id job-execution-id current-dataset-version]
+(defn- apply-undo [{:keys [tenant-conn] :as deps} dataset-id job-execution-id current-dataset-version]
   (let [imported-table-name (:imported-table-name current-dataset-version)
         previous-table-name (:table-name current-dataset-version)
         initial-columns (vec (:columns (dataset-version-by-dataset-id tenant-conn
@@ -204,7 +204,7 @@
             (drop-table tenant-conn {:table-name previous-table-name})
             (lib/created next-dataset-version)))
         (let [{:keys [success? message columns execution-log]}
-              (try-apply-operation tenant-conn table-name columns (first transformations))]
+              (try-apply-operation deps table-name columns (first transformations))]
           (if success?
             (recur (rest transformations) columns (into full-execution-log execution-log))
             (do
@@ -213,13 +213,13 @@
               (log/debug "Job executionid: " job-execution-id)
               (throw (ex-info "Failed to undo" {})))))))))
 
-(defn execute-undo [tenant-conn dataset-id job-execution-id]
+(defn execute-undo [{:keys [tenant-conn] :as deps} dataset-id job-execution-id]
   (let [current-dataset-version (latest-dataset-version-by-dataset-id tenant-conn
                                                                       {:dataset-id dataset-id})
         current-version (:version current-dataset-version)]
     (if (= current-version 1)
       (lib/created (assoc current-dataset-version :dataset-id dataset-id))
-      (apply-undo tenant-conn
+      (apply-undo deps
                   dataset-id
                   job-execution-id
                   current-dataset-version))))

--- a/backend/src/akvo/lumen/transformation/engine.clj
+++ b/backend/src/akvo/lumen/transformation/engine.clj
@@ -90,16 +90,23 @@
 (defn args [op-spec]
   (get op-spec "args"))
 
-(defn next-column-name [columns]
+(defn derivation-column-name
+  [i]
+  {:pre [(int? i)]}
+  (format "d%s" i))
+
+(defn next-column-index [columns]
   (let [nums (->> columns
                   (map #(get % "columnName"))
                   (filter #(re-find #"^d\d+$" %))
                   (map #(subs % 1))
                   (map #(Long/parseLong %)))]
-    (str "d"
-         (if (empty? nums)
-           1
-           (inc (apply max nums))))))
+    (if (empty? nums)
+      1
+      (inc (apply max nums)))))
+
+(defn next-column-name [columns]
+  (derivation-column-name (next-column-index columns)))
 
 (defn- deliver-promise-success [promise dataset-id dataset-version-id job-execution-id]
   (deliver promise {:status "OK"

--- a/backend/src/akvo/lumen/transformation/multiple_column.clj
+++ b/backend/src/akvo/lumen/transformation/multiple_column.clj
@@ -3,7 +3,7 @@
             [akvo.lumen.transformation.engine :as t.engine]
             [akvo.lumen.transformation.multiple-column.caddisfly :as t.m-c.caddisfly]
             [clojure.tools.logging :as log]
-            [clojure.walk :refer (keywordize-keys)]))
+            [clojure.walk :refer (keywordize-keys stringify-keys)]))
 
 (defmethod t.engine/valid? :core/extract-multiple
   [op-spec]
@@ -18,5 +18,7 @@
   [deps table-name columns op-spec]
   (let [{:keys [onError op args] :as op-spec} (keywordize-keys op-spec)]
     ;; so far we only implement `caddisfly` in other case we throw exception based on core/condp impl
-    (condp = (-> args :selectedColumn :multipleType)
-      "caddisfly" (t.m-c.caddisfly/apply-operation deps table-name columns op-spec))))
+    (update
+     (condp = (-> args :selectedColumn :multipleType)
+       "caddisfly" (t.m-c.caddisfly/apply-operation deps table-name columns op-spec))
+     :columns stringify-keys)))

--- a/backend/src/akvo/lumen/transformation/multiple_column.clj
+++ b/backend/src/akvo/lumen/transformation/multiple_column.clj
@@ -1,0 +1,22 @@
+(ns akvo.lumen.transformation.multiple-column
+  (:require [akvo.lumen.dataset.utils :as u]
+            [akvo.lumen.transformation.engine :as t.engine]
+            [akvo.lumen.transformation.multiple-column.caddisfly :as t.m-c.caddisfly]
+            [clojure.tools.logging :as log]
+            [clojure.walk :refer (keywordize-keys)]))
+
+(defmethod t.engine/valid? :core/extract-multiple
+  [op-spec]
+  (let [{:keys [onError op args]} (keywordize-keys op-spec)
+        columns-to-extract        (filter :extract (:columns args))]
+    (and
+     (or (:extractImage args) (not-empty columns-to-extract))
+     (every? (comp t.engine/valid-type? :type) columns-to-extract)
+     (#{"fail" "leave-empty" "delete-row"} onError))))
+
+(defmethod t.engine/apply-operation :core/extract-multiple
+  [deps table-name columns op-spec]
+  (let [{:keys [onError op args] :as op-spec} (keywordize-keys op-spec)]
+    ;; so far we only implement `caddisfly` in other case we throw exception based on core/condp impl
+    (condp = (-> args :selectedColumn :multipleType)
+      "caddisfly" (t.m-c.caddisfly/apply-operation deps table-name columns op-spec))))

--- a/backend/src/akvo/lumen/transformation/multiple_column/caddisfly.clj
+++ b/backend/src/akvo/lumen/transformation/multiple_column/caddisfly.clj
@@ -1,0 +1,96 @@
+(ns akvo.lumen.transformation.multiple-column.caddisfly
+  (:require [akvo.lumen.transformation.engine :as engine]
+            [cheshire.core :as json]
+            [clojure.java.jdbc :as jdbc]
+            [clojure.string :as string]
+            [clojure.tools.logging :as log]
+            [hugsql.core :as hugsql]))
+
+(hugsql/def-db-fns "akvo/lumen/transformation.sql")
+
+(hugsql/def-db-fns "akvo/lumen/transformation/engine.sql")
+
+(defn- get-caddisfly-schema
+  [caddisfly column]
+  (if-let [caddisflyResourceUuid (:multipleId column)]
+    (get (:schema caddisfly) caddisflyResourceUuid)
+    (throw
+     (ex-info "this column doesn't have a caddisflyResourceUuid currently associated!"
+              {:message
+               {:possible-reason "maybe you don't update the flow dataset!? (via client dashboard ...)"}}))))
+
+(defn- add-name-to-new-columns
+  [current-columns columns-to-extract]
+  (let [next-column-index (engine/next-column-index current-columns)
+        indexes (map engine/derivation-column-name (iterate inc next-column-index))]
+    (map #(assoc % :columnName %2 :id %2) columns-to-extract indexes)))
+
+(defn- update-row [conn table-name row-id vals-map]
+  (let [r (string/join "," (doall (map (fn [[k v]]
+                                         (str (name k) "='" v "'::TEXT")) vals-map)))
+        sql (str  "update " table-name " SET "  r " where rnum=" row-id)]
+    (log/debug :sql sql)
+    (jdbc/execute! conn sql)))
+
+(defn columns-to-extract [columns selected-column caddisfly-schema extractImage]
+  (let [columns   (filter :extract columns)
+        base-column (dissoc selected-column :multipleId :type :multipleType :columnName :title)]
+    (cond->>
+        (map #(assoc base-column :title (:name %) :type (:type %) :caddisfly-test-id (:id %)) columns)
+      (and (:hasImage caddisfly-schema) extractImage)
+      (cons (with-meta (assoc base-column :type "text" :title (str (:title selected-column) "| Image"))
+              {:image true})))))
+
+(defn multiple-cell-value
+  "get json parsed value from cell row"
+  [row column-name]
+  (json/parse-string ((keyword column-name) row) keyword))
+
+(defn- test-results
+  "`test`-results in caddisfly terminology means the values extracted of caddisfly samples.
+  This function assoc values from json parsed data to selected columns to extract."
+  [cell-value columns-to-extract]
+  (map (fn [c]
+         (if (:image (meta c))
+           (:image cell-value)
+           (:value (some #(when (= (:caddisfly-test-id c) (:id %)) %) (:result cell-value)))))
+   columns-to-extract))
+
+(defn apply-operation 
+  [{:keys [tenant-conn caddisfly] :as deps} table-name current-columns op-spec]
+  (jdbc/with-db-transaction [conn tenant-conn]
+    (let [{:keys [onError op args]} op-spec
+
+          selected-column (-> args :selectedColumn)
+
+          caddisfly-schema (get-caddisfly-schema caddisfly selected-column)
+
+          new-columns (->> (columns-to-extract (:columns args) selected-column caddisfly-schema (:extractImage args))
+                           (add-name-to-new-columns current-columns))
+          
+          _ (log/debug ::apply-operation table-name (:columnName selected-column) onError)
+          _ (log/debug :new-columns new-columns :selected-column selected-column :extractImage (:extractImage args))
+
+          add-db-columns (doseq [c new-columns]
+                           (add-column conn {:table-name      table-name
+                                             :column-type     (:type c)
+                                             :new-column-name (:id c)}))
+          update-db-columns (->> (select-rnum-and-column conn {:table-name table-name :column-name (:columnName selected-column)})
+                                 (map
+                                  (fn [m]
+                                    (let [cell-value (multiple-cell-value m (:columnName selected-column))
+                                          cad-results (or (test-results cell-value new-columns)
+                                                          (repeat nil))
+                                          update-vals (->> (map
+                                                            (fn [new-column-name new-column-val]
+                                                              [(keyword new-column-name) new-column-val])
+                                                            (map :id new-columns)
+                                                            cad-results)
+                                                           (reduce #(apply assoc % %2) {}))]
+                                      (log/debug :update-vals update-vals)
+                                      (update-row conn table-name (:rnum m) update-vals))))
+                                 doall)]
+      (log/info :db-txs selected-column add-db-columns update-db-columns)
+      {:success?      true
+       :execution-log [(format "Extract caddisfly column %s" (:columnName selected-column))]
+       :columns       (into current-columns (vec new-columns))})))

--- a/backend/test/akvo/lumen/lib/pivot_test.clj
+++ b/backend/test/akvo/lumen/lib/pivot_test.clj
@@ -16,7 +16,7 @@
   (let [dataset-id (import-file *tenant-conn* *error-tracker* "pivot.csv" {:dataset-name "pivot"
                                                                            :has-column-headers? true})
         query (partial aggregation/query *tenant-conn* dataset-id "pivot")]
-    (tf/apply *tenant-conn*
+    (tf/apply {:tenant-conn *tenant-conn*}
               dataset-id
               {:type :transformation
                :transformation {"op" "core/change-datatype"

--- a/backend/test/akvo/lumen/transformation/engine_test.clj
+++ b/backend/test/akvo/lumen/transformation/engine_test.clj
@@ -68,7 +68,22 @@
    :change-title {"op" "core/change-column-title"
                   "args" {"columnName" "c2"
                           "columnTitle" "My column"}
-                  "onError" "fail"}})
+                  "onError" "fail"}
+   :extract-multiple-column {"args"
+                              {"columnName" "c11",
+                               "columns"
+                               [{"extract" true, "id" 1, "name" "title 1", "type" "text"}
+                                {"extract" false, "id" 2, "name" "title 2", "type" "text"}],
+                               "extractImage" false,
+                               "selectedColumn"
+                               {"columnName" "c11",
+                                "direction" nil,
+                                "hidden" false,
+                                "sort" nil,
+                                "title" "Column 11",
+                                "type" "multiple"}},
+                              "onError" "fail",
+                              "op" "core/extract-multiple"}})
 
 (deftest ^:functional test-transformations
   (testing "Valid data"

--- a/backend/test/akvo/lumen/transformation/engine_test.clj
+++ b/backend/test/akvo/lumen/transformation/engine_test.clj
@@ -74,7 +74,7 @@
   (testing "Valid data"
     (let [ops (:ops transformations)]
       (is (every? :success? (for [op ops]
-                              (try-apply-operation *tenant-conn* "ds_test_1" columns op))))))
+                              (try-apply-operation {:tenant-conn *tenant-conn*} "ds_test_1" columns op))))))
 
   (testing "Filter column (text)"
     (let [ops (:filter-column transformations)
@@ -84,7 +84,7 @@
       (db-delete-test-data *tenant-conn*)
       (db-test-data *tenant-conn*)
 
-      (is (= true (:success? (try-apply-operation *tenant-conn* "ds_test_1" columns filter-using-is))))
+      (is (= true (:success? (try-apply-operation {:tenant-conn *tenant-conn*} "ds_test_1" columns filter-using-is))))
 
       (let [result (db-select-test-data *tenant-conn*)]
         (is (= 1 (count result)))
@@ -93,7 +93,7 @@
       (db-delete-test-data *tenant-conn*)
       (db-test-data *tenant-conn*)
 
-      (is (= true (:success? (try-apply-operation *tenant-conn* "ds_test_1" columns filter-using-contains))))
+      (is (= true (:success? (try-apply-operation {:tenant-conn *tenant-conn*} "ds_test_1" columns filter-using-contains))))
 
       (let [result (db-select-test-data *tenant-conn*)]
         (is (= 1 (count result)))
@@ -106,8 +106,8 @@
       (db-delete-test-data *tenant-conn*)
       (db-insert-invalid-data *tenant-conn*)
 
-      (is (not (:success? (try-apply-operation *tenant-conn* "ds_test_1" columns op-to-number))))
-      (is (not (:success? (try-apply-operation *tenant-conn* "ds_test_1" columns op-to-date))))))
+      (is (not (:success? (try-apply-operation {:tenant-conn *tenant-conn*} "ds_test_1" columns op-to-number))))
+      (is (not (:success? (try-apply-operation {:tenant-conn *tenant-conn*} "ds_test_1" columns op-to-date))))))
 
   (testing "Invalid data, on-error: default-value"
     (let [op1 (assoc (:to-number transformations) "onError" "default-value")
@@ -116,7 +116,7 @@
       (db-delete-test-data *tenant-conn*)
       (db-insert-invalid-data *tenant-conn*)
 
-      (let [result (try-apply-operation *tenant-conn* "ds_test_1" columns op1)
+      (let [result (try-apply-operation {:tenant-conn *tenant-conn*} "ds_test_1" columns op1)
             data (db-select-test-data *tenant-conn*)]
         (is (:success? result))
         (is (= 1 (count data)))

--- a/backend/test/akvo/lumen/transformation_test.clj
+++ b/backend/test/akvo/lumen/transformation_test.clj
@@ -37,13 +37,13 @@
 (deftest ^:functional test-transformations
   (testing "Transformation application"
     (is (= [::lib/bad-request {"message" "Dataset not found"}]
-           (tf/apply *tenant-conn* "Not-valid-id" []))))
+           (tf/apply {:tenant-conn *tenant-conn*} "Not-valid-id" []))))
   (testing "Valid log"
     (let [dataset-id (import-file *tenant-conn* *error-tracker*
                                   "transformation_test.csv" {:name "Transformation Test"
                                                              :has-column-headers? true})
           [tag _] (last (for [transformation ops]
-                          (tf/apply *tenant-conn* dataset-id {:type :transformation
+                          (tf/apply {:tenant-conn *tenant-conn*} dataset-id {:type :transformation
                                                               :transformation transformation})))]
       (is (= ::lib/ok tag)))))
 
@@ -63,7 +63,7 @@
                   "onError" "fail"}]
           dataset-id (import-file *tenant-conn* *error-tracker* "GDP.csv" {:name "GDP Test" :has-column-headers? false})]
       (let [[tag {:strs [datasetId]}] (last (for [transformation t-log]
-                                              (tf/apply *tenant-conn*
+                                              (tf/apply {:tenant-conn *tenant-conn*}
                                                         dataset-id
                                                         {:type :transformation
                                                          :transformation transformation})))]
@@ -85,7 +85,7 @@
   (let [dataset-id (import-file *tenant-conn* *error-tracker* "GDP.csv" {:dataset-name "GDP Undo Test"})
         {previous-table-name :table-name} (latest-dataset-version-by-dataset-id *tenant-conn*
                                                                                 {:dataset-id dataset-id})
-        apply-transformation (partial tf/apply *tenant-conn* dataset-id)]
+        apply-transformation (partial tf/apply {:tenant-conn *tenant-conn*} dataset-id)]
     (is (= ::lib/ok (first (apply-transformation {:type :undo}))))
     (let [[tag _] (do (apply-transformation {:type :transformation
                                              :transformation {"op" "core/to-lowercase"
@@ -124,7 +124,7 @@
 
 (deftest ^:functional combine-transformation-test
   (let [dataset-id (import-file *tenant-conn* *error-tracker* "name.csv" {:has-column-headers? true})
-        apply-transformation (partial tf/apply *tenant-conn* dataset-id)]
+        apply-transformation (partial tf/apply {:tenant-conn *tenant-conn*} dataset-id)]
     (let [[tag _] (apply-transformation {:type :transformation
                                          :transformation {"op" "core/combine"
                                                           "args" {"columnNames" ["c1" "c2"]
@@ -171,7 +171,7 @@
 
 (deftest ^:functional date-parsing-test
   (let [dataset-id (import-file *tenant-conn* *error-tracker* "dates.csv" {:has-column-headers? true})
-        apply-transformation (partial tf/apply *tenant-conn* dataset-id)]
+        apply-transformation (partial tf/apply {:tenant-conn *tenant-conn*} dataset-id)]
     (let [[tag {:strs [datasetId]}] (do (apply-transformation (date-transformation "c1" "YYYY"))
                                         (apply-transformation (date-transformation "c2" "DD/MM/YYYY"))
                                         (apply-transformation (date-transformation "c3" "YYYY-MM-DD")))]
@@ -220,7 +220,7 @@
 
 (deftest ^:functional derived-column-test
   (let [dataset-id (import-file *tenant-conn* *error-tracker* "derived-column.csv" {:has-column-headers? true})
-        apply-transformation (partial tf/apply *tenant-conn* dataset-id)]
+        apply-transformation (partial tf/apply {:tenant-conn *tenant-conn*} dataset-id)]
     (do (apply-transformation (change-datatype-transformation "c2"))
         (apply-transformation (change-datatype-transformation "c3")))
 
@@ -342,7 +342,7 @@
 
 (deftest ^:functional delete-column-test
   (let [dataset-id (import-file *tenant-conn* *error-tracker* "dates.csv" {:has-column-headers? true})
-        apply-transformation (partial tf/apply *tenant-conn* dataset-id)]
+        apply-transformation (partial tf/apply {:tenant-conn *tenant-conn*} dataset-id)]
     (let [[tag _] (apply-transformation {:type :transformation
                                          :transformation {"op" "core/delete-column"
                                                           "args" {"columnName" "c2"}
@@ -357,7 +357,7 @@
 
 (deftest ^:functional rename-column-test
   (let [dataset-id (import-file *tenant-conn* *error-tracker* "dates.csv" {:has-column-headers? true})
-        apply-transformation (partial tf/apply *tenant-conn* dataset-id)]
+        apply-transformation (partial tf/apply {:tenant-conn *tenant-conn*} dataset-id)]
     (let [[tag _] (apply-transformation {:type :transformation
                                          :transformation {"op" "core/rename-column"
                                                           "args" {"columnName" "c2"
@@ -390,7 +390,7 @@
 
 (deftest ^:functional generate-geopoints-test
   (let [dataset-id (import-file *tenant-conn* *error-tracker* "geopoints.csv" {:has-column-headers? true})
-        apply-transformation (partial tf/apply *tenant-conn* dataset-id)]
+        apply-transformation (partial tf/apply {:tenant-conn *tenant-conn*} dataset-id)]
     (let [[tag _] (apply-transformation {:type :transformation
                                          :transformation {"op" "core/generate-geopoints"
                                                           "args" {"columnNameLat" "c2"

--- a/backend/test/resources/columns_test.json
+++ b/backend/test/resources/columns_test.json
@@ -68,4 +68,11 @@
     "hidden": false,
     "direction": null,
     "columnName": "c10"
+}, {
+    "sort": null,
+    "type": "multiple",
+    "title": "Column 11",
+    "hidden": false,
+    "direction": null,
+    "columnName": "c11"
 }]


### PR DESCRIPTION
# Add core/extract-multiple transformation op
Relates to #1571 

These changes allow multiple-column cell data to be extracted to new columns 

the `client` [side](https://github.com/akvo/akvo-lumen/pull/1614) will send following payload ...

core/extract-multiple transformation payload

- `args.selectedColumn.multipleType` and `args.selectedColumn.multipleId` should be used to dispatch functionality on backend

- `args.columns`  payload describes the extraction column schema 

```
{
    "op": "core/extract-multiple",
    "args": {
        "columns": [
            {
                "id": 1,
                "name": "Soil Electrical Conductivity :: μS/cm",
                "type": "text",
                "extract": true
            },
            {
                "id": 2,
                "name": "Temperature :: °Celsius",
                "type": "text",
                "extract": false
            }
        ],
        "columnName": "c107069115",
        "extractImage": false,
        "selectedColumn": {
            "columnName": "c107069115",
            "multipleType": "caddisfly",
            "hidden": false,
            "multipleId": "80697cd1-acc9-4a15-8358-f32b4257dfaf",
            "title": "Soil Electrical Conductivity",
            "type": "multiple",
            "sort": null,
            "key": false,
            "direction": null
        }
    },
    "onError": "fail"
}
```

- [ ] **Update release notes if necessary**
- [x] **add tests!**
- [x] **fix transformation log**
