### PR TITLE
Add some monitoring

### DIFF
--- a/backend/dev/resources/dev.edn
+++ b/backend/dev/resources/dev.edn
@@ -9,7 +9,7 @@
   {:middleware
    {:functions {:stacktrace #ig/ref :akvo.lumen.middleware.ring.stacktrace/wrap-stacktrace}
     :applied   ^:replace [:not-found :json-response :ring-defaults :json-body
-                          :wrap-auth :wrap-jwt :wrap-label-tenant :stacktrace :lumen-monitoring]
+                          :wrap-auth :wrap-jwt :lumen-monitoring :wrap-label-tenant :stacktrace]
     :arguments {:wrap-jwt {:keycloak-url   "http://auth.lumen.local:8080/auth"
                            :keycloak-realm "akvo"}}}}
   :db {:uri "jdbc:postgresql://postgres/lumen?user=lumen&password=password&ssl=true"}

--- a/backend/dev/resources/dev.edn
+++ b/backend/dev/resources/dev.edn
@@ -9,7 +9,7 @@
   {:middleware
    {:functions {:stacktrace #ig/ref :akvo.lumen.middleware.ring.stacktrace/wrap-stacktrace}
     :applied   ^:replace [:not-found :json-response :ring-defaults :json-body
-                          :wrap-auth :wrap-jwt :wrap-label-tenant :stacktrace]
+                          :wrap-auth :wrap-jwt :wrap-label-tenant :stacktrace :lumen-monitoring]
     :arguments {:wrap-jwt {:keycloak-url   "http://auth.lumen.local:8080/auth"
                            :keycloak-realm "akvo"}}}}
   :db {:uri "jdbc:postgresql://postgres/lumen?user=lumen&password=password&ssl=true"}

--- a/backend/project.clj
+++ b/backend/project.clj
@@ -45,7 +45,11 @@
                  [ring/ring-defaults "0.3.2"]
                  [ring/ring-json "0.4.0"]
                  [selmer "1.11.8"]
-                 [net.postgis/postgis-jdbc "2.2.1" :exclusions [org.postgresql/postgresql]]]
+                 [net.postgis/postgis-jdbc "2.2.1" :exclusions [org.postgresql/postgresql]]
+
+                 [iapetos "0.1.8" :exclusions [io.prometheus/simpleclient]]
+                 [io.prometheus/simpleclient_hotspot "0.5.0"]
+                 [io.prometheus/simpleclient_dropwizard "0.5.0"]]
   :uberjar-name "akvo-lumen.jar"
   :repl-options {:timeout 120000}
   :pedantic? :abort

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -114,7 +114,11 @@
                                                         :default-charset        "utf-8"}}
                             :wrap-sentry   [sentry-backend-dsn {:namespaces ["org.akvo" "akvo"]}]}}}
   :http          {:port http-port}
-  :db            {:uri db-uri}
+  :db            {:uri db-uri
+                  :pool-name "tenant-manager"
+                  :maximum-pool-size 5
+                  :minimum-idle 2}
+
   :caddisfly     {:schema-uri caddisfly-schema-uri}
   :emailer       {:email-host     email-host
                   :email-password email-password

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -75,14 +75,14 @@
               #ig/ref :akvo.lumen.endpoint.user/user
               #ig/ref :akvo.lumen.endpoint.visualisation/visualisation]
   :config    #ig/ref :akvo.lumen.config}
- 
+
  :akvo.lumen.component.http/http      {:config #ig/ref :akvo.lumen.config
                                        :app    #ig/ref :akvo.lumen.component.handler/handler}
  :akvo.lumen.component.caddisfly/prod {:config #ig/ref :akvo.lumen.config}
  :akvo.lumen.component.keycloak       {:config #ig/ref :akvo.lumen.config}
  :akvo.lumen.component.tenant-manager {:config #ig/ref :akvo.lumen.config
                                        :db     #ig/ref :akvo.lumen.component.hikaricp/hikaricp}
- 
+
  :akvo.lumen.component.emailer/mailjet-emailer {:config #ig/ref :akvo.lumen.config}
 
  :akvo.lumen.component.error-tracker/prod {:config #ig/ref :akvo.lumen.config}
@@ -92,15 +92,16 @@
                 :tenants        "akvo/lumen/migrations/tenants"}
    :middleware {:functions {:hide-errors       #ig/ref :akvo.lumen.middleware.duct.erros/wrap-hide-errors
                             :json-body         #ig/ref :akvo.lumen.middleware.ring.json/wrap-json-body
-                            :json-response     #ig/ref :akvo.lumen.middleware.ring.json/wrap-json-response 
-                            :not-found         #ig/ref :akvo.lumen.middleware.duct.not-found/wrap-not-found 
+                            :json-response     #ig/ref :akvo.lumen.middleware.ring.json/wrap-json-response
+                            :not-found         #ig/ref :akvo.lumen.middleware.duct.not-found/wrap-not-found
                             :ring-defaults     #ig/ref :akvo.lumen.middleware.ring.defaults/wrap-defaults
                             :wrap-auth         #ig/ref :akvo.lumen.middleware.auth/wrap-auth
                             :wrap-jwt          #ig/ref :akvo.lumen.middleware.auth/wrap-jwt
                             :wrap-label-tenant #ig/ref :akvo.lumen.middleware.tenant-manager/wrap-label-tenant
-                            :wrap-sentry       #ig/ref :akvo.lumen.middleware.sentry/wrap-sentry}
+                            :wrap-sentry       #ig/ref :akvo.lumen.middleware.sentry/wrap-sentry
+                            :lumen-monitoring  #ig/ref :akvo.lumen.lumen-monitoring/middleware}
                 :applied   [:not-found :json-response :ring-defaults :json-body
-                            :wrap-auth :wrap-jwt :wrap-label-tenant :wrap-sentry
+                            :wrap-auth :wrap-jwt :wrap-label-tenant :wrap-sentry :lumen-monitoring
                             :hide-errors]
                 :arguments {:not-found     "Resource Not Found"
                             :hide-errors   "Internal Server Error"
@@ -143,4 +144,8 @@
                   :realm       keycloak-realm
                   :credentials {"client_id"     keycloak-client-id
                                 "client_secret" keycloak-client-secret}}}
+
+ :akvo.lumen.lumen-monitoring/collector {}
+ :akvo.lumen.lumen-monitoring/middleware {:collector #ig/ref :akvo.lumen.lumen-monitoring/collector}
+
  }

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -118,7 +118,8 @@
   :db            {:uri db-uri
                   :pool-name "tenant-manager"
                   :maximum-pool-size 5
-                  :minimum-idle 2}
+                  :minimum-idle 2
+                  :metric-registry #ig/ref :akvo.lumen.lumen-monitoring/dropwizard-registry}
 
   :caddisfly     {:schema-uri caddisfly-schema-uri}
   :emailer       {:email-host     email-host
@@ -139,13 +140,15 @@
                   :sentry-backend-dsn        sentry-backend-dsn
                   :flow-api-url              flow-api-url
                   :windshaft-url             "http://localhost:4000"
+                  :dropwizard-registry       #ig/ref :akvo.lumen.lumen-monitoring/dropwizard-registry
                   :piwik-site-id             piwik-site-id}
   :keycloak      {:url         keycloak-url
                   :realm       keycloak-realm
                   :credentials {"client_id"     keycloak-client-id
                                 "client_secret" keycloak-client-secret}}}
 
- :akvo.lumen.lumen-monitoring/collector {}
+ :akvo.lumen.lumen-monitoring/dropwizard-registry {}
+ :akvo.lumen.lumen-monitoring/collector {:dropwizard-registry #ig/ref :akvo.lumen.lumen-monitoring/dropwizard-registry}
  :akvo.lumen.lumen-monitoring/middleware {:collector #ig/ref :akvo.lumen.lumen-monitoring/collector}
 
  }

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -101,7 +101,7 @@
                             :wrap-sentry       #ig/ref :akvo.lumen.middleware.sentry/wrap-sentry
                             :lumen-monitoring  #ig/ref :akvo.lumen.lumen-monitoring/middleware}
                 :applied   [:not-found :json-response :ring-defaults :json-body
-                            :wrap-auth :wrap-jwt :wrap-label-tenant :wrap-sentry :lumen-monitoring
+                            :wrap-auth :wrap-jwt :lumen-monitoring :wrap-label-tenant :wrap-sentry
                             :hide-errors]
                 :arguments {:not-found     "Resource Not Found"
                             :hide-errors   "Internal Server Error"

--- a/backend/src/akvo/lumen/component/hikaricp.clj
+++ b/backend/src/akvo/lumen/component/hikaricp.clj
@@ -3,7 +3,10 @@
             [duct.database.sql.hikaricp]))
 
 (defmethod ig/init-key :akvo.lumen.component.hikaricp/hikaricp  [_ {:keys [ config] :as opts}]
-  (ig/init-key :duct.database.sql/hikaricp {:jdbc-url (-> config :db :uri)}))
+  (ig/init-key :duct.database.sql/hikaricp
+               (-> config
+                   :db
+                   (clojure.set/rename-keys {:uri :jdbc-url}))))
 
 (defmethod ig/halt-key! :akvo.lumen.component.hikaricp/hikaricp  [_ opts]
   (ig/halt-key! :duct.database.sql/hikaricp opts))

--- a/backend/src/akvo/lumen/component/tenant_manager.clj
+++ b/backend/src/akvo/lumen/component/tenant_manager.clj
@@ -54,13 +54,13 @@
 (defn pool
   "Created a Hikari connection pool."
   [{:keys [db_uri label dropwizard-registry]}]
-  (let [minutes_5 (* 5 60 1000)
+  (let [minute (* 60 1000)
         cfg (doto
               (HikariConfig.)
               (.setJdbcUrl db_uri)
               (.setPoolName label)
               (.setMinimumIdle 0)
-              (.setIdleTimeout minutes_5)
+              (.setIdleTimeout (* 10 minute))
               (.setConnectionTimeout (* 10 1000))
               (.setMaximumPoolSize 10)
               (.setMetricRegistry dropwizard-registry))]

--- a/backend/src/akvo/lumen/component/tenant_manager.clj
+++ b/backend/src/akvo/lumen/component/tenant_manager.clj
@@ -53,10 +53,16 @@
 (defn pool
   "Created a Hikari connection pool."
   [tenant]
-  (let [cfg (HikariConfig.)]
-    (.setJdbcUrl cfg (:db_uri tenant))
-    (.setPoolName cfg (:label tenant))
-    (.setMinimumIdle cfg 2)
+  (let [minutes_5 (* 5 60 1000)
+        cfg (doto
+              (HikariConfig.)
+              (.setJdbcUrl (:db_uri tenant))
+              (.setPoolName (:label tenant))
+              (.setMinimumIdle 0)
+              (.setIdleTimeout minutes_5)
+              (.setConnectionTimeout (* 10 1000))
+              (.setMaximumPoolSize 10))
+        ]
     {:datasource (HikariDataSource. cfg)}))
 
 

--- a/backend/src/akvo/lumen/component/tenant_manager.clj
+++ b/backend/src/akvo/lumen/component/tenant_manager.clj
@@ -18,9 +18,9 @@
 (defn subdomain? [host]
   (>= (get (frequencies host) \.) 2))
 
-(defn healthz? [{:keys [request-method path-info]}]
+(defn path-info? [expected-path-info {:keys [request-method path-info]}]
   (and (= request-method :get)
-       (= path-info "/healthz")))
+       (= path-info expected-path-info)))
 
 (defn tenant-host [host]
   (-> host
@@ -35,7 +35,8 @@
   (fn [req]
     (let [host (get-in req [:headers "host"])]
       (cond
-        (healthz? req) (handler req)
+        (path-info? "/healthz" req) (handler req)
+        (path-info? "/metrics" req) (handler req)
         (subdomain? host) (handler (assoc req :tenant (tenant-host host)))
         :else (lib/bad-request "Not a tenant")))))
 

--- a/backend/src/akvo/lumen/lumen_monitoring.clj
+++ b/backend/src/akvo/lumen/lumen_monitoring.clj
@@ -2,16 +2,17 @@
   (:require [iapetos.core :as prometheus]
             [iapetos.collector.jvm :as jvm]
             [iapetos.collector.ring :as ring]
-            [integrant.core :as ig]
-            [iapetos.collector.exceptions :as ex])
+            [integrant.core :as ig])
   (:import (io.prometheus.client.dropwizard DropwizardExports)
            (com.codahale.metrics MetricRegistry)))
 
+(defmethod ig/init-key ::dropwizard-registry [_ _]
+  (MetricRegistry.))
 
-(defmethod ig/init-key ::collector [_ config]
+(defmethod ig/init-key ::collector [_ {:keys [dropwizard-registry]}]
   (-> (prometheus/collector-registry)
       (jvm/initialize)
-      (prometheus/register (DropwizardExports. (MetricRegistry.)))
+      (prometheus/register (DropwizardExports. dropwizard-registry))
       (ring/initialize)))
 
 (defmethod ig/init-key ::middleware [_ {:keys [collector]}]

--- a/backend/src/akvo/lumen/lumen_monitoring.clj
+++ b/backend/src/akvo/lumen/lumen_monitoring.clj
@@ -16,7 +16,7 @@
 
 (defmethod ig/init-key ::middleware [_ {:keys [collector]}]
   #(-> %
-       (ring/wrap-metrics collector)))
+       (ring/wrap-metrics collector {:path-fn (constantly "unknown")})))
 
 (comment
   (slurp "http://localhost:3000/metrics")

--- a/backend/src/akvo/lumen/lumen_monitoring.clj
+++ b/backend/src/akvo/lumen/lumen_monitoring.clj
@@ -13,11 +13,13 @@
   (-> (prometheus/collector-registry)
       (jvm/initialize)
       (prometheus/register (DropwizardExports. dropwizard-registry))
-      (ring/initialize)))
+      (ring/initialize {:labels [:tenant]})))
 
 (defmethod ig/init-key ::middleware [_ {:keys [collector]}]
   #(-> %
-       (ring/wrap-metrics collector {:path-fn (constantly "unknown")})))
+       (ring/wrap-metrics collector {:path-fn (constantly "unknown")
+                                     :label-fn (fn [request _]
+                                                 {:tenant (:tenant request)})})))
 
 (comment
   (slurp "http://localhost:3000/metrics")

--- a/backend/src/akvo/lumen/lumen_monitoring.clj
+++ b/backend/src/akvo/lumen/lumen_monitoring.clj
@@ -1,0 +1,23 @@
+(ns akvo.lumen.lumen-monitoring
+  (:require [iapetos.core :as prometheus]
+            [iapetos.collector.jvm :as jvm]
+            [iapetos.collector.ring :as ring]
+            [integrant.core :as ig]
+            [iapetos.collector.exceptions :as ex])
+  (:import (io.prometheus.client.dropwizard DropwizardExports)
+           (com.codahale.metrics MetricRegistry)))
+
+
+(defmethod ig/init-key ::collector [_ config]
+  (-> (prometheus/collector-registry)
+      (jvm/initialize)
+      (prometheus/register (DropwizardExports. (MetricRegistry.)))
+      (ring/initialize)))
+
+(defmethod ig/init-key ::middleware [_ {:keys [collector]}]
+  #(-> %
+       (ring/wrap-metrics collector)))
+
+(comment
+  (slurp "http://localhost:3000/metrics")
+  )


### PR DESCRIPTION
Using Prometheus:

* Added monitoring stats from HikariCP (https://github.com/brettwooldridge/HikariCP/wiki/Dropwizard-Metrics)
* Added very basic HTTP metrics.
* JVM (memory/threads/gc)

Also fixed a connection pool leak.

About the HTTP metrics, there is no way to get the full compojure matched path, so instead of
having thousands of urls (due to the REST urls), prefer to have just one
stat, so at least we can see the traffic and error rates.

Compojure has a wrap-routes function to do this, but it doesnt work as we
need when using compojure/context. When using context, we can just capture
the latest bit of the matched api. For example:

(context "/visualization/:id"
  (GET "/meta"...

We are just able to get the "/meta" part, when what we actually want is
   "/visualization/:id/meta".