### PR TITLE
Avoid database inconsistencies on updating problematic datasets (Connect #1689 )

### DIFF
--- a/backend/resources/akvo/lumen/migrations/tenants/020-dataset-version-create-index-version.down.sql
+++ b/backend/resources/akvo/lumen/migrations/tenants/020-dataset-version-create-index-version.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX dataset_version_version_idx;

--- a/backend/resources/akvo/lumen/migrations/tenants/020-dataset-version-create-index-version.up.sql
+++ b/backend/resources/akvo/lumen/migrations/tenants/020-dataset-version-create-index-version.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX dataset_version_version_idx ON dataset_version (version);

--- a/backend/src/akvo/lumen/dataset.clj
+++ b/backend/src/akvo/lumen/dataset.clj
@@ -8,7 +8,7 @@
             [clojure.tools.logging :as log]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
-            [clojure.set :refer (rename-keys) :as set]
+            [clojure.set :refer (rename-keys)]
             [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/dataset.sql")

--- a/backend/src/akvo/lumen/dataset.clj
+++ b/backend/src/akvo/lumen/dataset.clj
@@ -3,12 +3,12 @@
   (:require [akvo.lumen.endpoint.job-execution :as job-execution]
             [akvo.lumen.import :as import]
             [akvo.lumen.lib :as lib]
+            [akvo.lumen.transformation.merge-datasets :as md]
             [akvo.lumen.update :as update]
             [clojure.tools.logging :as log]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.set :refer (rename-keys) :as set]
-            [clojure.walk :refer (keywordize-keys)]
             [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/dataset.sql")
@@ -78,31 +78,6 @@
            (assoc :rows data :columns columns :status "OK"))))
     (lib/not-found {:error "Not found"})))
 
-(defn- dataset-merged-sources [tenant-conn dataset-id]
-  (->> {:dataset-id dataset-id}
-       (update/latest-dataset-version-by-dataset-id tenant-conn)
-       :transformations
-       keywordize-keys
-       (filter #(= "core/merge-datasets" (:op %)))
-       (map #(-> % :args :source))))
-
-(defn- problematic-merged-datasets? [tenant-conn dataset-merged-sources]
-  (let [datasets-merged (mapv :datasetId dataset-merged-sources)]
-    (if (empty? datasets-merged)
-      nil
-      (let [diff (set/difference (set datasets-merged)
-                                 (set (map :id (select-datasets-by-id tenant-conn {:ids datasets-merged}))))]
-        (when (not-empty diff)
-          {:diff diff})))))
-
-(defn problematic-merged-columns? [dss  merge-source-op]
- (let [ds      (some #(when (= (:dataset-id %) (:datasetId merge-source-op)) %) dss)
-       columns (set (conj (:mergeColumns merge-source-op)
-                          (:mergeColumn merge-source-op)
-                          (:aggregationColumn merge-source-op)))]
-   (= (set (map #(get % "columnName") (:columns ds)))
-      columns)))
-
 (defn delete
   [tenant-conn id]
   (let [c (delete-dataset-by-id tenant-conn {:id id})]
@@ -114,31 +89,21 @@
 
 (defn update
   [tenant-conn config dataset-id {refresh-token "refreshToken"}]
-  (let [merged-sources (dataset-merged-sources tenant-conn dataset-id)]
-    (if-let [merged-problems (problematic-merged-datasets? tenant-conn merged-sources)]
-      (lib/bad-request  {:error "This dataset can't be updated thus it has dependent datasets that were removed"
-                         :merged-problems merged-problems})
-      (if-let [column-problem (when (not-empty merged-sources)
-                                (let [dss (->> {:dataset-ids (mapv :datasetId merged-sources)}
-                                               (update/latest-dataset-versions-by-dataset-ids tenant-conn )
-                                               (map #(rename-keys % {:dataset_id :dataset-id})))]
-                                  (some #(when-not (problematic-merged-columns? dss %) %) merged-sources)))]
-        (lib/bad-request  {:error "This dataset can't be updated thus it has dependent columns that were removed"
-                           :merged-problems column-problem})
-
-        (if-let [{data-source-spec :spec
-                  data-source-id   :id} (data-source-by-dataset-id tenant-conn {:dataset-id dataset-id})]
-          (if-not (= (get-in data-source-spec ["source" "kind"])
-                     "DATA_FILE")
-            (update/update-dataset tenant-conn
-                                   config
-                                   dataset-id
-                                   data-source-id
-                                   (assoc-in data-source-spec
-                                             ["source" "refreshToken"]
-                                             refresh-token))
-            (lib/bad-request {:error "Can't update uploaded dataset"}))
-          (lib/not-found {:id dataset-id}))))))
+  (if-let [error (md/consistency-error? tenant-conn dataset-id)]
+    (lib/bad-request error)
+    (if-let [{data-source-spec :spec
+              data-source-id   :id} (data-source-by-dataset-id tenant-conn {:dataset-id dataset-id})]
+      (if-not (= (get-in data-source-spec ["source" "kind"])
+                 "DATA_FILE")
+        (update/update-dataset tenant-conn
+                               config
+                               dataset-id
+                               data-source-id
+                               (assoc-in data-source-spec
+                                         ["source" "refreshToken"]
+                                         refresh-token))
+        (lib/bad-request {:error "Can't update uploaded dataset"}))
+      (lib/not-found {:id dataset-id}))))
 
 (defn update-meta
   [tenant-conn id {:strs [name]}]

--- a/backend/src/akvo/lumen/dataset.sql
+++ b/backend/src/akvo/lumen/dataset.sql
@@ -46,6 +46,11 @@ VALUES (:id, :title, :description, :author);
 -- :doc delete dataset
 DELETE FROM dataset WHERE id=:id;
 
+-- :name select-datasets-by-id :? :*
+-- :doc select datasets by id
+SELECT * from dataset WHERE id IN (:v*:ids);
+
+
 -- :name update-dataset-meta :! :n
 -- :doc update dataset meta
 UPDATE dataset SET title = :title WHERE id = :id;

--- a/backend/src/akvo/lumen/dataset.sql
+++ b/backend/src/akvo/lumen/dataset.sql
@@ -50,7 +50,6 @@ DELETE FROM dataset WHERE id=:id;
 -- :doc select datasets by id
 SELECT * from dataset WHERE id IN (:v*:ids);
 
-
 -- :name update-dataset-meta :! :n
 -- :doc update dataset meta
 UPDATE dataset SET title = :title WHERE id = :id;

--- a/backend/src/akvo/lumen/transformation.sql
+++ b/backend/src/akvo/lumen/transformation.sql
@@ -22,6 +22,14 @@ SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-na
                     FROM dataset_version v
                    WHERE v.dataset_id = :dataset-id);
 
+
+-- :name latest-dataset-versions-by-dataset-ids :? :*
+-- :doc Returns the most recent dataset version for a given dataset id
+select DISTINCT ON (dataset_id) dataset_id, id, version, transformations, columns
+FROM dataset_version
+WHERE dataset_id IN (:v*:dataset-ids)
+order by dataset_id, version desc;
+
 -- :name update-dataset-version :! :n
 -- :doc Update dataset version
 UPDATE dataset_version SET columns= :columns,  transformations= :transformations

--- a/backend/src/akvo/lumen/transformation.sql
+++ b/backend/src/akvo/lumen/transformation.sql
@@ -22,7 +22,6 @@ SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-na
                     FROM dataset_version v
                    WHERE v.dataset_id = :dataset-id);
 
-
 -- :name latest-dataset-versions-by-dataset-ids :? :*
 -- :doc Returns the most recent dataset version for a given dataset id
 select DISTINCT ON (dataset_id) dataset_id, id, version, transformations, columns

--- a/backend/src/akvo/lumen/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/transformation/merge_datasets.clj
@@ -194,7 +194,7 @@
                             (map #(-> % :args :source)))]
     (if-let [ds-diff (and (not-empty merged-sources)
                           (merged-datasets-diff tenant-conn merged-sources))]
-      {:error        (format "This dataset can't be updated thus it has merged dataset transformations that were removed: %s" (reduce str ds-diff))
+      {:error        (format "This version of the dataset isn't consistent thus it has merge transformations with datasets which were already removed. Dataset diff: %s" (reduce str ds-diff))
        :dataset-diff ds-diff}
       (when-let [column-diff (when (not-empty merged-sources)
                                (let [dss              (->> {:dataset-ids (mapv :datasetId merged-sources)}
@@ -205,5 +205,5 @@
                                                            (filter some?))]
                                  (when (not-empty column-diff-coll)
                                    column-diff-coll)))]
-        {:error       (format "This dataset can't be updated thus it has merged columns transformations that were removed from their datasets: %s" (reduce str column-diff))
+        {:error       (format "This version of the dataset isn't consistent thus it has merge transformations with datasets columns wich were already removed from their datasets: %s" (reduce str column-diff))
          :column-diff column-diff}))))

--- a/backend/src/akvo/lumen/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/transformation/merge_datasets.clj
@@ -1,13 +1,17 @@
 (ns akvo.lumen.transformation.merge-datasets
-  (:require [akvo.lumen.transformation.engine :as engine]
-            [akvo.lumen.import.common :as import]
+  (:require [akvo.lumen.import.common :as import]
+            [akvo.lumen.transformation.engine :as engine]
             [clojure.java.jdbc :as jdbc]
+            [clojure.tools.logging :as log]
             [clojure.set :as set]
+            [clojure.set :refer (rename-keys) :as set]
             [clojure.string :as s]
+            [clojure.walk :refer (keywordize-keys)]
             [hugsql.core :as hugsql])
   (:import [java.sql Timestamp]
            [org.postgis PGgeometry]))
 
+(hugsql/def-db-fns "akvo/lumen/dataset.sql")
 (hugsql/def-db-fns "akvo/lumen/transformation.sql")
 (hugsql/def-db-fns "akvo/lumen/transformation/engine.sql")
 
@@ -162,3 +166,44 @@
 (defmethod engine/apply-operation :core/merge-datasets
   [{:keys [tenant-conn]} table-name columns op-spec]
   (apply-merge-operation tenant-conn table-name columns op-spec))
+
+(defn- merged-datasets-diff [tenant-conn merged-dataset-sources]
+  (let [dataset-ids (mapv :datasetId merged-dataset-sources)
+        diff        (set/difference (set dataset-ids)
+                                    (set (map :id (select-datasets-by-id tenant-conn {:ids dataset-ids}))))]
+    (when (not-empty diff)
+      {:diff diff})))
+
+(defn- merged-columns-diff [dss merge-source-op]
+  (let [merged-dataset (some #(when (= (:dataset-id %) (:datasetId merge-source-op)) %) dss)
+
+        columns        (set (conj (:mergeColumns merge-source-op)
+                                  (:mergeColumn merge-source-op)
+                                  (:aggregationColumn merge-source-op)))
+        expected-columns (set (map #(get % "columnName") (:columns merged-dataset)))
+        diff (set/difference columns expected-columns)]
+    (when (not-empty diff)
+      {:diff diff
+       :dataset-id (:datasetId merge-source-op)})))
+
+(defn consistency-error? [tenant-conn dataset-id]
+  (let [merged-sources (->> (latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id})
+                            :transformations
+                            keywordize-keys
+                            (filter #(= "core/merge-datasets" (:op %)))
+                            (map #(-> % :args :source)))]
+    (if-let [ds-diff (and (not-empty merged-sources)
+                          (merged-datasets-diff tenant-conn merged-sources))]
+      {:error        "This dataset can't be updated thus it has dependent datasets that were removed"
+       :dataset-diff ds-diff}
+      (when-let [column-diff (when (not-empty merged-sources)
+                               (let [dss              (->> {:dataset-ids (mapv :datasetId merged-sources)}
+                                                           (latest-dataset-versions-by-dataset-ids tenant-conn)
+                                                           (map #(rename-keys % {:dataset_id :dataset-id})))
+                                     column-diff-coll (->> merged-sources
+                                                           (map (partial merged-columns-diff dss))
+                                                           (filter some?))]
+                                 (when (not-empty column-diff-coll)
+                                   column-diff-coll)))]
+        {:error       "This dataset can't be updated thus it has dependent columns that were removed"
+         :column-diff column-diff}))))

--- a/backend/src/akvo/lumen/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/transformation/merge_datasets.clj
@@ -194,7 +194,7 @@
                             (map #(-> % :args :source)))]
     (if-let [ds-diff (and (not-empty merged-sources)
                           (merged-datasets-diff tenant-conn merged-sources))]
-      {:error        "This dataset can't be updated thus it has dependent datasets that were removed"
+      {:error        (format "This dataset can't be updated thus it has merged dataset transformations that were removed: %s" (reduce str ds-diff))
        :dataset-diff ds-diff}
       (when-let [column-diff (when (not-empty merged-sources)
                                (let [dss              (->> {:dataset-ids (mapv :datasetId merged-sources)}
@@ -205,5 +205,5 @@
                                                            (filter some?))]
                                  (when (not-empty column-diff-coll)
                                    column-diff-coll)))]
-        {:error       "This dataset can't be updated thus it has dependent columns that were removed"
+        {:error       (format "This dataset can't be updated thus it has merged columns transformations that were removed from their datasets: %s" (reduce str column-diff))
          :column-diff column-diff}))))


### PR DESCRIPTION
Problematic datasets are those that have merge transformations that use datasets columns that don't exist anymore, maybe the column was removed, maybe the dataset was removed

- [ ] **Update release notes if necessary**
- [x] check new queries work properly with more test data
- [X] check dependent datasets
- [x] check dependent dataset columns