### PR TITLE
Add clojure spec gradually (Connect #1441)

### DIFF
--- a/backend/dev/src/dev.clj
+++ b/backend/dev/src/dev.clj
@@ -9,7 +9,7 @@
             [clojure.java.jdbc :as jdbc]
             [clojure.pprint :refer [pprint]]
             [clojure.repl :refer :all]
-            [clojure.tools.namespace.repl :refer [refresh]]
+            [clojure.tools.namespace.repl :as repl]
             [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha :as stest]
             [clojure.tools.logging :as log]
@@ -27,6 +27,11 @@
 (defn uncheck-specs! []
   (log/warn "unstrumenting specs!")
   (stest/unstrument))
+
+(defn refresh []
+  (uncheck-specs!)
+  (repl/refresh)
+  (check-specs!))
 
 
 (defn read-config []

--- a/backend/dev/src/dev.clj
+++ b/backend/dev/src/dev.clj
@@ -10,12 +10,24 @@
             [clojure.pprint :refer [pprint]]
             [clojure.repl :refer :all]
             [clojure.tools.namespace.repl :refer [refresh]]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.tools.logging :as log]
             [duct.core :as duct]
             [duct.generate :as gen]
             [integrant.core :as ig]
             [integrant.repl :as ir]
             [integrant.repl.state :as state :refer (system)])
   (:import [org.postgresql.util PSQLException PGobject]))
+
+(defn check-specs! []
+  (log/warn "instrumenting specs!")
+  (stest/instrument))
+
+(defn uncheck-specs! []
+  (log/warn "unstrumenting specs!")
+  (stest/unstrument))
+
 
 (defn read-config []
   (duct/read-config (io/resource "dev.edn")))

--- a/backend/project.clj
+++ b/backend/project.clj
@@ -91,7 +91,8 @@
                                     :init (do
                                             (println "Starting BackEnd ...")
                                             (go)
-                                            (migrate-and-seed))
+                                            (migrate-and-seed)
+                                            (check-specs!))
                                     :host "0.0.0.0"
                                     :port 47480}
                    :env            {:port "3000"}}

--- a/backend/project.clj
+++ b/backend/project.clj
@@ -90,9 +90,9 @@
                    :repl-options   {:init-ns dev
                                     :init (do
                                             (println "Starting BackEnd ...")
+                                            (check-specs!)
                                             (go)
-                                            (migrate-and-seed)
-                                            (check-specs!))
+                                            (migrate-and-seed))
                                     :host "0.0.0.0"
                                     :port 47480}
                    :env            {:port "3000"}}

--- a/backend/src/akvo/lumen/component/caddisfly.clj
+++ b/backend/src/akvo/lumen/component/caddisfly.clj
@@ -10,28 +10,20 @@
   (->> (:tests json-schema)
        (reduce #(assoc % (:uuid %2) %2) {})))
 
-(defn dev-caddisfly
-  "caddisfly development version, so we can develop without internet connection"
-  [options]
-  {:pre [(:local-schema-uri options)]}
-  options)
-
-(defn caddisfly [options]
-  {:pre [(:schema-uri options)]}
-  options)
-
 (defmethod ig/init-key :akvo.lumen.component.caddisfly/local  [_ {:keys [config] :as opts}]
-  (let [{:keys [local-schema-uri] :as this} (dev-caddisfly (:caddisfly config))
+  {:pre [(-> config :caddisfly :local-schema-uri)]}
+  (let [{:keys [local-schema-uri] :as this} (:caddisfly config)
         tests (-> local-schema-uri io/resource slurp (json/parse-string keyword) extract-tests)]
     (log/warn ::start "Using caddisfly LOCAL schema-uri:" local-schema-uri)
     (assoc this :schema tests)))
 
 (defmethod ig/init-key :akvo.lumen.component.caddisfly/prod  [_ {:keys [config] :as opts}]
-  (let [{:keys [schema-uri] :as this} (caddisfly (:caddisfly config))
+  {:pre [(-> config :caddisfly :schema-uri)]}
+  (let [{:keys [schema-uri] :as this}  (:caddisfly config)
         tests (-> schema-uri client/get :body (json/decode keyword) extract-tests)]
     (log/info ::start "Using caddisfly ONLINE schema-uri" schema-uri)
     (assoc this :schema tests)))
 
-(defn get-caddisfly-schema
+(defn get-schema
   [caddisfly caddisflyResourceUuid]
   (get (:schema caddisfly) caddisflyResourceUuid))

--- a/backend/src/akvo/lumen/component/caddisfly.clj
+++ b/backend/src/akvo/lumen/component/caddisfly.clj
@@ -31,3 +31,7 @@
         tests (-> schema-uri client/get :body (json/decode keyword) extract-tests)]
     (log/info ::start "Using caddisfly ONLINE schema-uri" schema-uri)
     (assoc this :schema tests)))
+
+(defn get-caddisfly-schema
+  [caddisfly caddisflyResourceUuid]
+  (get (:schema caddisfly) caddisflyResourceUuid))

--- a/backend/src/akvo/lumen/import.clj
+++ b/backend/src/akvo/lumen/import.clj
@@ -82,7 +82,6 @@
         (with-open [importer (import/dataset-importer (get spec "source") config)]
           (let [columns (import/columns importer)]
             (import/create-dataset-table conn table-name columns)
-            (import/add-key-constraints conn table-name columns)
             (doseq [record (map import/coerce-to-sql (import/records importer))]
               (jdbc/insert! conn table-name record))
             (successful-import conn job-execution-id table-name columns spec claims data-source))))

--- a/backend/src/akvo/lumen/import/common.clj
+++ b/backend/src/akvo/lumen/import/common.clj
@@ -102,11 +102,7 @@
       ;; else
       nil)))
 
-(defn create-dataset-table [conn table-name columns]
-  (jdbc/execute! conn [(dataset-table-sql table-name columns)])
-  (create-indexes conn table-name columns))
-
-(defn add-key-constraints [conn table-name columns]
+(defn- add-key-constraints [conn table-name columns]
   (doseq [column columns
           :when (:key column)]
     (jdbc/execute! conn
@@ -117,6 +113,11 @@
                    (format "ALTER TABLE \"%s\" ALTER COLUMN %s SET NOT NULL"
                            table-name
                            (name (:id column))))))
+
+(defn create-dataset-table [conn table-name columns]
+  (jdbc/execute! conn [(dataset-table-sql table-name columns)])
+  (create-indexes conn table-name columns)
+  (add-key-constraints conn table-name columns))
 
 (defrecord Geoshape [wkt-string])
 

--- a/backend/src/akvo/lumen/lib/multiple_column.clj
+++ b/backend/src/akvo/lumen/lib/multiple_column.clj
@@ -1,17 +1,18 @@
 (ns akvo.lumen.lib.multiple-column
   (:require [clojure.tools.logging :as log]
+            [akvo.lumen.component.caddisfly :as c.caddisfly]
             [ring.util.response :refer [response not-found]]))
 
 (defn- extract
   [caddisfly id]
   (when id
-    (if-let [schema (get (:schema caddisfly) id)]
-      (let [res (select-keys schema [:hasImage])]
-        (assoc res :columns (map (fn [r]
-                                   {:id   (:id r)
-                                    :name (format "%s (%s)" (:name r) (:unit r))
-                                    :type "text" ;; TODO will be improved after design discussions 
-                                    }) (:results schema)))))))
+    (if-let [schema (c.caddisfly/get-schema caddisfly id)]
+      (-> (select-keys schema [:hasImage])
+          (assoc :columns (map (fn [r]
+                                 {:id   (:id r)
+                                  :name (format "%s (%s)" (:name r) (:unit r))
+                                  :type "text" ;; TODO will be improved after design discussions
+                                  }) (:results schema)))))))
 
 (defn details
   "depending of type of multiple columns we dispatch to different logic impls"

--- a/backend/src/akvo/lumen/specs/components.clj
+++ b/backend/src/akvo/lumen/specs/components.clj
@@ -11,19 +11,5 @@
 
 (s/def :integrant/component-args (s/multi-spec integrant-key identity))
 
-(s/fdef ig/init-key
-  :args :integrant/component-args)
-
-(s/def ::caddisfly/local-schema-uri string?)
-
-(s/def ::caddisfly/caddisfly (s/keys :req-un [::caddisfly/local-schema-uri]))
-
-(s/def ::caddisfly/config (s/keys :req-un [::caddisfly/caddisfly] ))
-
-(defmethod integrant-key ::caddisfly/local [_]
-  (s/cat :kw keyword? :config (s/keys :req-un [::caddisfly/config])))
-
-(s/explain :integrant/component-args [::caddisfly/local {:config {:caddisfly {:local-schema-uri "./caddisfly/tests-schema.json"}}}])
-
-#_(ig/init-key ::caddisfly/local {:config {:caddisfly {:local-schema-uri "./caddisfly/tests-schema.json"}}})
+(s/fdef ig/init-key :args :integrant/component-args)
 

--- a/backend/src/akvo/lumen/specs/components.clj
+++ b/backend/src/akvo/lumen/specs/components.clj
@@ -1,0 +1,29 @@
+(ns akvo.lumen.specs.components
+  (:require [akvo.lumen.component.caddisfly :as caddisfly]
+            [clojure.spec.alpha :as s]
+            [clojure.tools.logging :as log]
+            [integrant.core :as ig]))
+
+(defmulti integrant-key first)
+
+(defmethod integrant-key :default [_]
+  (s/cat :kw keyword? :opts any?))
+
+(s/def :integrant/component-args (s/multi-spec integrant-key identity))
+
+(s/fdef ig/init-key
+  :args :integrant/component-args)
+
+(s/def ::caddisfly/local-schema-uri string?)
+
+(s/def ::caddisfly/caddisfly (s/keys :req-un [::caddisfly/local-schema-uri]))
+
+(s/def ::caddisfly/config (s/keys :req-un [::caddisfly/caddisfly] ))
+
+(defmethod integrant-key ::caddisfly/local [_]
+  (s/cat :kw keyword? :config (s/keys :req-un [::caddisfly/config])))
+
+(s/explain :integrant/component-args [::caddisfly/local {:config {:caddisfly {:local-schema-uri "./caddisfly/tests-schema.json"}}}])
+
+#_(ig/init-key ::caddisfly/local {:config {:caddisfly {:local-schema-uri "./caddisfly/tests-schema.json"}}})
+

--- a/backend/src/akvo/lumen/specs/components/caddisfly.clj
+++ b/backend/src/akvo/lumen/specs/components/caddisfly.clj
@@ -13,9 +13,3 @@
 
 (defmethod integrant-key ::caddisfly/local [_]
   (s/cat :kw keyword? :config (s/keys :req-un [::caddisfly/config])))
-
-(s/explain :integrant/component-args [::caddisfly/local
-                                      {:config {:caddisfly {:local-schema-uri "./caddisfly/tests-schema.json"}}}])
-
-
-#_(ig/init-key ::caddisfly/local {:config {:caddisfly {:local-schema-uri "./caddisfly/tests-schema.json"}}})

--- a/backend/src/akvo/lumen/specs/components/caddisfly.clj
+++ b/backend/src/akvo/lumen/specs/components/caddisfly.clj
@@ -1,0 +1,21 @@
+(ns akvo.lumen.specs.components.caddisfly
+  (:require [akvo.lumen.component.caddisfly :as caddisfly]
+            [akvo.lumen.specs.components :refer (integrant-key)]
+            [clojure.spec.alpha :as s]
+            [clojure.tools.logging :as log]
+            [integrant.core :as ig]))
+
+(s/def ::caddisfly/local-schema-uri string?)
+
+(s/def ::caddisfly/caddisfly (s/keys :req-un [::caddisfly/local-schema-uri]))
+
+(s/def ::caddisfly/config (s/keys :req-un [::caddisfly/caddisfly] ))
+
+(defmethod integrant-key ::caddisfly/local [_]
+  (s/cat :kw keyword? :config (s/keys :req-un [::caddisfly/config])))
+
+(s/explain :integrant/component-args [::caddisfly/local
+                                      {:config {:caddisfly {:local-schema-uri "./caddisfly/tests-schema.json"}}}])
+
+
+#_(ig/init-key ::caddisfly/local {:config {:caddisfly {:local-schema-uri "./caddisfly/tests-schema.json"}}})

--- a/backend/src/akvo/lumen/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/transformation/merge_datasets.clj
@@ -1,6 +1,5 @@
 (ns akvo.lumen.transformation.merge-datasets
-  (:require [akvo.lumen.import.common :as import]
-            [akvo.lumen.transformation.engine :as engine]
+  (:require [akvo.lumen.transformation.engine :as engine]
             [clojure.java.jdbc :as jdbc]
             [clojure.tools.logging :as log]
             [clojure.set :as set]

--- a/backend/src/akvo/lumen/transformation/multiple_column.clj
+++ b/backend/src/akvo/lumen/transformation/multiple_column.clj
@@ -14,11 +14,13 @@
      (every? (comp t.engine/valid-type? :type) columns-to-extract)
      (#{"fail" "leave-empty" "delete-row"} onError))))
 
-(defmethod t.engine/apply-operation :core/extract-multiple
-  [deps table-name columns op-spec]
+(defn- apply-operation [deps table-name columns op-spec]
   (let [{:keys [onError op args] :as op-spec} (keywordize-keys op-spec)]
     ;; so far we only implement `caddisfly` in other case we throw exception based on core/condp impl
-    (update
-     (condp = (-> args :selectedColumn :multipleType)
-       "caddisfly" (t.m-c.caddisfly/apply-operation deps table-name columns op-spec))
-     :columns stringify-keys)))
+    (condp = (-> args :selectedColumn :multipleType)
+      "caddisfly" (t.m-c.caddisfly/apply-operation deps table-name columns op-spec))))
+
+(defmethod t.engine/apply-operation :core/extract-multiple
+  [deps table-name columns op-spec]
+  (-> (apply-operation deps table-name columns op-spec)
+      (update :columns stringify-keys)))

--- a/backend/src/akvo/lumen/transformation/multiple_column/caddisfly.clj
+++ b/backend/src/akvo/lumen/transformation/multiple_column/caddisfly.clj
@@ -1,7 +1,7 @@
 (ns akvo.lumen.transformation.multiple-column.caddisfly
   (:require [akvo.lumen.postgres :as postgres]
             [akvo.lumen.transformation.engine :as engine]
-            [akvo.lumen.component.caddisfly :refer (get-caddisfly-schema)]
+            [akvo.lumen.component.caddisfly :refer (get-schema)]
             [cheshire.core :as json]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as string]
@@ -11,8 +11,6 @@
 (hugsql/def-db-fns "akvo/lumen/transformation.sql")
 
 (hugsql/def-db-fns "akvo/lumen/transformation/engine.sql")
-
-
 
 (defn- add-name-to-new-columns
   [current-columns columns-to-extract]
@@ -27,7 +25,7 @@
     (log/debug :sql sql)
     (jdbc/execute! conn sql)))
 
-(defn columns-to-extract [columns selected-column caddisfly-schema extractImage]
+(defn- columns-to-extract [columns selected-column caddisfly-schema extractImage]
   (let [columns   (filter :extract columns)
         base-column (dissoc selected-column :multipleId :type :multipleType :columnName :title)]
     (cond->>
@@ -36,7 +34,7 @@
       (cons (with-meta (assoc base-column :type "text" :title (str (:title selected-column) "| Image"))
               {:image true})))))
 
-(defn multiple-cell-value
+(defn- multiple-cell-value
   "get json parsed value from cell row"
   [row column-name]
   (json/parse-string ((keyword column-name) row) keyword))
@@ -59,7 +57,7 @@
           selected-column (-> args :selectedColumn)
 
           caddisfly-schema (if-let [multiple-id (:multipleId selected-column)]
-                             (get-caddisfly-schema caddisfly multiple-id)
+                             (get-schema caddisfly multiple-id)
                              (throw
                               (ex-info "this column doesn't have a caddisflyResourceUuid currently associated!"
                                        {:message

--- a/backend/src/akvo/lumen/update.clj
+++ b/backend/src/akvo/lumen/update.clj
@@ -1,8 +1,6 @@
 (ns akvo.lumen.update
   (:require [akvo.lumen.boundary.error-tracker :as error-tracker]
             [akvo.lumen.import.common :as import]
-            [akvo.lumen.import.csv]
-            [akvo.lumen.import.flow]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.transformation.engine :as engine]
             [akvo.lumen.util :as util]
@@ -104,7 +102,6 @@
         (if-not (compatible-columns? imported-dataset-columns importer-columns)
           (failed-update conn job-execution-id "Column mismatch")
           (do (import/create-dataset-table conn table-name importer-columns)
-              (import/add-key-constraints conn table-name importer-columns)
               (doseq [record (map import/coerce-to-sql (import/records importer))]
                 (jdbc/insert! conn table-name record))
               (clone-data-table conn

--- a/backend/test/akvo/lumen/component/caddisfly_test.clj
+++ b/backend/test/akvo/lumen/component/caddisfly_test.clj
@@ -13,8 +13,6 @@
      (->> {:config {:caddisfly {:local-schema-uri "./caddisfly/tests-schema.json"}}}
           (ig/init-key :akvo.lumen.component.caddisfly/local)))))
 
-
-
 (deftest component-versions-test
   (testing "prod component version"
     (is (= (-> (caddisfly :prod) :schema first val keys)

--- a/backend/test/akvo/lumen/test_utils.clj
+++ b/backend/test/akvo/lumen/test_utils.clj
@@ -3,11 +3,19 @@
             [akvo.lumen.import :refer [do-import]]
             [akvo.lumen.util :refer [squuid]]
             [clojure.edn :as edn]
+            [clojure.spec.test.alpha :as stest]
             [clojure.java.io :as io]
             [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/job-execution.sql")
 
+(defn spec-instrument
+  "Fixture to instrument all functions"
+  [f]
+  (stest/instrument)
+  (let [r (f)]
+    (stest/unstrument)
+    r))
 
 (def seed-data
   (->> "test-seed.edn"

--- a/backend/test/akvo/lumen/transformation_test.clj
+++ b/backend/test/akvo/lumen/transformation_test.clj
@@ -9,6 +9,7 @@
             [akvo.lumen.postgres :as postgres]
             [akvo.lumen.transformation :as tf]
             [akvo.lumen.transformation.engine :as engine]
+            [akvo.lumen.test-utils :as tu]
             [cheshire.core :as json]
             [clojure.java.io :as io]
             [clojure.test :refer :all]
@@ -25,8 +26,7 @@
 (hugsql/def-db-fns "akvo/lumen/transformation_test.sql")
 (hugsql/def-db-fns "akvo/lumen/transformation.sql")
 
-(use-fixtures :once tenant-conn-fixture error-tracker-fixture)
-
+(use-fixtures :once tu/spec-instrument tenant-conn-fixture error-tracker-fixture)
 
 (deftest op-validation
   (testing "op validation"


### PR DESCRIPTION
Relates to #1441 

Adding specs to current code will need in many times some apparently unrelated changes like changing type of arguments (instead of seq of args to use a single arg map type with keys keywordized ... ) and/or changing functions to be somehow more _specable_ (moving to another ns, renaming ... ).  As a practical example this PR also contains refactors that affect to caddisfly logic

- [ ] **Update release notes if necessary**
- [x] [instrument development](https://clojure.org/guides/spec#_instrumentation_and_testing)
- [x] [instrument tests with fixture](https://github.com/akvo/akvo-lumen/compare/issue-1441-use-clojure-spec#diff-b87c8af64bc3639cfe3a858ea626ec48)
- [x] proof of concept for specifing integrant config components through [spec/multi-spec](https://clojure.org/guides/spec#_multi_spec) 
  - [x] specification example for caddisfly local component

