### PR TITLE
Add transformation and db specs (Connect #1441 & #1450 & #1858)

### DIFF
--- a/backend/project.clj
+++ b/backend/project.clj
@@ -84,7 +84,8 @@
                                     [org.clojure/tools.nrepl "0.2.13"]
                                     [eftest "0.5.1"]
                                     [com.gearswithingears/shrubbery "0.4.1"]
-                                    [kerodon "0.9.0"]]
+                                    [kerodon "0.9.0"]
+                                    [robert/hooke "1.3.0"]]
                    :source-paths   ["dev/src" "specs"]
                    :resource-paths ["dev/resources" "test/resources"]
                    :repl-options   {:init-ns dev
@@ -99,6 +100,7 @@
    :project/test  {:source-paths   ["specs"]
                    :resource-paths ["test/resources"]
                    :dependencies [[org.clojure/test.check "0.10.0-alpha3"]
-                                  [diehard "0.7.2" :exclusions [org.clojure/spec.alpha]]]
+                                  [diehard "0.7.2" :exclusions [org.clojure/spec.alpha]]
+                                  [robert/hooke "1.3.0"]]
                    :env
                    {:db {:uri "jdbc:postgresql://postgres/lumen?user=lumen&password=password"}}}})

--- a/backend/specs/akvo/lumen/specs.clj
+++ b/backend/specs/akvo/lumen/specs.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.specs
   (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
+            [akvo.lumen.util :refer (squuid)]
             [clojure.tools.logging :as log]))
 
 (defn keyname [key] (str (namespace key) "/" (name key)))
@@ -10,3 +11,11 @@
 
 (defn sample [s amount]
   (map first (s/exercise s amount)))
+(defn str-uuid? [v]
+  (when (some? v)
+    (uuid? (read-string (format "#uuid \"%s\"" v)))))
+
+(s/def ::str-uuid
+  (s/with-gen
+    str-uuid?
+    #(s/gen (reduce (fn [c _] (conj c (str (squuid)))) #{} (range 100)))))

--- a/backend/specs/akvo/lumen/specs.clj
+++ b/backend/specs/akvo/lumen/specs.clj
@@ -9,8 +9,12 @@
 (defn sample-with-gen [s map-gen amount]
   (map first (s/exercise s amount map-gen)))
 
-(defn sample [s amount]
-  (map first (s/exercise s amount)))
+(defn sample
+  ([s]
+   (map first (s/exercise s 1)))
+  ([s amount]
+   (map first (s/exercise s amount))))
+
 (defn str-uuid? [v]
   (when (some? v)
     (uuid? (read-string (format "#uuid \"%s\"" v)))))

--- a/backend/specs/akvo/lumen/specs/db.clj
+++ b/backend/specs/akvo/lumen/specs/db.clj
@@ -1,0 +1,16 @@
+(ns akvo.lumen.specs.db
+  (:require [clojure.spec.alpha :as s])
+  (:import com.zaxxer.hikari.HikariDataSource))
+
+(s/def ::uri (s/with-gen string?
+	       #(s/gen #{"jdbc:postgresql://postgres/lumen?user=lumen&password=password&ssl=true"})))
+
+(s/def ::datasource (s/with-gen (partial instance? HikariDataSource)
+		      #(s/gen #{(HikariDataSource.)})))
+
+(s/def ::spec (s/keys :req-un [::datasource]))
+
+(s/def ::db (s/keys :req-un [::datasource]
+		    :opt-un [::uri]))
+
+(s/def ::tenant-connection ::spec)

--- a/backend/specs/akvo/lumen/specs/import.clj
+++ b/backend/specs/akvo/lumen/specs/import.clj
@@ -20,7 +20,7 @@
                                                                                          {(adapt-spec (first t)) (last t)})  1)
                                 (lumen.s/sample (kw->column-spec t) 1))) types-gens-tuple)
                        (mapv #(assoc (first %2)
-                                     :id (str "c" %)
+                                     :id (keyword (str "c" %))
                                      :title (str "Column" (inc %)))
                              (range (count headers))))
         _         (do

--- a/backend/specs/akvo/lumen/specs/import.clj
+++ b/backend/specs/akvo/lumen/specs/import.clj
@@ -1,5 +1,6 @@
 (ns akvo.lumen.specs.import
   (:require [akvo.lumen.specs :as lumen.s]
+            [akvo.lumen.util :as u]
             [akvo.lumen.specs.import.column :as c]
             [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
@@ -25,7 +26,7 @@
                              (range (count headers))))
         _         (do
                     ;; "ensure columns headers are valid specs"
-                    (reduce #(assert (s/valid? ::c/header %2) %) [] columns))
+                    (reduce (fn [_ i] (u/conform ::c/header i)) [] columns))
         row-types (map (fn [t]
                          (let [t (if (sequential? t) (first t) t)]
                            (kw->body-spec t))) types-gens-tuple)
@@ -39,6 +40,6 @@
                           [] (range rows-count))
         _         (do
                    ;;  "ensure column bodies (cells) are valid specs"
-                    (reduce #(assert (s/valid? ::c/body %2) %) [] (flatten rows0)))
+                    (reduce (fn [_ i] (u/conform ::c/body i)) [] (flatten rows0)))
         rows      (mapv #(mapv (fn [c] (dissoc c :type)) %) rows0)]
     {:columns columns :rows rows}))

--- a/backend/specs/akvo/lumen/specs/import/values.clj
+++ b/backend/specs/akvo/lumen/specs/import/values.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.specs.import.values
   (:require [clojure.spec.alpha :as s]
             [akvo.lumen.util :refer (squuid)]
+            [akvo.lumen.specs :as lumen.s :refer (sample)]
             [akvo.lumen.lib.import.csv :as csv]))
 
 (def polygon

--- a/backend/specs/akvo/lumen/specs/import/values.clj
+++ b/backend/specs/akvo/lumen/specs/import/values.clj
@@ -38,19 +38,10 @@
 
 (s/def ::key boolean?)
 
-(defn str-uuid? [v]
-  (when (some? v)
-    (uuid? (read-string (format "#uuid \"%s\"" v)))))
-
-(s/def ::str-uuid
-  (s/with-gen
-    str-uuid?
-    #(s/gen (reduce (fn [c _] (conj c (str (squuid)))) #{} (range 100)))))
-
 ;; alias and custom generator doesn't work so far
 ;; https://dev.clojure.org/jira/browse/CLJ-2079
 (s/def ::multiple-id (s/with-gen
-                       str-uuid?
+                       lumen.s/str-uuid?
                        #(s/gen (reduce (fn [c _] (conj c (str (squuid)))) #{} (range 100)))))
 
 (s/def ::multiple-type #{:caddisfly})

--- a/backend/specs/akvo/lumen/specs/import/values.clj
+++ b/backend/specs/akvo/lumen/specs/import/values.clj
@@ -29,8 +29,8 @@
     #(s/gen #{polygon multipolygon})))
 
 (s/def ::id (s/with-gen
-                     string?
-                     #(s/gen #{"c1" "c2" "c3"})))
+                     keyword?
+                     #(s/gen #{:c1 :c2 :c3})))
 
 (s/def ::title (s/with-gen
                         string?

--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -1,0 +1,56 @@
+(ns akvo.lumen.specs.transformation
+  (:require [akvo.lumen.specs :as lumen.s :refer (sample)]
+            [akvo.lumen.specs.db :as db.s]
+            [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.util :as u]
+            [akvo.lumen.specs.import.column :as import.column.s]
+            [akvo.lumen.specs.import.values :as i.values.s]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.string :as string]
+            [clojure.tools.logging :as log]))
+
+(create-ns  'akvo.lumen.specs.db.dataset-version)
+(alias 'db.dsv 'akvo.lumen.specs.db.dataset-version)
+
+(create-ns  'akvo.lumen.specs.db.dataset-version.column)
+(alias 'db.dsv.column 'akvo.lumen.specs.db.dataset-version.column)
+
+
+(s/def ::db.dsv/id ::lumen.s/str-uuid)
+(s/def ::db.dsv/dataset-id ::lumen.s/str-uuid)
+(s/def ::db.dsv/job-execution-id (s/nilable ::lumen.s/str-uuid))
+
+(defn- ds-table-name? [s]
+  (let [[_ uuid] (string/split  s #"ds_")]
+       (lumen.s/str-uuid? uuid)))
+
+(s/def ::db.dsv/table-name (s/with-gen
+                             (s/and string? ds-table-name?)
+                             #(s/gen (into #{} (take 5 (repeatedly (fn [] (str "ds_" (u/squuid)))))))))
+
+(s/def ::db.dsv/version int?)
+(s/def ::db.dsv/transformations any?) ;; TODO complete ... 
+
+(s/def ::db.dsv.column/key boolean?)
+(s/def ::db.dsv.column/hidden boolean?)
+(s/def ::sort #{"asc" "dsc"})
+
+(s/def ::db.dsv.column/sort (s/nilable ::sort))
+(s/def ::db.dsv.column/direction (s/nilable string?))
+(s/def ::db.dsv.column/columnName string?)
+
+(s/def ::db.dsv.column/id (s/nilable keyword?))
+(s/def ::db.dsv/column* (s/keys :req-un [::db.dsv.column/hidden ::db.dsv.column/direction
+                                         ::db.dsv.column/sort ::db.dsv.column/columnName]))
+
+(s/def ::db.dsv/column (s/merge ::import.column.s/header ::db.dsv/column*))
+
+(s/def ::db.dsv/columns (s/coll-of ::db.dsv/column :kind vector? :distinct true))
+
+
+
+(s/def ::next-dataset-version (s/keys :req-un [::db.dsv/id ::db.dsv/dataset-id
+                                               ::db.dsv/job-execution-id ::db.dsv/table-name
+                                               ::db.dsv/imported-table-name ::db.dsv/version
+                                               ::db.dsv/transformations ::db.dsv/columns]))

--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -23,11 +23,19 @@
 
 (defn- ds-table-name? [s]
   (let [[_ uuid] (string/split  s #"ds_")]
-       (lumen.s/str-uuid? uuid)))
+       (lumen.s/str-uuid? (string/replace uuid "_" "-"))))
 
 (s/def ::db.dsv/table-name (s/with-gen
                              (s/and string? ds-table-name?)
-                             #(s/gen (into #{} (take 5 (repeatedly (fn [] (str "ds_" (u/squuid)))))))))
+                             #(s/gen (into #{} (take 5 (repeatedly (partial u/gen-table-name "ds")))))))
+
+(defn- imported-table-name? [s]
+  (let [[_ uuid] (string/split  s #"imported_")]
+       (lumen.s/str-uuid? (string/replace uuid "_" "-"))))
+
+(s/def ::db.dsv/imported-table-name (s/with-gen
+                                      (s/and string? imported-table-name?)
+                                      #(s/gen (into #{} (take 5 (repeatedly (fn [] (str "imported_" (u/squuid)))))))))
 
 (s/def ::db.dsv/version int?)
 (s/def ::db.dsv/transformations any?) ;; TODO complete ... 

--- a/backend/src/akvo/lumen/lib/transformation/multiple_column/caddisfly.clj
+++ b/backend/src/akvo/lumen/lib/transformation/multiple_column/caddisfly.clj
@@ -1,8 +1,10 @@
 (ns akvo.lumen.lib.transformation.multiple-column.caddisfly
   (:require [akvo.lumen.postgres :as postgres]
             [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.lib.dataset.utils :refer (find-column)]
             [akvo.lumen.component.caddisfly :refer (get-schema)]
             [cheshire.core :as json]
+            [clojure.walk :refer (keywordize-keys)]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
@@ -53,8 +55,7 @@
   [{:keys [tenant-conn caddisfly] :as deps} table-name current-columns op-spec]
   (jdbc/with-db-transaction [conn tenant-conn]
     (let [{:keys [onError op args]} op-spec
-
-          selected-column (-> args :selectedColumn)
+          selected-column (keywordize-keys (find-column current-columns (:columnName (-> args :selectedColumn))))
 
           caddisfly-schema (if-let [multiple-id (:multipleId selected-column)]
                              (get-schema caddisfly multiple-id)

--- a/backend/src/akvo/lumen/lib/transformation/split_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/split_column.clj
@@ -1,8 +1,8 @@
 (ns akvo.lumen.lib.transformation.split-column
   (:require [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.lib.dataset.utils :refer (find-column)]
             [akvo.lumen.util :as util]
             [clojure.java.jdbc :as jdbc]
-            
             [akvo.lumen.postgres :as postgres]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
@@ -56,7 +56,8 @@
     (map #(assoc % :columnName %2 :id %2) new-columns indexes)))
 
 (defn columns-to-extract [prefix number-new-rows selected-column columns]
-  (let [base-column (dissoc selected-column :type :columnName)
+  (let [selected-column (keywordize-keys (find-column columns (:columnName selected-column)))
+        base-column (dissoc selected-column :type :columnName)
         new-columns (map #(assoc base-column :title (str prefix "-" %) :type "text")
                          (range 1 (inc number-new-rows)))]
     (add-name-to-new-columns columns new-columns)))

--- a/backend/src/akvo/lumen/util.clj
+++ b/backend/src/akvo/lumen/util.clj
@@ -71,12 +71,13 @@
 (defn valid-type? [s]
   (#{"text" "number" "date" "geopoint"} s))
 
-
-(defn conform
+(defn conform  
+  ([s d]
+   (when-not (s/valid? s d)
+     (throw (ex-info (str s " spec problem!")
+                     {:message (s/explain-str s d)
+                      :data d})))
+   d)
   ([s d adapter]
    (conform s (adapter d))
-   d)
-  ([s d]
-   (when-not (s/valid? s d) (throw (ex-info (str s " spec problem!") {:message (s/explain-str s d)
-                                                                      :data d})))
    d))

--- a/backend/src/akvo/lumen/util.clj
+++ b/backend/src/akvo/lumen/util.clj
@@ -20,8 +20,10 @@
 
 (defn gen-table-name
   "Generates a table name using a UUID suffix"
-  [prefix]
-  (str prefix "_" (str/replace (java.util.UUID/randomUUID) "-" "_")))
+  ([]
+   (gen-table-name nil))
+  ([prefix]
+   (str (when prefix (str prefix "_")) (str/replace (java.util.UUID/randomUUID) "-" "_"))))
 
 (defn conform-email
   "Returns valid email or throws."

--- a/backend/src/akvo/lumen/util.clj
+++ b/backend/src/akvo/lumen/util.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.util
   (:require [clojure.string :as str]
             [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
             [org.akvo.resumed :as resumed]))
 
 (defn squuid
@@ -68,3 +69,12 @@
 (defn valid-type? [s]
   (#{"text" "number" "date" "geopoint"} s))
 
+
+(defn conform
+  ([s d adapter]
+   (conform s (adapter d))
+   d)
+  ([s d]
+   (when-not (s/valid? s d) (throw (ex-info (str s " spec problem!") {:message (s/explain-str s d)
+                                                                      :data d})))
+   d))

--- a/backend/test/akvo/lumen/fixtures.clj
+++ b/backend/test/akvo/lumen/fixtures.clj
@@ -1,5 +1,6 @@
 (ns akvo.lumen.fixtures
   (:require [akvo.lumen.component.error-tracker :refer [local-error-tracker]]
+            [akvo.lumen.component.caddisfly-test :refer (caddisfly)]
             [akvo.lumen.test-utils :as test-utils]
             [akvo.lumen.test-utils
              :refer
@@ -47,4 +48,12 @@
   "Returns a fixture that binds a local error tracker to *error-tracker*"
   [f]
   (binding [*error-tracker* (local-error-tracker {})]
+    (f)))
+
+(def ^:dynamic *caddisfly*)
+
+(defn caddisfly-fixture
+  "Returns a fixture that binds a local error tracker to *error-tracker*"
+  [f]
+  (binding [*caddisfly* (caddisfly)]
     (f)))

--- a/backend/test/akvo/lumen/test_utils.clj
+++ b/backend/test/akvo/lumen/test_utils.clj
@@ -119,3 +119,20 @@
           (if (= "OK" status)
             (:dataset_id (dataset-id-by-job-execution-id tenant-conn {:id updateId}))
             updateId))))))
+
+(defn rand-bol []
+  (if (= 0 (rand-int 2)) false true))
+
+(defn- replace-item
+  "Returns a list with the n-th item of l replaced by v."
+  [l n v]
+  (concat (take n l) (list v) (drop (inc n) l)))
+
+(defn at-least-one-true
+  "returns a seq of boolean with a minimum one true"
+  [c]
+  (let [res (for [r (range c)]
+              (rand-bol))]
+    (if (some true? res)
+      res
+      (replace-item res (rand-int c) true))))


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Relates to #1441 & #1450 & #1858 

Also conform in `test` and `dev` the new-dataset-version db call in import and transformation processes 

Thus we need some data adaptation for conforming the new-dataset-version payload, we can't use plain s/instrument facility for conforming the spec. As an alternative the PR uses robert-hooke library to check specs that need this data adaptation in `dev` and `test` environments