### PR TITLE
Last graphs cut off in shared dashboards #1639

### DIFF
--- a/client/src/components/dashboard/DashboardCanvasItemEditable.scss
+++ b/client/src/components/dashboard/DashboardCanvasItemEditable.scss
@@ -6,9 +6,18 @@
   .DashboardCanvasItemEditableInput {
     height: calc(100% - 51px);
 
+    .ql-container {
+      border-bottom: none;
+    }
+
     .ql-editor {
       background: white;
       min-height: 40px;
+      border-bottom: 1px solid #ccc;
+      border-right: 1px solid #ccc;
+      border-left: 1px solid #ccc;
+      margin-left: -1px;
+      margin-right: -1px;
     }
 
     .ql-toolbar {

--- a/client/src/components/dashboard/DashboardViewerItem.jsx
+++ b/client/src/components/dashboard/DashboardViewerItem.jsx
@@ -58,16 +58,21 @@ export default class DashboardViewerItem extends Component {
       }
 
       case 'large':
+        const maxHeight = (layout.h * unit) - (cMargin * 2);
         return {
-          display: 'inline-block',
+          position: 'absolute',
+          display: 'block',
+          left: (layout.x * unit) + cMargin,
+          top: (layout.y * unit) + cMargin,
           width: (layout.w * unit) - (cMargin * 2),
           height: (
             item.type === 'visualisation' &&
             item.visualisation &&
             item.visualisation.visualisationType === 'map'
           ) ?
-            Math.max(MIN_HEIGHT, (layout.h * unit) - (cMargin * 2)) :
+            Math.max(MIN_HEIGHT, maxHeight) :
             (layout.h * unit) - (cMargin * 2),
+          maxHeight,
           margin: cMargin,
           padding: cPadding,
         };

--- a/client/src/components/dashboard/DashboardViewerItem.jsx
+++ b/client/src/components/dashboard/DashboardViewerItem.jsx
@@ -57,7 +57,7 @@ export default class DashboardViewerItem extends Component {
         };
       }
 
-      case 'large':
+      case 'large': {
         const maxHeight = (layout.h * unit) - (cMargin * 2);
         return {
           position: 'absolute',
@@ -76,6 +76,7 @@ export default class DashboardViewerItem extends Component {
           margin: cMargin,
           padding: cPadding,
         };
+      }
 
       default:
         throw new Error(`Unknown viewportType ${viewportType} supplied to getItemStyle()`);

--- a/client/src/components/dashboard/DashboardViewerItem.scss
+++ b/client/src/components/dashboard/DashboardViewerItem.scss
@@ -7,6 +7,7 @@
   background-color: white;
   color: $dashboardFG;
   @include border-radius(8px);
+  float: left;
 
   .title {
       display: none;
@@ -15,7 +16,6 @@
   &.text {
     overflow-y: auto;
     color: $dashboardFG;
-    height: auto !important;
 
     ol,
     ul {


### PR DESCRIPTION
Ive fixed this but as a result the comment here about white space under text cannot be fixed - https://github.com/akvo/akvo-lumen/issues/1576#issuecomment-415463201 - we cant have a dashboard where the elements are laid out properly AND the text elements have variable heights. All boxes need to be absolutely positioned with fixed heights @janagombitova 