### PR TITLE
[#1796] Move current protocols to akvo.lumen.protocols ns

### DIFF
--- a/backend/src/akvo/lumen/component/emailer.clj
+++ b/backend/src/akvo/lumen/component/emailer.clj
@@ -1,20 +1,18 @@
 (ns akvo.lumen.component.emailer
   (:require [cheshire.core :as json]
             [clj-http.client :as client]
+            [akvo.lumen.protocols :as p]
             [clojure.tools.logging :as log]
             [integrant.core :as ig]))
 
-(defprotocol SendEmail
-  (send-email [this recipients email] "Send email"))
-
 (defrecord DevEmailer []
-  SendEmail
+  p/SendEmail
   (send-email [this recipients email]
     (log/info recipients)
     (log/info email)))
 
 (defrecord MailJetV3Emailer [config]
-  SendEmail
+  p/SendEmail
   (send-email [{{credentials :credentials
                  from-email  :from-email
                  from-name   :from-name} :config}

--- a/backend/src/akvo/lumen/component/error_tracker.clj
+++ b/backend/src/akvo/lumen/component/error_tracker.clj
@@ -1,5 +1,6 @@
 (ns akvo.lumen.component.error-tracker
-  (:require [integrant.core :as ig]
+  (:require [akvo.lumen.protocols :as p]
+            [integrant.core :as ig]
             [raven-clj.core :as raven]
             [raven-clj.interfaces :as raven-interface]))
 
@@ -19,15 +20,12 @@
 (defmethod ig/init-key :akvo.lumen.component.error-tracker/prod  [_ {:keys [config] :as opts}]
   (sentry-error-tracker (-> config :error-tracker)))
 
-(defprotocol IErrorTracker
-  (track [this error]))
-
 (defn event-map [error]
   (let [text (str (ex-data error))]
     {:extra {:ex-data (subs text 0 (min (count text) 4096))}
      :message (.getMessage error)}))
 
-(extend-protocol IErrorTracker
+(extend-protocol p/IErrorTracker
 
   SentryErrorTracker
   (track [{:keys [dsn]} error]

--- a/backend/src/akvo/lumen/component/keycloak.clj
+++ b/backend/src/akvo/lumen/component/keycloak.clj
@@ -2,47 +2,13 @@
   "We leverage Keycloak groups for tenant partition and admin roles.
    More info can be found in the Keycloak integration doc spec."
   (:require [akvo.lumen.lib :as lib]
+            [akvo.lumen.protocols :as p]
             [cheshire.core :as json]
             [clj-http.client :as client]
             [integrant.core :as ig]
             [clojure.set :as set]
             [clojure.tools.logging :as log]
             [ring.util.response :refer [response]]))
-
-
-(defprotocol KeycloakUserManagement
-  (add-user-with-email
-    [this tenant-label email]
-    "Add user to tenant")
-
-  (create-user
-    [this request-headers email]
-    "Create user")
-
-  (demote-user-from-admin
-    [this tenant author-claims user-id]
-    "Demote tenant admin to member")
-
-  (promote-user-to-admin
-    [this tenant author-claims user-id]
-    "Promote existing tenant member to admin")
-
-  (reset-password
-    [this request-headers user-id tmp-password]
-    "Set temporary user password")
-
-  (remove-user
-    [this tenant author-claims user-id]
-    "Remove user from tenant")
-
-  (user?
-    [this email]
-    "Predicate to see if the email has a user in KC")
-
-  (users
-    [this tenant-label]
-    "List tenants users"))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helper fns
@@ -258,7 +224,7 @@
 ;;;
 
 (defrecord KeycloakAgent [issuer openid-config api-root]
-  KeycloakUserManagement
+  p/KeycloakUserManagement
   (add-user-with-email [{:keys [api-root] :as keycloak} tenant-label email]
     (let [request-headers (request-headers keycloak)
           user-id (get (fetch-user-by-email request-headers api-root email)

--- a/backend/src/akvo/lumen/component/tenant_manager.clj
+++ b/backend/src/akvo/lumen/component/tenant_manager.clj
@@ -3,6 +3,7 @@
   We use the first domain label e.g. t1 in t1.lumen.akvo.org to dispatch."
   (:require [akvo.lumen.lib :as lib]
             [akvo.lumen.lib.aes :as aes]
+            [akvo.lumen.protocols :as p]
             [clojure.tools.logging :as log]
             [integrant.core :as ig]
             [clojure.string :as str]
@@ -43,13 +44,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Component
 ;;;
-
-(defprotocol TenantConnection
-  (connection [this label] "Connection based on a tenant dns label.")
-  (uri [this label] "Database URI based on a tenant dns label."))
-
-(defprotocol TenantAdmin
-  (current-plan [this label] "Get the current plan."))
 
 (defn pool
   "Created a Hikari connection pool."
@@ -92,14 +86,14 @@
       (get label))))
 
 (defrecord TenantManager [db config]
-  TenantConnection
+  p/TenantConnection
   (connection [{:keys [tenants]} label]
     @(::spec (get-or-create-tenant db config tenants label)))
 
   (uri [{:keys [tenants]} label]
     (::uri (get-or-create-tenant db config tenants label)))
 
-  TenantAdmin
+  p/TenantAdmin
   (current-plan [{:keys [db]} label]
     (:tier (select-current-plan (:spec db) {:label label}))))
 

--- a/backend/src/akvo/lumen/endpoint/aggregation.clj
+++ b/backend/src/akvo/lumen/endpoint/aggregation.clj
@@ -1,5 +1,5 @@
 (ns akvo.lumen.endpoint.aggregation
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.endpoint.commons.http :as http]
             [akvo.lumen.lib.aggregation :as aggregation]
             [cheshire.core :as json]
@@ -9,7 +9,7 @@
 
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/aggregation" {:keys [tenant query-params] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
       (GET "/:dataset-id/:visualisation-type" [dataset-id visualisation-type]
         (if-let [query (get query-params "query")]
           (try

--- a/backend/src/akvo/lumen/endpoint/collection.clj
+++ b/backend/src/akvo/lumen/endpoint/collection.clj
@@ -1,12 +1,12 @@
 (ns akvo.lumen.endpoint.collection
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.collection :as collection]            
             [compojure.core :refer :all]
             [integrant.core :as ig]))
 
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/collections" {:keys [params tenant] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
 
       (GET "/" _
         (collection/all tenant-conn))

--- a/backend/src/akvo/lumen/endpoint/dashboard.clj
+++ b/backend/src/akvo/lumen/endpoint/dashboard.clj
@@ -1,5 +1,5 @@
 (ns akvo.lumen.endpoint.dashboard
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.dashboard :as dashboard]
             [compojure.core :refer :all]
             [integrant.core :as ig]))
@@ -7,7 +7,7 @@
 (defn endpoint [{:keys [tenant-manager]}]
 
   (context "/api/dashboards" {:keys [params tenant] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
 
       (GET "/" _
         (dashboard/all tenant-conn))

--- a/backend/src/akvo/lumen/endpoint/data_source.clj
+++ b/backend/src/akvo/lumen/endpoint/data_source.clj
@@ -1,12 +1,12 @@
 (ns akvo.lumen.endpoint.data-source
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.data-source :as data-source]
             [compojure.core :refer :all]
             [integrant.core :as ig]))
 
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/data-source/job-execution" {:keys [tenant]}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
       (context "/:id/status/:status" [id status]
                (DELETE "/" _
                        (data-source/delete tenant-conn id status))))))

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -1,12 +1,12 @@
 (ns akvo.lumen.endpoint.dataset
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.dataset :as dataset]
             [compojure.core :refer :all]
             [integrant.core :as ig]))
 
 (defn endpoint [{:keys [config error-tracker tenant-manager]}]
   (context "/api/datasets" {:keys [params tenant] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
 
       (GET "/" _
         (dataset/all tenant-conn))

--- a/backend/src/akvo/lumen/endpoint/invite.clj
+++ b/backend/src/akvo/lumen/endpoint/invite.clj
@@ -1,5 +1,5 @@
 (ns akvo.lumen.endpoint.invite
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.user :as user]
             [compojure.core :refer :all]
             [integrant.core :as ig]))
@@ -13,7 +13,7 @@
 
 (defn endpoint [{:keys [config emailer keycloak tenant-manager]}]
   (context "/api/admin/invites" {:keys [jwt-claims params tenant] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
       (GET "/" _
         (user/active-invites tenant-conn))
 
@@ -28,7 +28,7 @@
 
 (defn verify-endpoint [{:keys [config keycloak tenant-manager]}]
   (context "/verify" {:keys [tenant] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
       (GET "/:id" [id]
         (user/verify-invite keycloak tenant-conn tenant id
                             (location (:invite-redirect config) request))))))

--- a/backend/src/akvo/lumen/endpoint/job_execution.clj
+++ b/backend/src/akvo/lumen/endpoint/job_execution.clj
@@ -1,12 +1,12 @@
 (ns akvo.lumen.endpoint.job-execution
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.job-execution :as job-execution]
             [compojure.core :refer :all]
             [integrant.core :as ig]))
 
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/job_executions" {:keys [tenant]}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
       (context "/:id" [id]
         (GET "/" _
           (job-execution/status tenant-conn id))))))

--- a/backend/src/akvo/lumen/endpoint/library.clj
+++ b/backend/src/akvo/lumen/endpoint/library.clj
@@ -1,5 +1,5 @@
 (ns akvo.lumen.endpoint.library
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.dataset :as dataset]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.lib
@@ -13,7 +13,7 @@
 
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/library" {:keys [tenant] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
       (GET "/" _
         (lib/ok
          {:dashboards (variant/value (dashboard/all tenant-conn))

--- a/backend/src/akvo/lumen/endpoint/public.clj
+++ b/backend/src/akvo/lumen/endpoint/public.clj
@@ -1,5 +1,5 @@
 (ns akvo.lumen.endpoint.public
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.public :as public]
             [cheshire.core :as json]
             [compojure.core :refer :all]
@@ -7,7 +7,7 @@
 
 (defn endpoint [{:keys [tenant-manager config]}]
   (context "/share" {:keys [params tenant headers] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
 
       (GET "/:id" [id]
         (let [password (get headers "x-password")]

--- a/backend/src/akvo/lumen/endpoint/raster.clj
+++ b/backend/src/akvo/lumen/endpoint/raster.clj
@@ -1,12 +1,12 @@
 (ns akvo.lumen.endpoint.raster
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [integrant.core :as ig]
             [akvo.lumen.lib.raster :as raster]
             [compojure.core :refer :all]))
 
 (defn endpoint [{:keys [tenant-manager config]}]
   (context "/api/rasters" {:keys [params tenant] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
 
       (GET "/" _
         (raster/all tenant-conn))

--- a/backend/src/akvo/lumen/endpoint/resource.clj
+++ b/backend/src/akvo/lumen/endpoint/resource.clj
@@ -1,13 +1,13 @@
 (ns akvo.lumen.endpoint.resource
-  (:require [akvo.lumen.component.tenant-manager :refer [connection current-plan]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.resource :as resource]
             [compojure.core :refer :all]
             [integrant.core :as ig]))
 
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/resources" {:keys [params tenant] :as request}
-           (let-routes [tenant-conn (connection tenant-manager tenant)
-                        current-plan (current-plan tenant-manager tenant)]
+           (let-routes [tenant-conn (p/connection tenant-manager tenant)
+                        current-plan (p/current-plan tenant-manager tenant)]
 
              (GET "/" _
                   (resource/all tenant-conn current-plan)))))

--- a/backend/src/akvo/lumen/endpoint/share.clj
+++ b/backend/src/akvo/lumen/endpoint/share.clj
@@ -1,12 +1,12 @@
 (ns akvo.lumen.endpoint.share
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.share :as share]
             [compojure.core :refer :all]
             [integrant.core :as ig]))
 
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/shares" {:keys [params tenant] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
 
       (POST "/" {:keys [body] :as request}
         (share/fetch tenant-conn body))

--- a/backend/src/akvo/lumen/endpoint/split_column.clj
+++ b/backend/src/akvo/lumen/endpoint/split_column.clj
@@ -1,5 +1,5 @@
 (ns akvo.lumen.endpoint.split-column
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.lib.transformation.split-column :as transformation]
             [cheshire.core :as json]
@@ -20,7 +20,7 @@
            (context "/:dataset-id" [dataset-id]
                     (GET "/pattern-analysis" _
                          (let [query           (json/parse-string (get query-params "query") keyword)
-                               tenant-conn     (connection tenant-manager tenant)
+                               tenant-conn     (p/connection tenant-manager tenant)
                                dataset-version (latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id})
                                sql-query       {:table-name  (:table-name dataset-version)
                                                 :column-name (:columnName query)

--- a/backend/src/akvo/lumen/endpoint/tier.clj
+++ b/backend/src/akvo/lumen/endpoint/tier.clj
@@ -1,12 +1,12 @@
 (ns akvo.lumen.endpoint.tier
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.tier :as tier]
             [compojure.core :refer :all]
             [integrant.core :as ig]))
 
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/tiers" {:keys [tenant]}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
       (GET "/" _
         (tier/all tenant-conn)))))
 

--- a/backend/src/akvo/lumen/endpoint/transformation.clj
+++ b/backend/src/akvo/lumen/endpoint/transformation.clj
@@ -1,12 +1,12 @@
 (ns akvo.lumen.endpoint.transformation
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.transformation :as t]
             [compojure.core :refer :all]
             [integrant.core :as ig]))
 
 (defn endpoint [{:keys [tenant-manager caddisfly]}]
   (context "/api/transformations" {:keys [tenant] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
       (context "/:dataset-id" [dataset-id]
         (POST "/transform" {:keys [body] :as request}
               (t/apply {:tenant-conn tenant-conn :caddisfly caddisfly}

--- a/backend/src/akvo/lumen/endpoint/visualisation.clj
+++ b/backend/src/akvo/lumen/endpoint/visualisation.clj
@@ -1,5 +1,5 @@
 (ns akvo.lumen.endpoint.visualisation
-  (:require [akvo.lumen.component.tenant-manager :refer [connection]]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.visualisation :as visualisation]
             [akvo.lumen.lib.visualisation.maps :as maps]
             [compojure.core :refer :all]
@@ -8,7 +8,7 @@
 (defn endpoint [{:keys [config tenant-manager]}]
 
   (context "/api/visualisations" {:keys [params tenant] :as request}
-    (let-routes [tenant-conn (connection tenant-manager tenant)]
+    (let-routes [tenant-conn (p/connection tenant-manager tenant)]
       (GET "/" _
         (visualisation/all tenant-conn))
 

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.import
   (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.import.common :as import]
+            [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.import.csv]
             [akvo.lumen.lib.import.flow]
             [akvo.lumen.lib :as lib]
@@ -80,9 +81,9 @@
     (try
       (let [spec (:spec (data-source-spec-by-job-execution-id conn {:job-execution-id job-execution-id}))]
         (with-open [importer (import/dataset-importer (get spec "source") config)]
-          (let [columns (import/columns importer)]
+          (let [columns (p/columns importer)]
             (import/create-dataset-table conn table-name columns)
-            (doseq [record (map import/coerce-to-sql (import/records importer))]
+            (doseq [record (map import/coerce-to-sql (p/records importer))]
               (jdbc/insert! conn table-name record))
             (successful-import conn job-execution-id table-name columns spec claims data-source))))
       (catch Throwable e

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -1,5 +1,5 @@
 (ns akvo.lumen.lib.import
-  (:require [akvo.lumen.component.error-tracker :as error-tracker]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.import.common :as import]
             [akvo.lumen.lib.import.csv]
             [akvo.lumen.lib.import.flow]
@@ -88,7 +88,7 @@
       (catch Throwable e
         (failed-import conn job-execution-id (.getMessage e) table-name)
         (log/error e)
-        (error-tracker/track error-tracker e)
+        (p/track error-tracker e)
         (throw e)))))
 
 (defn handle-import-request [tenant-conn config error-tracker claims data-source]

--- a/backend/src/akvo/lumen/lib/import/common.clj
+++ b/backend/src/akvo/lumen/lib/import/common.clj
@@ -2,57 +2,9 @@
   (:require [clojure.java.io :as io]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
+            [akvo.lumen.protocols :as p]
             [org.akvo.resumed :as resumed])
   (:import [org.postgis PGgeometry]))
-
-(defprotocol DatasetImporter
-  "
-  A protocol for importing datasets into Lumen. A typical implementation
-  should also implement `java.io.Closeable` since some data sources are
-  backed by resources that need to be released.
-
-  Example:
-  (reify
-    Closeable
-    (close [this])
-
-    DatasetImporter
-    (columns [this]
-      [{:id :a :type :text :title \"A\"}
-       {:id :b :type :number :title \"B\"}
-       {:id :c :type :date :title \"C\"}])
-    (records [this]
-      [{:a \"foo\"
-        :b 42
-        :c (Instant/now)}
-       {:a \"bar\"
-        :b 3.14
-        :c (Instant/now)}
-  "
-
-  (columns [this]
-    "Returns a sequence of column specifications of the dataset to be imported.
-     A column specification is a map with keys
-
-     Required:
-       :type - The lumen type of the column. Currently :text, :number, :date, :geoshape or :geopoint
-       :title - The title of the column
-       :id - The internal id of the column (as a keyword). The id must be
-             lowercase alphanumeric ([a-z][a-z0-9]*)
-
-     Optional:
-       :key - True if this column is required to be non-null and unique")
-  (records [this]
-    "Returns a sequence of record data. A record is a map of column ids to values.
-     The type of the value depends on the type of the column where
-
-       :text - java.lang.String
-       :number - java.lang.Number
-       :date - java.time.Instant
-       :geoshape - Geoshape
-                   Well-known text (WKT) shape (POLYGON or MULTIPOLYGON)
-       :geopoint - Geopoint
-                   Well-known text (WKT) shape (POINT)"))
 
 (defn dispatch-on-kind [spec]
   (let [kind (get spec "kind")]
@@ -123,10 +75,7 @@
 
 (defrecord Geopoint [wkt-string])
 
-(defprotocol CoerceToSql
-  (coerce [this]))
-
-(extend-protocol CoerceToSql
+(extend-protocol p/CoerceToSql
   java.lang.String
   (coerce [value] value)
   java.lang.Number
@@ -148,7 +97,7 @@
 (defn coerce-to-sql [record]
   (reduce-kv
    (fn [result k v]
-     (assoc result k (when v (coerce v))))
+     (assoc result k (when v (p/coerce v))))
    {}
    record))
 

--- a/backend/src/akvo/lumen/lib/import/csv.clj
+++ b/backend/src/akvo/lumen/lib/import/csv.clj
@@ -1,5 +1,6 @@
 (ns akvo.lumen.lib.import.csv
   (:require [akvo.lumen.lib.import.common :as import]
+            [akvo.lumen.protocols :as p]
             [clojure.data.csv :as csv]
             [clojure.java.io :as io]
             [clojure.java.jdbc :as jdbc]
@@ -84,7 +85,7 @@
                        (repeat column-count :text))
         column-spec (get-column-tuples column-titles column-types)]
     (reify
-      import/DatasetImporter
+      p/DatasetImporter
       (columns [this] column-spec)
       (records [this]
         (data-records column-spec rows))

--- a/backend/src/akvo/lumen/lib/import/flow.clj
+++ b/backend/src/akvo/lumen/lib/import/flow.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.import.flow
   (:require [akvo.commons.psql-util :as pg]
             [akvo.lumen.lib.import.common :as import]
+            [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.import.flow-common :as flow-common]
             [akvo.lumen.lib.import.flow-v2 :as v2]
             [akvo.lumen.lib.import.flow-v3 :as v3]))
@@ -21,7 +22,7 @@
     (reify
       java.io.Closeable
       (close [this])
-      import/DatasetImporter
+      p/DatasetImporter
       (columns [this]
         (cond
           (<= version 2) (v2/dataset-columns (flow-common/form @survey formId) version)

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -1,6 +1,5 @@
 (ns akvo.lumen.lib.import.flow-common
   (:require [akvo.commons.psql-util :as pg]
-            [akvo.lumen.lib.import.common :as import]
             [cheshire.core :as json]
             [clj-http.client :as http]
             [clojure.java.jdbc :as jdbc]

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -1,6 +1,5 @@
 (ns akvo.lumen.lib.import.flow-v2
   (:require [akvo.commons.psql-util :as pg]
-            [akvo.lumen.lib.import.common :as import]
             [akvo.lumen.lib.import.flow-common :as flow-common]
             [cheshire.core :as json]
             [clj-http.client :as http]

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -1,5 +1,5 @@
 (ns akvo.lumen.lib.update
-  (:require [akvo.lumen.component.error-tracker :as error-tracker]
+  (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.import.common :as import]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.lib.transformation.engine :as engine]
@@ -141,6 +141,6 @@
                      data-source-spec))
         (catch Exception e
           (failed-update tenant-conn job-execution-id (.getMessage e))
-          (error-tracker/track error-tracker e)
+          (p/track error-tracker e)
           (log/error e))))
     (lib/ok {"updateId" job-execution-id})))

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -101,11 +101,11 @@
         initial-dataset-version (initial-dataset-version-to-update-by-dataset-id conn {:dataset-id dataset-id})
         imported-dataset-columns (vec (:columns initial-dataset-version))]
     (with-open [importer (import/dataset-importer (get data-source-spec "source") config)]
-      (let [importer-columns (import/columns importer)]
+      (let [importer-columns (p/columns importer)]
         (if-not (compatible-columns? imported-dataset-columns importer-columns)
           (failed-update conn job-execution-id "Column mismatch")
           (do (import/create-dataset-table conn table-name importer-columns)
-              (doseq [record (map import/coerce-to-sql (import/records importer))]
+              (doseq [record (map import/coerce-to-sql (p/records importer))]
                 (jdbc/insert! conn table-name record))
               (clone-data-table conn
                                 {:from-table table-name

--- a/backend/src/akvo/lumen/lib/user.clj
+++ b/backend/src/akvo/lumen/lib/user.clj
@@ -1,8 +1,8 @@
 (ns akvo.lumen.lib.user
-  (:require [akvo.lumen.component.emailer :as emailer]
-            [akvo.lumen.component.keycloak :as keycloak]
+  (:require [akvo.lumen.component.keycloak :as keycloak]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.lib.share :refer [random-url-safe-string]]
+            [akvo.lumen.protocols :as p]
             [clj-time.coerce :as c]
             [clj-time.core :as t]
             [clojure.string :as str]
@@ -24,7 +24,7 @@
                     {:author-email (get author-claims "email")
                      :invite-id invite-id
                      :location location})]
-    (emailer/send-email emailer [email] {"Subject" "Akvo Lumen invite"
+    (p/send-email emailer [email] {"Subject" "Akvo Lumen invite"
                                          "Text-part" text-part})))
 
 (defn create-new-account-and-invite-to-tenant
@@ -53,7 +53,7 @@
                      :location location
                      :tmp-password tmp-password})]
     (keycloak/reset-password keycloak request-headers user-id tmp-password)
-    (emailer/send-email emailer [email] {"Subject" "Akvo Lumen invite"
+    (p/send-email emailer [email] {"Subject" "Akvo Lumen invite"
                                          "Text-part" text-part})))
 
 (defn create-invite

--- a/backend/src/akvo/lumen/lib/user.clj
+++ b/backend/src/akvo/lumen/lib/user.clj
@@ -32,7 +32,7 @@
   [emailer keycloak tenant-conn location email
    {:strs [name] :as author-claims}]
   (let [request-headers (keycloak/request-headers keycloak)
-        user-id (as-> (keycloak/create-user keycloak request-headers email) x
+        user-id (as-> (p/create-user keycloak request-headers email) x
                   (:headers x)
                   (get x "Location")
                   (str/split x #"/")
@@ -52,7 +52,7 @@
                      :invite-id invite-id
                      :location location
                      :tmp-password tmp-password})]
-    (keycloak/reset-password keycloak request-headers user-id tmp-password)
+    (p/reset-password keycloak request-headers user-id tmp-password)
     (p/send-email emailer [email] {"Subject" "Akvo Lumen invite"
                                          "Text-part" text-part})))
 
@@ -66,7 +66,7 @@
     (keycloak/tenant-member?
      keycloak tenant email) (lib/bad-request
                              {"reason" "Already tenant member"})
-    (keycloak/user?
+    (p/user?
      keycloak email) (invite-to-tenant emailer tenant-conn location email
                                        author-claims)
     :else
@@ -92,7 +92,7 @@
   "Try and consume invite; Add user to keycloak; redirect to app."
   [keycloak tenant-conn tenant id location]
   (if-let [{:keys [email]} (first (consume-invite tenant-conn {:id id}))]
-    (if-let [accepted (keycloak/add-user-with-email keycloak tenant email)]
+    (if-let [accepted (p/add-user-with-email keycloak tenant email)]
       (lib/redirect location)
       (lib/unprocessable-entity (format "<html><body>%s</body></html>"
                                         "Problem completing your invite.")))
@@ -100,16 +100,16 @@
 
 (defn users
   [keycloak tenant]
-  (keycloak/users keycloak tenant))
+  (p/users keycloak tenant))
 
 (defn remove-user
   [keycloak tenant author-claims user-id]
-  (keycloak/remove-user keycloak tenant author-claims user-id))
+  (p/remove-user keycloak tenant author-claims user-id))
 
 (defn demote-user-from-admin
   [keycloak tenant author-claims user-id]
-  (keycloak/demote-user-from-admin keycloak tenant author-claims user-id))
+  (p/demote-user-from-admin keycloak tenant author-claims user-id))
 
 (defn promote-user-to-admin
   [keycloak tenant author-claims user-id]
-  (keycloak/promote-user-to-admin keycloak tenant author-claims user-id))
+  (p/promote-user-to-admin keycloak tenant author-claims user-id))

--- a/backend/src/akvo/lumen/protocols.clj
+++ b/backend/src/akvo/lumen/protocols.clj
@@ -1,0 +1,4 @@
+(ns akvo.lumen.protocols)
+
+(defprotocol IErrorTracker
+  (track [this error]))

--- a/backend/src/akvo/lumen/protocols.clj
+++ b/backend/src/akvo/lumen/protocols.clj
@@ -2,3 +2,10 @@
 
 (defprotocol IErrorTracker
   (track [this error]))
+
+(defprotocol TenantConnection
+  (connection [this label] "Connection based on a tenant dns label.")
+  (uri [this label] "Database URI based on a tenant dns label."))
+
+(defprotocol TenantAdmin
+  (current-plan [this label] "Get the current plan."))

--- a/backend/src/akvo/lumen/protocols.clj
+++ b/backend/src/akvo/lumen/protocols.clj
@@ -45,3 +45,55 @@
   (users
     [this tenant-label]
     "List tenants users"))
+
+(defprotocol DatasetImporter
+  "
+  A protocol for importing datasets into Lumen. A typical implementation
+  should also implement `java.io.Closeable` since some data sources are
+  backed by resources that need to be released.
+
+  Example:
+  (reify
+    Closeable
+    (close [this])
+
+    DatasetImporter
+    (columns [this]
+      [{:id :a :type :text :title \"A\"}
+       {:id :b :type :number :title \"B\"}
+       {:id :c :type :date :title \"C\"}])
+    (records [this]
+      [{:a \"foo\"
+        :b 42
+        :c (Instant/now)}
+       {:a \"bar\"
+        :b 3.14
+        :c (Instant/now)}
+  "
+
+  (columns [this]
+    "Returns a sequence of column specifications of the dataset to be imported.
+     A column specification is a map with keys
+
+     Required:
+       :type - The lumen type of the column. Currently :text, :number, :date, :geoshape or :geopoint
+       :title - The title of the column
+       :id - The internal id of the column (as a keyword). The id must be
+             lowercase alphanumeric ([a-z][a-z0-9]*)
+
+     Optional:
+       :key - True if this column is required to be non-null and unique")
+  (records [this]
+    "Returns a sequence of record data. A record is a map of column ids to values.
+     The type of the value depends on the type of the column where
+
+       :text - java.lang.String
+       :number - java.lang.Number
+       :date - java.time.Instant
+       :geoshape - Geoshape
+                   Well-known text (WKT) shape (POLYGON or MULTIPOLYGON)
+       :geopoint - Geopoint
+                   Well-known text (WKT) shape (POINT)"))
+
+(defprotocol CoerceToSql
+  (coerce [this]))

--- a/backend/src/akvo/lumen/protocols.clj
+++ b/backend/src/akvo/lumen/protocols.clj
@@ -9,3 +9,6 @@
 
 (defprotocol TenantAdmin
   (current-plan [this label] "Get the current plan."))
+
+(defprotocol SendEmail
+  (send-email [this recipients email] "Send email"))

--- a/backend/src/akvo/lumen/protocols.clj
+++ b/backend/src/akvo/lumen/protocols.clj
@@ -12,3 +12,36 @@
 
 (defprotocol SendEmail
   (send-email [this recipients email] "Send email"))
+
+(defprotocol KeycloakUserManagement
+  (add-user-with-email
+    [this tenant-label email]
+    "Add user to tenant")
+
+  (create-user
+    [this request-headers email]
+    "Create user")
+
+  (demote-user-from-admin
+    [this tenant author-claims user-id]
+    "Demote tenant admin to member")
+
+  (promote-user-to-admin
+    [this tenant author-claims user-id]
+    "Promote existing tenant member to admin")
+
+  (reset-password
+    [this request-headers user-id tmp-password]
+    "Set temporary user password")
+
+  (remove-user
+    [this tenant author-claims user-id]
+    "Remove user from tenant")
+
+  (user?
+    [this email]
+    "Predicate to see if the email has a user in KC")
+
+  (users
+    [this tenant-label]
+    "List tenants users"))


### PR DESCRIPTION
Reasoning behind these changes is that having currently these protocols defined and in use, we need to put them in a generic place (I've defined only one to put all together but we could create more specific namespaces if we need it) to decouple implementation. That's to say, service clients doesn't need to know where implementation lives 

Relates to #1796 specifically to https://github.com/akvo/akvo-lumen/issues/1796#issuecomment-441480602 and https://github.com/akvo/akvo-lumen/issues/1796#issuecomment-441519559

Review could iterate through commits thus they are isolated (Commit titles should serve as doc porpose)

- [ ] **Update release notes if necessary**

