### PR TITLE
Clean up blue-green-gateway

### DIFF
--- a/ci/k8s/blue-green-gateway.yaml
+++ b/ci/k8s/blue-green-gateway.yaml
@@ -48,7 +48,6 @@ spec:
 ---
 apiVersion: v1
 data:
-  current-live: green
   default.conf: |-
         client_max_body_size 50M;
         large_client_header_buffers 16 32k;


### PR DESCRIPTION
Removing unused config, as the dark/live to blue/green mapping is stored
in the lumen-live service

Fixes #1751

- [x] **Update release notes if necessary**