### PR TITLE
#1854 hide bubble legend if no label set

### DIFF
--- a/client/src/components/charts/BubbleChart.jsx
+++ b/client/src/components/charts/BubbleChart.jsx
@@ -235,7 +235,7 @@ class BubbleChart extends Component {
             horizontal={!horizontal}
             title={legendTitle}
             description={
-              <BubbleLegend title={legendDescription} />
+              legendDescription && <BubbleLegend title={legendDescription} />
             }
             data={series.data.map(({ key }) => key)}
             colorMapping={

--- a/client/src/components/charts/BubbleLegend.jsx
+++ b/client/src/components/charts/BubbleLegend.jsx
@@ -6,7 +6,7 @@ import './BubbleLegend.scss';
 
 const MAX_LENGTH = 30;
 
-const BubbleLegend = ({ title }) => (title.length > MAX_LENGTH ? (
+const BubbleLegend = ({ title = '' }) => (title.length > MAX_LENGTH ? (
   <div className="BubbleLegend">
     <h4>
       <FormattedMessage id="size" />


### PR DESCRIPTION
this fixes a bug where we try render a bubble chart and the title for the bubble legend is not set

- [ ] **Update release notes if necessary**
