### PR TITLE
Integration tests (Connect #1710)

### DIFF
--- a/backend/test/akvo/lumen/transformation/engine_test.clj
+++ b/backend/test/akvo/lumen/transformation/engine_test.clj
@@ -1,7 +1,6 @@
 (ns akvo.lumen.transformation.engine-test
   {:functional true}
-  (:require [akvo.lumen.fixtures :refer [migrate-tenant rollback-tenant]]
-            [akvo.lumen.test-utils :refer [test-tenant test-tenant-conn]]
+  (:require [akvo.lumen.test-utils :refer [test-tenant test-tenant-conn]]
             [akvo.lumen.transformation.engine :refer :all]
             [cheshire.core :as json]
             [clojure.java.io :as io]
@@ -15,13 +14,11 @@
 (def ^:dynamic *tenant-conn*)
 
 (defn fixture [f]
-  (migrate-tenant test-tenant)
   (binding [*tenant-conn* (test-tenant-conn test-tenant)]
     (db-drop-test-table *tenant-conn*)
     (db-test-table *tenant-conn*)
     (db-test-data *tenant-conn*)
-    (f)
-    (rollback-tenant test-tenant)))
+    (f)))
 
 (use-fixtures :once fixture)
 

--- a/backend/test/resources/public_tables.sql
+++ b/backend/test/resources/public_tables.sql
@@ -1,0 +1,7 @@
+-- :name db-public-tables :? :*
+-- :doc Returns all public tables, except internal system ones
+SELECT table_schema || '.' || table_name AS table_name
+  FROM information_schema.tables
+ WHERE table_schema IN ('public', 'history')
+   AND table_type = 'BASE TABLE'
+   AND table_name NOT IN ('spatial_ref_sys', 'ragtime_migrations')


### PR DESCRIPTION
I've tested 2 approaches for speeding up the tests without modifying the tests themselves:

* Only delete the data
* Create a new DB based on a _template_ instead of issuing a full rollback of the migrations

Here have some numbers (not scientific measures)

this measurements have the `collection-test` disabled as it requires a Datasource
```
== delete all data ==
real	0m30.719s
user	0m25.790s
sys	0m1.239s

== one db per test ==
real	0m52.985s
user	0m33.904s
sys	0m1.878s

== develop (migrate/rollback per test) ==
real	0m53.156s
user	0m0.411s
sys	0m0.075s
```

I think we could speed up the one of one db per test, there is an overhead of connecting to a new db, etc. But I didn't want to spend more time on this.

The proper fix is to migrate/seed and then the tests need to assert only the things they have changed and not expect an _empty_ database.