### PR TITLE
[#1710] Fix ubound variable

### DIFF
--- a/backend/maybe-import-and-java-jar.sh
+++ b/backend/maybe-import-and-java-jar.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 
-if [[ "${WAIT_FOR_DB}" = "true" ]]; then
+if [[ "${WAIT_FOR_DB:=false}" = "true" ]]; then
   /app/wait-for-dependencies.sh
 fi
 


### PR DESCRIPTION
We use WAIT_FOR_DB as signal for develop and testing in CI. When
running a bash script with `set -o nounset` we need to provide defaults
to potentially uninitialized variables. We use the "${VAR:=default}"
as way to default a value.

> ${parameter:=word}
>
>    If parameter is unset or null, the expansion of word is assigned
>    to parameter. The value of parameter is then
>    substituted. Positional parameters and special parameters may not
>    be assigned to in this way.

https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

- [ ] **Update release notes if necessary**
