### PR TITLE
Extract common functions from a.l.l.t.engine to a.l.util (Connect #1796)

### DIFF
--- a/backend/src/akvo/lumen/lib/transformation/change_datatype.clj
+++ b/backend/src/akvo/lumen/lib/transformation/change_datatype.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.transformation.change-datatype
   (:require [akvo.lumen.lib.transformation.engine :as engine]
             [akvo.lumen.postgres :as postgres]
+            [akvo.lumen.util :as util]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -13,8 +14,8 @@
   (let [{column-name "columnName"
          new-type "newType"
          parse-format "parseFormat"} (engine/args op-spec)]
-    (boolean (and (engine/valid-type? new-type)
-                  (engine/valid-column-name? column-name)
+    (boolean (and (util/valid-type? new-type)
+                  (util/valid-column-name? column-name)
                   (if (= new-type "date")
                     (string? parse-format)
                     true)))))

--- a/backend/src/akvo/lumen/lib/transformation/combine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/combine.clj
@@ -1,5 +1,6 @@
 (ns akvo.lumen.lib.transformation.combine
   (:require [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.util :as util]
             [clojure.tools.logging :as log]
             [hugsql.core :as hugsql]))
 
@@ -11,7 +12,7 @@
   (let [{[column-name-1 column-name-2] "columnNames"
          column-title "newColumnTitle"
          separator "separator"} (engine/args op-spec)]
-    (boolean (and (every? engine/valid-column-name? [column-name-1 column-name-2])
+    (boolean (and (every? util/valid-column-name? [column-name-1 column-name-2])
                   (string? column-title)
                   (string? separator)
                   (= (engine/error-strategy op-spec) "fail")))))

--- a/backend/src/akvo/lumen/lib/transformation/delete_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/delete_column.clj
@@ -1,5 +1,6 @@
 (ns akvo.lumen.lib.transformation.delete-column
   (:require [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.util :as util]
             [clojure.tools.logging :as log]
             [clojure.string :as str]
             [akvo.lumen.lib.transformation.merge-datasets :as merge-datasets]
@@ -12,7 +13,7 @@
 
 (defmethod engine/valid? :core/delete-column
   [op-spec]
-  (engine/valid-column-name? (col-name op-spec)))
+  (util/valid-column-name? (col-name op-spec)))
 
 (defn- merged-sources-with-column
   "search for merged-datasets with this column related"

--- a/backend/src/akvo/lumen/lib/transformation/derive.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive.clj
@@ -77,7 +77,7 @@
                 ::column-title
                 ::column-type]} (args op-spec)]
     (and (string? column-title) 
-         (engine/valid-type? column-type)
+         (util/valid-type? column-type)
          (#{"fail" "leave-empty" "delete-row"} (engine/error-strategy op-spec))
          (js-engine/evaluable? code))))
 

--- a/backend/src/akvo/lumen/lib/transformation/engine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/engine.clj
@@ -54,17 +54,6 @@
     (throw (ex-info "Not a number" {:n n})))
   n)
 
-(defn valid-column-name? [s]
-  (and (string? s)
-       (boolean (re-find #"^[a-z][a-z0-9_]*$" s))))
-
-(defn valid-dataset-id? [s]
-  (and (string? s)
-       (boolean (re-find #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" s))))
-
-(defn valid-type? [s]
-  (#{"text" "number" "date" "geopoint"} s))
-
 (defn column-index
   "Returns the column index for a given column-name"
   [columns column-name]

--- a/backend/src/akvo/lumen/lib/transformation/geo.clj
+++ b/backend/src/akvo/lumen/lib/transformation/geo.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.transformation.geo
   "Geometry data transformations"
   (:require [akvo.lumen.lib.import.common :as import]
+            [akvo.lumen.util :as util]
             [akvo.lumen.lib.transformation.engine :as engine]
             [akvo.lumen.postgres :as postgres]
             [clojure.java.jdbc :as jdbc]
@@ -14,7 +15,7 @@
   [op-spec]
   (let [{:strs [columnNameLat columnNameLong]} (engine/args op-spec)]
     (boolean
-      (every? engine/valid-column-name? [columnNameLat columnNameLong]))))
+      (every? util/valid-column-name? [columnNameLat columnNameLong]))))
 
 (defmethod engine/valid? :core/generate-geopoints
   [op-spec]

--- a/backend/src/akvo/lumen/lib/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/lib/transformation/merge_datasets.clj
@@ -1,5 +1,6 @@
 (ns akvo.lumen.lib.transformation.merge-datasets
-  (:require [akvo.lumen.lib.transformation.engine :as engine]
+  (:require [akvo.lumen.util :as util]
+            [akvo.lumen.lib.transformation.engine :as engine]
             [clojure.java.jdbc :as jdbc]
             [clojure.tools.logging :as log]
             [clojure.set :as set]
@@ -18,14 +19,14 @@
   [op-spec]
   (let [source (get-in op-spec ["args" "source"])
         target (get-in op-spec ["args" "target"])]
-    (and (engine/valid-column-name? (get source "mergeColumn"))
-         (every? engine/valid-column-name? (get source "mergeColumns"))
-         (engine/valid-dataset-id? (get source "datasetId"))
+    (and (util/valid-column-name? (get source "mergeColumn"))
+         (every? util/valid-column-name? (get source "mergeColumns"))
+         (util/valid-dataset-id? (get source "datasetId"))
          (let [aggregation-column (get source "aggregationColumn")]
            (or (nil? aggregation-column)
-               (engine/valid-column-name? aggregation-column)))
+               (util/valid-column-name? aggregation-column)))
          (#{"ASC" "DESC"} (get source "aggregationDirection"))
-         (engine/valid-column-name? (get target "mergeColumn")))))
+         (util/valid-column-name? (get target "mergeColumn")))))
 
 (defn merge-column-names-map
   "Returns a map translating source merge column names to new column names that can be used

--- a/backend/src/akvo/lumen/lib/transformation/multiple_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/multiple_column.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.transformation.multiple-column
   (:require [akvo.lumen.lib.dataset.utils :as u]
             [akvo.lumen.lib.transformation.engine :as t.engine]
+            [akvo.lumen.util :as util]
             [akvo.lumen.lib.transformation.multiple-column.caddisfly :as t.m-c.caddisfly]
             [clojure.tools.logging :as log]
             [clojure.walk :refer (keywordize-keys stringify-keys)]))
@@ -11,7 +12,7 @@
         columns-to-extract        (filter :extract (:columns args))]
     (and
      (or (:extractImage args) (not-empty columns-to-extract))
-     (every? (comp t.engine/valid-type? :type) columns-to-extract)
+     (every? (comp util/valid-type? :type) columns-to-extract)
      (#{"fail" "leave-empty" "delete-row"} onError))))
 
 (defn- apply-operation [deps table-name columns op-spec]

--- a/backend/src/akvo/lumen/lib/transformation/rename_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/rename_column.clj
@@ -1,5 +1,7 @@
 (ns akvo.lumen.lib.transformation.rename-column
-  (:require [akvo.lumen.lib.transformation.engine :as engine]))
+  (:require [akvo.lumen.util :as util]
+            [akvo.lumen.lib.transformation.engine :as engine]
+            ))
 
 (defn col-name [op-spec]
   (get (engine/args op-spec) "columnName"))
@@ -9,7 +11,7 @@
 
 (defmethod engine/valid? :core/rename-column
   [op-spec]
-  (and (engine/valid-column-name? (col-name op-spec))
+  (and (util/valid-column-name? (col-name op-spec))
        (string? (new-col-title op-spec))))
 
 (defmethod engine/apply-operation :core/rename-column

--- a/backend/src/akvo/lumen/lib/transformation/reverse_geocode.clj
+++ b/backend/src/akvo/lumen/lib/transformation/reverse_geocode.clj
@@ -1,5 +1,6 @@
 (ns akvo.lumen.lib.transformation.reverse-geocode
   (:require [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.util :as util]
             [clojure.java.jdbc :as jdbc]
             [hugsql.core :as hugsql]))
 
@@ -11,10 +12,10 @@
   [op-spec]
   (let [{:strs [target source]} (get op-spec "args")]
     (and (string? (get target "title"))
-         (engine/valid-column-name? (get target "geopointColumn"))
-         (engine/valid-dataset-id? (get source "datasetId"))
-         (engine/valid-column-name? (get source "geoshapeColumn"))
-         (engine/valid-column-name? (get source "mergeColumn")))))
+         (util/valid-column-name? (get target "geopointColumn"))
+         (util/valid-dataset-id? (get source "datasetId"))
+         (util/valid-column-name? (get source "geoshapeColumn"))
+         (util/valid-column-name? (get source "mergeColumn")))))
 
 (defn table-qualify [table-name column-name]
   (str table-name "." column-name))

--- a/backend/src/akvo/lumen/lib/transformation/sort_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/sort_column.clj
@@ -1,17 +1,18 @@
 (ns akvo.lumen.lib.transformation.sort-column
   (:require [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.util :as util]
             [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/transformation/sort_column.sql")
 
 (defmethod engine/valid? :core/sort-column
   [op-spec]
-  (and (engine/valid-column-name? (get (engine/args op-spec) "columnName"))
+  (and (util/valid-column-name? (get (engine/args op-spec) "columnName"))
        (boolean (#{"ASC" "DESC"} (get (engine/args op-spec) "sortDirection")))))
 
 (defmethod engine/valid? :core/remove-sort
   [op-spec]
-  (engine/valid-column-name? (get (engine/args op-spec) "columnName")))
+  (util/valid-column-name? (get (engine/args op-spec) "columnName")))
 
 (defn- get-sort-idx
   "Returns the next sort index for a given vector of columns"

--- a/backend/src/akvo/lumen/lib/transformation/split_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/split_column.clj
@@ -1,6 +1,8 @@
 (ns akvo.lumen.lib.transformation.split-column
   (:require [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.util :as util]
             [clojure.java.jdbc :as jdbc]
+            
             [akvo.lumen.postgres :as postgres]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
@@ -43,7 +45,7 @@
 (defmethod engine/valid? :core/split-column
   [op-spec]
   (let [{:keys [onError op args] :as op-spec} (keywordize-keys op-spec)]
-    (and (engine/valid-column-name? (col-name args))
+    (and (util/valid-column-name? (col-name args))
          (pattern* args)
          (new-column-name args))))
 

--- a/backend/src/akvo/lumen/lib/transformation/text.clj
+++ b/backend/src/akvo/lumen/lib/transformation/text.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.transformation.text
   "Simple text transforms"
   (:require [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.util :as util]
             [clojure.tools.logging :as log]
             [hugsql.core :as hugsql]))
 
@@ -17,7 +18,7 @@
      :columns columns}))
 
 (defn valid? [op-spec]
-  (engine/valid-column-name? (get (engine/args op-spec) "columnName")))
+  (util/valid-column-name? (get (engine/args op-spec) "columnName")))
 
 (defmethod engine/valid? :core/trim [op-spec]
   (valid? op-spec))

--- a/backend/src/akvo/lumen/lib/visualisation/maps.clj
+++ b/backend/src/akvo/lumen/lib/visualisation/maps.clj
@@ -62,14 +62,14 @@
            :else false)))
 
 (defn conform-create-args [layers]
-  (let [dataset-id (get (first (filter (fn[layer] (engine/valid-dataset-id? (get layer "datasetId"))) layers)) "datasetId")
-        raster-id (get (first (filter (fn[layer] (engine/valid-dataset-id? (get layer "rasterId"))) layers)) "rasterId")]
+  (let [dataset-id (get (first (filter (fn[layer] (util/valid-dataset-id? (get layer "datasetId"))) layers)) "datasetId")
+        raster-id (get (first (filter (fn[layer] (util/valid-dataset-id? (get layer "rasterId"))) layers)) "rasterId")]
     (cond
       (and (not dataset-id) (not raster-id))
       (throw (ex-info "No valid datasetID"
                       {"reason" "No valid datasetID"}))
 
-      (some (fn [layer] (not (valid-location? layer engine/valid-column-name?))) (filter (fn [layer] (not (= (get layer "layerType") "raster"))) layers))
+      (some (fn [layer] (not (valid-location? layer util/valid-column-name?))) (filter (fn [layer] (not (= (get layer "layerType") "raster"))) layers))
       (throw (ex-info "Location spec not valid"
                       {"reason" "Location spec not valid"}))
 

--- a/backend/src/akvo/lumen/util.clj
+++ b/backend/src/akvo/lumen/util.clj
@@ -56,3 +56,15 @@
             (assoc index (get item key) item))
           {}
           coll))
+
+(defn valid-column-name? [s]
+  (and (string? s)
+       (boolean (re-find #"^[a-z][a-z0-9_]*$" s))))
+
+(defn valid-dataset-id? [s]
+  (and (string? s)
+       (boolean (re-find #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" s))))
+
+(defn valid-type? [s]
+  (#{"text" "number" "date" "geopoint"} s))
+

--- a/backend/test/akvo/lumen/lib/visualisation/maps_test.clj
+++ b/backend/test/akvo/lumen/lib/visualisation/maps_test.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.visualisation.maps-test
   (:require [akvo.lumen.lib.visualisation.maps :as m]
             [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.util :as util]
             [akvo.lumen.lib.visualisation.map-config :as map-config]
             [clojure.test :refer :all]))
 
@@ -12,7 +13,7 @@
 
 (deftest invalid-location-spec?
 
-  (let [p engine/valid-column-name?]
+  (let [p util/valid-column-name?]
 
     (testing "Sanity check for invalid location specs"
       (is (not (m/valid-location? nil p)))


### PR DESCRIPTION
Theoretically and later on, we'll need to create some kind of domain model namespace
to grab this common functionality a bit better
But so far let's put common things into util namespace

- [ ] **Update release notes if necessary**
