### PR TITLE
[#1796] Move akvo.lumen.import logic inside akvo.lumen.lib

### DIFF
--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -1,7 +1,7 @@
 (ns akvo.lumen.lib.dataset
   (:refer-clojure :exclude [update])
   (:require [akvo.lumen.endpoint.job-execution :as job-execution]
-            [akvo.lumen.import :as import]
+            [akvo.lumen.lib.import :as import]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.transformation.merge-datasets :as transformation.merge-datasets]
             [akvo.lumen.update :as update]

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -1,8 +1,8 @@
-(ns akvo.lumen.import
+(ns akvo.lumen.lib.import
   (:require [akvo.lumen.boundary.error-tracker :as error-tracker]
-            [akvo.lumen.import.common :as import]
-            [akvo.lumen.import.csv]
-            [akvo.lumen.import.flow]
+            [akvo.lumen.lib.import.common :as import]
+            [akvo.lumen.lib.import.csv]
+            [akvo.lumen.lib.import.flow]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.lib.raster :as raster]
             [akvo.lumen.util :as util]

--- a/backend/src/akvo/lumen/lib/import/common.clj
+++ b/backend/src/akvo/lumen/lib/import/common.clj
@@ -1,4 +1,4 @@
-(ns akvo.lumen.import.common
+(ns akvo.lumen.lib.import.common
   (:require [clojure.java.io :as io]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]

--- a/backend/src/akvo/lumen/lib/import/csv.clj
+++ b/backend/src/akvo/lumen/lib/import/csv.clj
@@ -1,5 +1,5 @@
-(ns akvo.lumen.import.csv
-  (:require [akvo.lumen.import.common :as import]
+(ns akvo.lumen.lib.import.csv
+  (:require [akvo.lumen.lib.import.common :as import]
             [clojure.data.csv :as csv]
             [clojure.java.io :as io]
             [clojure.java.jdbc :as jdbc]

--- a/backend/src/akvo/lumen/lib/import/flow.clj
+++ b/backend/src/akvo/lumen/lib/import/flow.clj
@@ -1,9 +1,9 @@
-(ns akvo.lumen.import.flow
+(ns akvo.lumen.lib.import.flow
   (:require [akvo.commons.psql-util :as pg]
-            [akvo.lumen.import.common :as import]
-            [akvo.lumen.import.flow-common :as flow-common]
-            [akvo.lumen.import.flow-v2 :as v2]
-            [akvo.lumen.import.flow-v3 :as v3]))
+            [akvo.lumen.lib.import.common :as import]
+            [akvo.lumen.lib.import.flow-common :as flow-common]
+            [akvo.lumen.lib.import.flow-v2 :as v2]
+            [akvo.lumen.lib.import.flow-v3 :as v3]))
 
 
 (defmethod import/dataset-importer "AKVO_FLOW"

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -1,6 +1,6 @@
-(ns akvo.lumen.import.flow-common
+(ns akvo.lumen.lib.import.flow-common
   (:require [akvo.commons.psql-util :as pg]
-            [akvo.lumen.import.common :as import]
+            [akvo.lumen.lib.import.common :as import]
             [cheshire.core :as json]
             [clj-http.client :as http]
             [clojure.java.jdbc :as jdbc]

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -1,7 +1,7 @@
-(ns akvo.lumen.import.flow-v2
+(ns akvo.lumen.lib.import.flow-v2
   (:require [akvo.commons.psql-util :as pg]
-            [akvo.lumen.import.common :as import]
-            [akvo.lumen.import.flow-common :as flow-common]
+            [akvo.lumen.lib.import.common :as import]
+            [akvo.lumen.lib.import.flow-common :as flow-common]
             [cheshire.core :as json]
             [clj-http.client :as http]
             [clojure.java.jdbc :as jdbc]

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -1,7 +1,7 @@
-(ns akvo.lumen.import.flow-v3
-  (:require [akvo.lumen.import.common :as import]
-            [akvo.lumen.import.flow-common :as flow-common]
-            [akvo.lumen.import.flow-v2 :as v2])
+(ns akvo.lumen.lib.import.flow-v3
+  (:require [akvo.lumen.lib.import.common :as import]
+            [akvo.lumen.lib.import.flow-common :as flow-common]
+            [akvo.lumen.lib.import.flow-v2 :as v2])
   (:import [java.time Instant]))
 
 (defn question-type->lumen-type

--- a/backend/src/akvo/lumen/lib/raster_impl.clj
+++ b/backend/src/akvo/lumen/lib/raster_impl.clj
@@ -1,6 +1,6 @@
 (ns akvo.lumen.lib.raster-impl
   (:require [akvo.lumen.endpoint.job-execution :as job-execution]
-            [akvo.lumen.import.common :as import]
+            [akvo.lumen.lib.import.common :as import]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.update :as update]
             [akvo.lumen.util :as util]

--- a/backend/src/akvo/lumen/transformation/geo.clj
+++ b/backend/src/akvo/lumen/transformation/geo.clj
@@ -1,6 +1,6 @@
 (ns akvo.lumen.transformation.geo
   "Geometry data transformations"
-  (:require [akvo.lumen.import.common :as import]
+  (:require [akvo.lumen.lib.import.common :as import]
             [akvo.lumen.transformation.engine :as engine]
             [clojure.java.jdbc :as jdbc]
             [clojure.tools.logging :as log]

--- a/backend/src/akvo/lumen/update.clj
+++ b/backend/src/akvo/lumen/update.clj
@@ -1,6 +1,6 @@
 (ns akvo.lumen.update
   (:require [akvo.lumen.boundary.error-tracker :as error-tracker]
-            [akvo.lumen.import.common :as import]
+            [akvo.lumen.lib.import.common :as import]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.transformation.engine :as engine]
             [akvo.lumen.util :as util]

--- a/backend/test/akvo/lumen/lib/import/csv_test.clj
+++ b/backend/test/akvo/lumen/lib/import/csv_test.clj
@@ -1,4 +1,4 @@
-(ns akvo.lumen.import.csv-test
+(ns akvo.lumen.lib.import.csv-test
   {:functional true}
   (:require [akvo.lumen.fixtures :refer [*tenant-conn*
                                          tenant-conn-fixture

--- a/backend/test/akvo/lumen/lib/import/raster_test.clj
+++ b/backend/test/akvo/lumen/lib/import/raster_test.clj
@@ -1,8 +1,7 @@
-(ns akvo.lumen.import.raster-test
+(ns akvo.lumen.lib.import.raster-test
   (:require [clojure.test :refer :all]
             [akvo.lumen.fixtures :refer [*tenant-conn*
                                          tenant-conn-fixture]]
-            #_[akvo.lumen.import.raster :refer :all]
             [clojure.java.io :as io]
             [clojure.java.jdbc :as jdbc]))
 

--- a/backend/test/akvo/lumen/test_utils.clj
+++ b/backend/test/akvo/lumen/test_utils.clj
@@ -1,6 +1,6 @@
 (ns akvo.lumen.test-utils
   (:require [akvo.lumen.component.tenant-manager :refer [pool]]
-            [akvo.lumen.import :refer [do-import]]
+            [akvo.lumen.lib.import :refer [do-import]]
             [akvo.lumen.util :refer [squuid]]
             [clojure.edn :as edn]
             [clojure.spec.test.alpha :as stest]


### PR DESCRIPTION
- [ ] **Update release notes if necessary**
Relates to #1796 
