### PR TITLE
[#1745] Handle middleware args as vectors

### DIFF
--- a/backend/src/akvo/lumen/component/handler.clj
+++ b/backend/src/akvo/lumen/component/handler.clj
@@ -9,7 +9,7 @@
   (:endpoints component (find-endpoint-keys component)))
 
 (defn- middleware-fn [f args]
-  (let [args (if (or (nil? args) (seq? args)) args (list args))]
+  (let [args (if (or (nil? args) (sequential? args)) args (list args))]
     #(apply f % args)))
 
 (defn- middleware-map [{:keys [functions arguments]}]


### PR DESCRIPTION
Since middleware arguments are defined in vectors and
(seq? []) ;; false
(sequential? []) ;; true

- [ ] **Update release notes if necessary**
