### PR TITLE
Don't allow deletion of dataset that is used in a merge transformation

### DIFF
--- a/backend/src/akvo/lumen/dataset.clj
+++ b/backend/src/akvo/lumen/dataset.clj
@@ -83,8 +83,7 @@
   (log/error :delete-id id)
   (if-let [datasets-merged-with (transformation.merge-datasets/datasets-merged-with tenant-conn id)]
     (lib/bad-request {:error    (format "This dataset is used in merge tranformations with other datasets: %s"
-                                        (str/join ", " (map :title datasets-merged-with)))
-                      :datasets (str/join "," (map :id datasets-merged-with))})
+                                        (str/join ", " datasets-merged-with))})
     (let [c (delete-dataset-by-id tenant-conn {:id id})]
       (if (zero? c)
         (do

--- a/backend/src/akvo/lumen/dataset.clj
+++ b/backend/src/akvo/lumen/dataset.clj
@@ -8,7 +8,7 @@
             [clojure.tools.logging :as log]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
-            [clojure.set :refer (rename-keys) :as set]
+            [clojure.set :refer (rename-keys)]
             [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/dataset.sql")

--- a/backend/src/akvo/lumen/dataset.clj
+++ b/backend/src/akvo/lumen/dataset.clj
@@ -80,12 +80,17 @@
 
 (defn delete
   [tenant-conn id]
-  (let [c (delete-dataset-by-id tenant-conn {:id id})]
-    (if (zero? c)
-      (do
-        (delete-failed-job-execution-by-id tenant-conn {:id id})
-        (lib/not-found {:error "Not found"}))
-      (let [v (delete-maps-by-dataset-id tenant-conn {:id id})](lib/ok {:id id})))))
+  (log/error :delete-id id)
+  (if-let [datasets-merged-with (transformation.merge-datasets/datasets-merged-with tenant-conn id)]
+    (lib/bad-request {:error    (format "This dataset is used in merge tranformations with other datasets: %s"
+                                        (str/join ", " (map :title datasets-merged-with)))
+                      :datasets (str/join "," (map :id datasets-merged-with))})
+    (let [c (delete-dataset-by-id tenant-conn {:id id})]
+      (if (zero? c)
+        (do
+          (delete-failed-job-execution-by-id tenant-conn {:id id})
+          (lib/not-found {:error "Not found"}))
+        (let [v (delete-maps-by-dataset-id tenant-conn {:id id})](lib/ok {:id id}))))))
 
 (defn update
   [tenant-conn config dataset-id {refresh-token "refreshToken"}]

--- a/backend/src/akvo/lumen/dataset.clj
+++ b/backend/src/akvo/lumen/dataset.clj
@@ -81,7 +81,7 @@
 (defn delete
   [tenant-conn id]
   (if-let [datasets-merged-with (transformation.merge-datasets/datasets-merged-with tenant-conn id)]
-    (lib/bad-request {:error    (format "This dataset is used in merge tranformations with other datasets: %s"
+    (lib/conflict {:error    (format "This dataset is used in merge tranformations with other datasets: %s"
                                         (str/join ", " datasets-merged-with))})
     (let [c (delete-dataset-by-id tenant-conn {:id id})]
       (if (zero? c)
@@ -95,7 +95,7 @@
   (if-let [{data-source-spec :spec
             data-source-id   :id} (data-source-by-dataset-id tenant-conn {:dataset-id dataset-id})]
     (if-let [error (transformation.merge-datasets/consistency-error? tenant-conn dataset-id)]
-      (lib/bad-request error)
+      (lib/conflict error)
       (if-not (= (get-in data-source-spec ["source" "kind"]) "DATA_FILE")
         (update/update-dataset tenant-conn config dataset-id data-source-id
                                (assoc-in data-source-spec ["source" "refreshToken"] refresh-token))

--- a/backend/src/akvo/lumen/dataset.clj
+++ b/backend/src/akvo/lumen/dataset.clj
@@ -80,9 +80,9 @@
 
 (defn delete
   [tenant-conn id]
-  (if-let [datasets-merged-with (transformation.merge-datasets/datasets-merged-with tenant-conn id)]
+  (if-let [datasets-merged-with (transformation.merge-datasets/datasets-related tenant-conn id)]
     (lib/conflict {:error    (format "This dataset is used in merge tranformations with other datasets: %s"
-                                        (str/join ", " datasets-merged-with))})
+                                     (str/join ", " datasets-merged-with))})
     (let [c (delete-dataset-by-id tenant-conn {:id id})]
       (if (zero? c)
         (do

--- a/backend/src/akvo/lumen/dataset.clj
+++ b/backend/src/akvo/lumen/dataset.clj
@@ -8,7 +8,7 @@
             [clojure.tools.logging :as log]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
-            [clojure.set :refer (rename-keys)]
+            [clojure.set :refer (rename-keys) :as set]
             [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/dataset.sql")

--- a/backend/src/akvo/lumen/dataset.clj
+++ b/backend/src/akvo/lumen/dataset.clj
@@ -81,8 +81,8 @@
 (defn delete
   [tenant-conn id]
   (if-let [datasets-merged-with (transformation.merge-datasets/datasets-related tenant-conn id)]
-    (lib/conflict {:error    (format "This dataset is used in merge tranformations with other datasets: %s"
-                                     (str/join ", " datasets-merged-with))})
+    (lib/conflict {:error (format "This dataset is used in merge tranformations with other datasets: %s"
+                                  (str/join ", " datasets-merged-with))})
     (let [c (delete-dataset-by-id tenant-conn {:id id})]
       (if (zero? c)
         (do

--- a/backend/src/akvo/lumen/dataset.clj
+++ b/backend/src/akvo/lumen/dataset.clj
@@ -80,7 +80,6 @@
 
 (defn delete
   [tenant-conn id]
-  (log/error :delete-id id)
   (if-let [datasets-merged-with (transformation.merge-datasets/datasets-merged-with tenant-conn id)]
     (lib/bad-request {:error    (format "This dataset is used in merge tranformations with other datasets: %s"
                                         (str/join ", " datasets-merged-with))})

--- a/backend/src/akvo/lumen/transformation.clj
+++ b/backend/src/akvo/lumen/transformation.clj
@@ -2,7 +2,6 @@
   (:refer-clojure :exclude [apply])
   (:require [akvo.lumen.lib :as lib]
             [akvo.lumen.transformation.engine :as engine]
-            [clojure.tools.logging :as log]
             [akvo.lumen.util :refer (squuid)]
             [clojure.java.jdbc :as jdbc]
             [hugsql.core :as hugsql]))
@@ -30,7 +29,6 @@
 (defn validate
   [command]
   (try
-    (log/error ::comand command)
     (condp = (:type command)
       :transformation (if (engine/valid? (:transformation command))
                         {:valid? true}

--- a/backend/src/akvo/lumen/transformation.clj
+++ b/backend/src/akvo/lumen/transformation.clj
@@ -50,10 +50,9 @@
         (try
           (new-transformation-job-execution tenant-conn {:id job-execution-id :dataset-id dataset-id})
           (jdbc/with-db-transaction [tx-conn tenant-conn]
-            (let [tx-deps (assoc deps :tenant-conn tx-conn)
-                  command-extended (engine/extend-data-command deps dataset-id command)]
+            (let [tx-deps (assoc deps :tenant-conn tx-conn)]
               (condp = (:type command)
-                :transformation (engine/execute-transformation tx-deps dataset-id job-execution-id command-extended)
+                :transformation (engine/execute-transformation tx-deps dataset-id job-execution-id (:transformation command))
                 :undo (engine/execute-undo tx-deps dataset-id job-execution-id))))
           (update-successful-job-execution tenant-conn {:id job-execution-id})
           (lib/ok {"jobExecutionId" job-execution-id "datasetId" dataset-id})

--- a/backend/src/akvo/lumen/transformation.sql
+++ b/backend/src/akvo/lumen/transformation.sql
@@ -31,8 +31,9 @@ order by dataset_id, version desc;
 
 -- :name latest-dataset-versions :? :*
 -- :doc Returns the most recent dataset version for a given dataset id
-select DISTINCT ON (dataset_id) dataset_id, id, version, transformations
-FROM dataset_version
+select DISTINCT ON (dataset_id) dataset_id, dataset_version.id as id, version, title, transformations
+FROM dataset_version, dataset
+where dataset.id=dataset_id
 order by dataset_id, version desc;
 
 

--- a/backend/src/akvo/lumen/transformation.sql
+++ b/backend/src/akvo/lumen/transformation.sql
@@ -36,7 +36,6 @@ FROM dataset_version, dataset
 where dataset.id=dataset_id
 order by dataset_id, version desc;
 
-
 -- :name update-dataset-version :! :n
 -- :doc Update dataset version
 UPDATE dataset_version SET columns= :columns,  transformations= :transformations

--- a/backend/src/akvo/lumen/transformation.sql
+++ b/backend/src/akvo/lumen/transformation.sql
@@ -29,6 +29,13 @@ FROM dataset_version
 WHERE dataset_id IN (:v*:dataset-ids)
 order by dataset_id, version desc;
 
+-- :name latest-dataset-versions :? :*
+-- :doc Returns the most recent dataset version for a given dataset id
+select DISTINCT ON (dataset_id) dataset_id, id, version, transformations
+FROM dataset_version
+order by dataset_id, version desc;
+
+
 -- :name update-dataset-version :! :n
 -- :doc Update dataset version
 UPDATE dataset_version SET columns= :columns,  transformations= :transformations

--- a/backend/src/akvo/lumen/transformation/delete_column.clj
+++ b/backend/src/akvo/lumen/transformation/delete_column.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.transformation.delete-column
   (:require [akvo.lumen.transformation.engine :as engine]
             [clojure.tools.logging :as log]
+            [akvo.lumen.transformation.merge-datasets :refer (datasets-merged-with*)]
             [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/transformation/engine.sql")
@@ -12,12 +13,18 @@
   [op-spec]
   (engine/valid-column-name? (col-name op-spec)))
 
+(defmethod engine/extend-data-command :core/delete-column
+  [{:keys [tenant-conn] :as deps} dataset-id command]
+  (assoc (:transformation command) :datasets-merged-with (datasets-merged-with* tenant-conn dataset-id)))
+
+
 (defmethod engine/apply-operation :core/delete-column
   [{:keys [tenant-conn]} table-name columns op-spec]
+  (log/error ::delete-column op-spec)
   (let [column-name (col-name op-spec)
-        column-idx (engine/column-index columns column-name)]
-    (delete-column tenant-conn {:table-name table-name :column-name column-name})
-    {:success? true
-     :execution-log [(format "Deleted column %s" column-name)]
-     :columns (into (vec (take column-idx columns))
-                    (drop (inc column-idx) columns))}))
+          column-idx (engine/column-index columns column-name)]
+      (delete-column tenant-conn {:table-name table-name :column-name column-name})
+      {:success? true
+       :execution-log [(format "Deleted column %s" column-name)]
+       :columns (into (vec (take column-idx columns))
+                      (drop (inc column-idx) columns))}))

--- a/backend/src/akvo/lumen/transformation/delete_column.clj
+++ b/backend/src/akvo/lumen/transformation/delete_column.clj
@@ -2,7 +2,7 @@
   (:require [akvo.lumen.transformation.engine :as engine]
             [clojure.tools.logging :as log]
             [clojure.string :as str]
-            [akvo.lumen.transformation.merge-datasets :refer (datasets-merged-with* ) :as merge-datasets]
+            [akvo.lumen.transformation.merge-datasets :as merge-datasets]
             [clojure.walk :refer (keywordize-keys)]
             [hugsql.core :as hugsql]))
 
@@ -17,7 +17,7 @@
 
 (defmethod engine/extend-data-command :core/delete-column
   [{:keys [tenant-conn] :as deps} dataset-id command]
-  (assoc (:transformation command) :datasets-merged-with (datasets-merged-with* tenant-conn dataset-id)))
+  (assoc (:transformation command) :datasets-merged-with (merge-datasets/datasets-related tenant-conn dataset-id :source)))
 
 (defmethod engine/apply-operation :core/delete-column
   [{:keys [tenant-conn]} table-name columns op-spec]

--- a/backend/src/akvo/lumen/transformation/delete_column.clj
+++ b/backend/src/akvo/lumen/transformation/delete_column.clj
@@ -1,7 +1,9 @@
 (ns akvo.lumen.transformation.delete-column
   (:require [akvo.lumen.transformation.engine :as engine]
             [clojure.tools.logging :as log]
-            [akvo.lumen.transformation.merge-datasets :refer (datasets-merged-with*)]
+            [clojure.string :as str]
+            [akvo.lumen.transformation.merge-datasets :refer (datasets-merged-with* ) :as merge-datasets]
+            [clojure.walk :refer (keywordize-keys)]
             [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/transformation/engine.sql")
@@ -17,14 +19,25 @@
   [{:keys [tenant-conn] :as deps} dataset-id command]
   (assoc (:transformation command) :datasets-merged-with (datasets-merged-with* tenant-conn dataset-id)))
 
-
 (defmethod engine/apply-operation :core/delete-column
   [{:keys [tenant-conn]} table-name columns op-spec]
-  (log/error ::delete-column op-spec)
-  (let [column-name (col-name op-spec)
-          column-idx (engine/column-index columns column-name)]
-      (delete-column tenant-conn {:table-name table-name :column-name column-name})
-      {:success? true
-       :execution-log [(format "Deleted column %s" column-name)]
-       :columns (into (vec (take column-idx columns))
-                      (drop (inc column-idx) columns))}))
+  (let [res         (mapv (juxt merge-datasets/distinct-columns :origin)
+                          (:datasets-merged-with op-spec))
+        columnskw   (keywordize-keys columns)
+        columnName  (-> (keywordize-keys op-spec) :args :columnName)
+        full-column (first (filter #(= columnName (:columnName %)) columnskw))        
+        resres (map second (filter (fn [[cns datasource]]
+                                     (log/error :cns cns columnName)
+                                     (not-empty (filter #(= % columnName) cns)))
+                                   res))]
+    (log/error :CK (empty? resres) (str/join "," (map :title resres)))
+    (if (empty? resres)
+      (let [column-name (col-name op-spec)
+            column-idx  (engine/column-index columns column-name)]
+        (delete-column tenant-conn {:table-name table-name :column-name column-name})
+        {:success?      true
+         :execution-log [(format "Deleted column %s" column-name)]
+         :columns       (into (vec (take column-idx columns))
+                              (drop (inc column-idx) columns))})
+      {:success? false
+       :message  (format "following datasets have merge operations based on this column %s " (str/join "," (map (juxt :title :id) resres)))})))

--- a/backend/src/akvo/lumen/transformation/delete_column.clj
+++ b/backend/src/akvo/lumen/transformation/delete_column.clj
@@ -3,7 +3,6 @@
             [clojure.tools.logging :as log]
             [clojure.string :as str]
             [akvo.lumen.transformation.merge-datasets :as merge-datasets]
-            [clojure.walk :refer (keywordize-keys)]
             [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/transformation/engine.sql")

--- a/backend/src/akvo/lumen/transformation/delete_column.clj
+++ b/backend/src/akvo/lumen/transformation/delete_column.clj
@@ -17,7 +17,7 @@
 
 (defmethod engine/extend-data-command :core/delete-column
   [{:keys [tenant-conn] :as deps} dataset-id command]
-  (assoc (:transformation command) :datasets-merged-with (merge-datasets/datasets-related tenant-conn dataset-id :source)))
+  (assoc (:transformation command) :datasets-merged-with (merge-datasets/sources-related tenant-conn dataset-id)))
 
 (defmethod engine/apply-operation :core/delete-column
   [{:keys [tenant-conn]} table-name columns op-spec]

--- a/backend/src/akvo/lumen/transformation/engine.clj
+++ b/backend/src/akvo/lumen/transformation/engine.clj
@@ -17,6 +17,16 @@
   [op-spec]
   false)
 
+(defmulti extend-data-command
+  "Validate transformation spec"
+  (fn [{:keys [tenant-conn] :as deps} dataset-id command]
+    (log/error :JOR command (keyword (get (:transformation command) "op")))
+    (keyword (get (:transformation command) "op"))))
+
+(defmethod extend-data-command :default
+  [{:keys [tenant-conn] :as deps} dataset-id command]
+  (:transformation command))
+
 (defmulti apply-operation
   "Applies a particular operation based on `op` key from spec
    * {:keys [tenant-conn] :as deps}: includes open connection to the database

--- a/backend/src/akvo/lumen/transformation/engine.clj
+++ b/backend/src/akvo/lumen/transformation/engine.clj
@@ -162,7 +162,7 @@
           (try-apply-operation deps source-table previous-columns transformation)]
       (when-not success?
         (log/errorf "Failed to transform: %s, columns: %s, execution-log: %s" message columns execution-log)
-        (throw (ex-info "Failed to transform" {})))
+        (throw (ex-info (format "Failed to transform. %s" (or message "")) {})))
       (let [new-dataset-version-id (str (util/squuid))]
         (clear-dataset-version-data-table tenant-conn {:id (:id dataset-version)})
         (let [next-dataset-version {:id new-dataset-version-id

--- a/backend/src/akvo/lumen/transformation/engine.clj
+++ b/backend/src/akvo/lumen/transformation/engine.clj
@@ -17,16 +17,6 @@
   [op-spec]
   false)
 
-(defmulti extend-data-command
-  "Validate transformation spec"
-  (fn [{:keys [tenant-conn] :as deps} dataset-id command]
-    (log/error :JOR command (keyword (get (:transformation command) "op")))
-    (keyword (get (:transformation command) "op"))))
-
-(defmethod extend-data-command :default
-  [{:keys [tenant-conn] :as deps} dataset-id command]
-  (:transformation command))
-
 (defmulti apply-operation
   "Applies a particular operation based on `op` key from spec
    * {:keys [tenant-conn] :as deps}: includes open connection to the database
@@ -159,7 +149,7 @@
         previous-columns (vec (:columns dataset-version))
         source-table (:table-name dataset-version)]
     (let [{:keys [success? message columns execution-log]}
-          (try-apply-operation deps source-table previous-columns transformation)]
+          (try-apply-operation deps source-table previous-columns (assoc transformation :dataset-id dataset-id))]
       (when-not success?
         (log/errorf "Failed to transform: %s, columns: %s, execution-log: %s" message columns execution-log)
         (throw (ex-info (format "Failed to transform. %s" (or message "")) {})))

--- a/backend/src/akvo/lumen/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/transformation/merge_datasets.clj
@@ -217,7 +217,8 @@
          (map (fn [i] (let [txs     (keywordize-keys (:transformations i))
                             mds     (filter #(= "core/merge-datasets" (:op %)) txs)
                             sources (map #(-> % :args :source) mds)]
-                                                  (map #(assoc % :origin (:dataset_id i)) sources))))
+                        (map #(assoc % :origin {:id (:dataset_id i)
+                                                :title (:title i)}) sources))))
                                    (reduce into [])
                                    (filter #(= (:datasetId %) dataset-id)))))
 
@@ -225,6 +226,6 @@
   "return the list of datasets that use dataset-id in merge transformations"
   [tenant-conn dataset-id]
   (let [datasets-in-merge-ops (datasets-merged-with* tenant-conn dataset-id)
-        dataset-ids-in-merge-ops (map :origin datasets-in-merge-ops)]
+        dataset-ids-in-merge-ops (map (comp :id :origin) datasets-in-merge-ops)]
     (when-not (empty? dataset-ids-in-merge-ops)
-      (select-datasets-by-id tenant-conn {:ids dataset-ids-in-merge-ops}))))
+      dataset-ids-in-merge-ops)))

--- a/backend/src/akvo/lumen/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/transformation/merge_datasets.clj
@@ -208,20 +208,23 @@
         {:error       (format "This version of the dataset isn't consistent thus it has merge transformations with datasets columns wich were already removed from their datasets: %s" (reduce str column-diff))
          :column-diff column-diff}))))
 
-(defn datasets-merged-with
+(defn datasets-merged-with*
   "return the list of datasets that use dataset-id in merge transformations"
   [tenant-conn dataset-id]
   (let [dsvs (latest-dataset-versions tenant-conn)
-        dsvs (filter #(not= dataset-id (:dataset_id %)) dsvs)
-        ;; _ (log/error :dsvs dsvs)
-        datasets-in-merge-ops (->> dsvs
-                                   (map (fn [i] (let [txs     (keywordize-keys (:transformations i))
-                                                      mds     (filter #(= "core/merge-datasets" (:op %)) txs)
-                                                      sources (map #(-> % :args :source) mds)]
+        dsvs (filter #(not= dataset-id (:dataset_id %)) dsvs)]
+    (->> dsvs
+         (map (fn [i] (let [txs     (keywordize-keys (:transformations i))
+                            mds     (filter #(= "core/merge-datasets" (:op %)) txs)
+                            sources (map #(-> % :args :source) mds)]
                                                   (map #(assoc % :origin (:dataset_id i)) sources))))
                                    (reduce into [])
-                                   (filter #(= (:datasetId %) dataset-id)))
+                                   (filter #(= (:datasetId %) dataset-id)))))
+
+(defn datasets-merged-with
+  "return the list of datasets that use dataset-id in merge transformations"
+  [tenant-conn dataset-id]
+  (let [datasets-in-merge-ops (datasets-merged-with* tenant-conn dataset-id)
         dataset-ids-in-merge-ops (map :origin datasets-in-merge-ops)]
     (when-not (empty? dataset-ids-in-merge-ops)
       (select-datasets-by-id tenant-conn {:ids dataset-ids-in-merge-ops}))))
-

--- a/client/src/actions/dataset.js
+++ b/client/src/actions/dataset.js
@@ -279,7 +279,7 @@ export function deleteDataset(id) {
         if (response.status >= 400) {
           response.json().then((error) => {
             dispatch(deleteDatasetFailure(id, error));
-            dispatch(showNotification('error', `deletion failed: ${error.error}. Ids: ${error.datasets}`));
+            dispatch(showNotification('error', `deletion failed: ${error.error}.`));
           });
         } else {
           response.json().then(() => dispatch(deleteDatasetSuccess(id)));

--- a/client/src/actions/dataset.js
+++ b/client/src/actions/dataset.js
@@ -275,9 +275,17 @@ export function deleteDataset(id) {
     dispatch(deleteDatasetRequest(id));
     api
       .del(`/api/datasets/${id}`)
-      .then(response => response.json())
-      .then(() => dispatch(deleteDatasetSuccess(id)))
-      .catch(error => dispatch(deleteDatasetFailure(id, error)));
+      .then((response) => {
+        if (response.status >= 400) {
+          response.json().then((error) => {
+            dispatch(deleteDatasetFailure(id, error));
+            dispatch(showNotification('error', `deletion failed: ${error.error}. Ids: ${error.datasets}`));
+          });
+        } else {
+          response.json().then(() => dispatch(deleteDatasetSuccess(id)));
+        }
+      })
+    ;
   };
 }
 


### PR DESCRIPTION
- [ ] **Update release notes if necessary**
These changes  don't allow either to delete columns that participate in an external merge-transformation