### PR TITLE
[Fixes #1697] Maps container set to 2000m

### DIFF
--- a/ci/k8s/deployment.yaml.template
+++ b/ci/k8s/deployment.yaml.template
@@ -37,7 +37,7 @@ spec:
           requests:
             cpu: "50m"
           limits:
-            cpu: "1000m"
+            cpu: "2000m"
         env:
         - name: LUMEN_ENCRYPTION_KEY
           valueFrom:


### PR DESCRIPTION
Raise the container max CPU limit to 2000.

- [ ] **Update release notes if necessary**
