### PR TITLE
Decouple a.l.transformation from a.l.update (Connect #1796)

### DIFF
--- a/backend/src/akvo/lumen/lib/transformation/derive.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive.clj
@@ -2,7 +2,6 @@
   (:require [akvo.lumen.lib.dataset.utils :as dataset.utils]
             [akvo.lumen.lib.transformation.derive.js-engine :as js-engine]
             [akvo.lumen.lib.transformation.engine :as engine]
-            [akvo.lumen.lib.update :as update]
             [akvo.lumen.util :as util]
             [clj-time.coerce :as tc]
             [clojure.java.jdbc :as jdbc]
@@ -55,7 +54,7 @@
            "references" []}
           (parse-row-object-references code)))
 
-(defmethod update/adapt-transformation :core/derive
+(defmethod engine/adapt-transformation :core/derive
   [op-spec older-columns new-columns]
   (update-in op-spec ["args" "code"]
              #(columnName>columnTitle (compute-transformation-code % older-columns) new-columns)))

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -15,7 +15,7 @@
 (hugsql/def-db-fns "akvo/lumen/lib/transformation.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")
 
-(defn successful-update
+(defn- successful-update
   "On a successful update we need to create a new dataset-version that
   is similar to the previous one, except with an updated :version and
   pointing to the new table-name, imported-table-name and columns. We
@@ -27,7 +27,7 @@
   (drop-table conn {:table-name (:table-name dataset-version)})
   (update-successful-job-execution conn {:id job-execution-id}))
 
-(defn failed-update [conn job-execution-id reason]
+(defn- failed-update [conn job-execution-id reason]
   (update-failed-job-execution conn {:id job-execution-id
                                      :reason [reason]}))
 
@@ -40,48 +40,49 @@
     (set/subset? (set (map #(select-keys % [:id :type]) imported-columns))
                  (set (map #(select-keys % [:id :type]) columns)))))
 
-(defn do-update [conn config dataset-id data-source-id job-execution-id data-source-spec]
-  (with-open [importer (import/dataset-importer (get data-source-spec "source") config)]
-    (let [initial-dataset-version (initial-dataset-version-to-update-by-dataset-id conn {:dataset-id dataset-id})
-          imported-dataset-columns (vec (:columns initial-dataset-version))
-          importer-columns (p/columns importer)]
-      (if-not (compatible-columns? imported-dataset-columns importer-columns)
-        (failed-update conn job-execution-id "Column mismatch")
-        (let [table-name (util/gen-table-name "ds")
-              imported-table-name (util/gen-table-name "imported")]
-          (postgres/create-dataset-table conn table-name importer-columns)
-          (doseq [record (map postgres/coerce-to-sql (p/records importer))]
-            (jdbc/insert! conn table-name record))
-          (clone-data-table conn {:from-table table-name
-                                  :to-table imported-table-name}
-                            {}
-                            {:transaction? false})
-          (let [dataset-version (latest-dataset-version-by-dataset-id conn {:dataset-id dataset-id})
-                coerce-column-fn (fn [{:keys [title id type key multiple-id multiple-type] :as column}]
-                                   (cond-> {"type" (name type)
-                                            "title" title
-                                            "columnName" (name id)
-                                            "sort" nil
-                                            "direction" nil
-                                            "hidden" false}
-                                     key           (assoc "key" (boolean key))
-                                     multiple-type (assoc "multipleType" multiple-type)
-                                     multiple-id   (assoc "multipleId" multiple-id)))
-                importer-columns (mapv coerce-column-fn importer-columns)]
-            (engine/apply-transformation-log conn
-                                             table-name
-                                             imported-table-name
-                                             importer-columns
-                                             imported-dataset-columns
-                                             dataset-id
-                                             job-execution-id
-                                             dataset-version)
-            (successful-update conn
-                               job-execution-id
-                               dataset-id
-                               table-name
-                               imported-table-name
-                               dataset-version)))))))
+(defn- do-update [tenant-conn config dataset-id data-source-id job-execution-id data-source-spec]
+  (jdbc/with-db-transaction [conn tenant-conn]
+    (with-open [importer (import/dataset-importer (get data-source-spec "source") config)]
+      (let [initial-dataset-version  (initial-dataset-version-to-update-by-dataset-id conn {:dataset-id dataset-id})
+            imported-dataset-columns (vec (:columns initial-dataset-version))
+            importer-columns         (p/columns importer)]
+        (if-not (compatible-columns? imported-dataset-columns importer-columns)
+          (failed-update conn job-execution-id "Column mismatch")
+          (let [table-name          (util/gen-table-name "ds")
+                imported-table-name (util/gen-table-name "imported")]
+            (postgres/create-dataset-table conn table-name importer-columns)
+            (doseq [record (map postgres/coerce-to-sql (p/records importer))]
+              (jdbc/insert! conn table-name record))
+            (clone-data-table conn {:from-table table-name
+                                    :to-table   imported-table-name}
+                              {}
+                              {:transaction? false})
+            (let [dataset-version  (latest-dataset-version-by-dataset-id conn {:dataset-id dataset-id})
+                  coerce-column-fn (fn [{:keys [title id type key multiple-id multiple-type] :as column}]
+                                     (cond-> {"type" (name type)
+                                              "title" title
+                                              "columnName" (name id)
+                                              "sort" nil
+                                              "direction" nil
+                                              "hidden" false}
+                                       key           (assoc "key" (boolean key))
+                                       multiple-type (assoc "multipleType" multiple-type)
+                                       multiple-id   (assoc "multipleId" multiple-id)))
+                  importer-columns (mapv coerce-column-fn importer-columns)]
+              (engine/apply-transformation-log conn
+                                               table-name
+                                               imported-table-name
+                                               importer-columns
+                                               imported-dataset-columns
+                                               dataset-id
+                                               job-execution-id
+                                               dataset-version)
+              (successful-update conn
+                                 job-execution-id
+                                 dataset-id
+                                 table-name
+                                 imported-table-name
+                                 dataset-version))))))))
 
 (defn update-dataset [tenant-conn config error-tracker dataset-id data-source-id data-source-spec]
   (let [job-execution-id (str (util/squuid))]
@@ -89,13 +90,12 @@
                                                       :data-source-id data-source-id})
     (future
       (try
-        (jdbc/with-db-transaction [tx-conn tenant-conn]
-          (do-update tx-conn
-                     config
-                     dataset-id
-                     data-source-id
-                     job-execution-id
-                     data-source-spec))
+        (do-update tenant-conn
+                   config
+                   dataset-id
+                   data-source-id
+                   job-execution-id
+                   data-source-spec)
         (catch Exception e
           (failed-update tenant-conn job-execution-id (.getMessage e))
           (p/track error-tracker e)

--- a/backend/test/akvo/lumen/lib/transformation/derive_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation/derive_test.clj
@@ -1,5 +1,6 @@
 (ns akvo.lumen.lib.transformation.derive-test
   (:require [akvo.lumen.lib.transformation.derive :as derive]
+            [akvo.lumen.lib.transformation.engine :as engine]
             [akvo.lumen.lib.update :as update]
             [clojure.test.check.generators :as gen]
             [clojure.string :as str]
@@ -140,7 +141,7 @@
         computed (derive/compute-transformation-code (get-in t1 ["args" "code"]) older-columns)]
     (is (= code_v2 (derive/columnName>columnTitle computed new-columns)))
     (is (= (update-in t1 ["args" "code"] (constantly code_v2))
-           (update/adapt-transformation t1 older-columns new-columns)))
+           (engine/adapt-transformation t1 older-columns new-columns)))
     ))
 
 

--- a/backend/test/akvo/lumen/lib/transformation/engine_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation/engine_test.clj
@@ -8,6 +8,8 @@
             [clojure.test :refer :all]
             [hugsql.core :as hugsql]))
 
+(def try-apply-operation #'akvo.lumen.lib.transformation.engine/try-apply-operation)
+
 (hugsql/def-db-fns "akvo/lumen/lib/transformation/engine_test.sql")
 
 (def columns (vec (take 3 (json/parse-string (slurp (io/resource "columns_test.json"))))))


### PR DESCRIPTION
- [ ] **Update release notes if necessary**
move apply-transformation-log from a.l.update to transformation.engine
thus transformation logic should live under a.l.transformation namespace
+ also hide a.l.t.engine/try-apply-operation 
+ tidy up