### PR TITLE
Add more work on  #1858 and #1450

### DIFF
--- a/backend/specs/akvo/lumen/specs/import.clj
+++ b/backend/specs/akvo/lumen/specs/import.clj
@@ -21,7 +21,7 @@
                                                                                          {(adapt-spec (first t)) (last t)})  1)
                                 (lumen.s/sample (kw->column-spec t) 1))) types-gens-tuple)
                        (mapv #(assoc (first %2)
-                                     :id (keyword (str "c" %))
+                                     :id (keyword (str "c" (inc %)))
                                      :title (str "Column" (inc %)))
                              (range (count headers))))
         _         (do

--- a/backend/specs/akvo/lumen/specs/import/column.clj
+++ b/backend/specs/akvo/lumen/specs/import/column.clj
@@ -1,9 +1,13 @@
 (ns akvo.lumen.specs.import.column
-  (:require [akvo.lumen.specs.import.values :as v]
+  (:require [akvo.lumen.specs :as lumen.s]
+            [akvo.lumen.specs.import.values :as v]
             [akvo.lumen.util :refer (squuid)]
+            [clj-time.coerce :as tcc]
+            [clj-time.core :as tc]
             [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
             [clojure.string :as string]
+            [clojure.test.check.generators :as tgen]
             [clojure.tools.logging :as log])
   (:import [akvo.lumen.postgres Geoshape Geopoint]
            [java.time Instant]))
@@ -67,9 +71,35 @@
 
 (s/def ::c.number/value double?)
 
-(s/def ::c.date/value (s/with-gen
-                        #(instance? Instant %)
-                        #(s/gen #{(Instant/parse "2017-12-03T10:15:30.00Z") (Instant/parse "2018-12-03T10:15:30.00Z")})))
+(def year-gen (tgen/choose 1976 2018))
+
+(def month-gen (tgen/choose 1 12))
+
+(def day-gen (tgen/choose 1 31))
+
+(def date-gen (tgen/such-that (fn [t]
+                                (try
+                                  (apply tc/date-time t)
+                                  (catch Exception e false)))
+                              (tgen/tuple year-gen month-gen day-gen)))
+
+(def instant-gen (tgen/fmap (fn [e] (Instant/ofEpochMilli (tcc/to-long (apply tc/date-time e)))) date-gen))
+
+(gen/sample date-gen 10)
+
+(gen/sample instant-gen 10)
+
+(def false-gen (gen/return false))
+
+(def text-year-gen (tgen/fmap str year-gen))
+
+(defn date-format-gen [fun] (tgen/fmap fun date-gen))
+
+(gen/sample (date-format-gen (fn [[y _ _]] (str y))) 10)
+
+(s/def ::c.date/value (s/with-gen #(instance? Instant %) (fn [] instant-gen)))
+
+(lumen.s/sample ::c.date/value)
 
 (s/def ::c.multiple/value (s/with-gen
                             string?

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -79,11 +79,17 @@
           (p/track error-tracker e)
           (throw e))))))
 
+(defn insert-data-source-db
+  "not all kind of things in data-source could be jsonify properly,
+  extracting here this functionality to be hookable in `dev` and `test`"
+  [tenant-conn data-source-id data-source]
+  (insert-data-source tenant-conn {:id data-source-id
+                                   :spec (json/generate-string data-source)}))
+
 (defn handle [tenant-conn config error-tracker claims data-source]
   (let [data-source-id (str (util/squuid))
         job-execution-id (str (util/squuid))]
-    (insert-data-source tenant-conn {:id data-source-id
-                                     :spec (json/generate-string data-source)})
+    (insert-data-source-db tenant-conn data-source-id data-source)
     (insert-job-execution tenant-conn {:id job-execution-id
                                        :data-source-id data-source-id})
     (execute tenant-conn config error-tracker job-execution-id data-source-id claims data-source)

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer.clj
@@ -1,7 +1,18 @@
 (ns akvo.lumen.lib.import.clj-data-importer
   (:require [akvo.lumen.lib.import.common :as common]
             [akvo.lumen.protocols :as p]
+            [robert.hooke :refer (add-hook) :as r]
+            [clojure.tools.logging :as log]
+            [akvo.lumen.lib.import :as l.import]
             [clojure.tools.logging :as log]))
+
+(defn new-insert-data-source
+  [f tenant-conn data-source-id data-source]
+  (log/info "hooking l.import/insert-data-source-db")
+  (f tenant-conn data-source-id (-> data-source (update-in ["source"] dissoc "data"))))
+
+(r/clear-hooks #'l.import/insert-data-source-db)
+(r/add-hook #'l.import/insert-data-source-db #'new-insert-data-source)
 
 (defn data-records [{:keys [columns rows]}]
   (for [row rows]

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
@@ -51,10 +51,10 @@
 	                                      "columnName"))))
 
       (is (= (map #(select-keys % ["type" "columnName"]) (:columns dataset))
-             '({"type" "text", "columnName" "c0"}
-	       {"type" "number", "columnName" "c1"})))
+             '({"type" "text", "columnName" "c1"}
+	       {"type" "number", "columnName" "c2"})))
 
-      (is (= (map keys stored-data) '((:rnum :c0 :c1) (:rnum :c0 :c1)))))))
+      (is (= (map keys stored-data) '((:rnum :c1 :c2) (:rnum :c1 :c2)))))))
 
 (deftest ^:functional test-update
   (testing "Testing update"

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -32,17 +32,17 @@
 (alias 'c.text 'akvo.lumen.specs.import.column.text)
 (alias 'i.values 'akvo.lumen.specs.import.values)
 
-(def ops (vec (json/parse-string (slurp (io/resource "ops.json")))))
-
-(def invalid-op (-> (take 3 ops)
-                    vec
-                    (update-in [1 "args"] dissoc "parseFormat")))
+(use-fixtures :once tu/spec-instrument caddisfly-fixture tenant-conn-fixture error-tracker-fixture)
 
 (hugsql/def-db-fns "akvo/lumen/lib/job-execution.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/transformation_test.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/transformation.sql")
 
-(use-fixtures :once tu/spec-instrument caddisfly-fixture tenant-conn-fixture error-tracker-fixture)
+(def ops (vec (json/parse-string (slurp (io/resource "ops.json")))))
+
+(def invalid-op (-> (take 3 ops)
+                    vec
+                    (update-in [1 "args"] dissoc "parseFormat")))
 
 (deftest op-validation
   (testing "op validation"
@@ -62,7 +62,7 @@
                                                                  :file "transformation_test.csv"})
           [tag _] (last (for [transformation ops]
                           (tf/apply {:tenant-conn *tenant-conn*} dataset-id {:type :transformation
-                                                              :transformation transformation})))]
+                                                                             :transformation transformation})))]
       (is (= ::lib/ok tag)))))
 
 (deftest ^:functional test-import-and-transform

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -435,7 +435,7 @@
   (let [dataset-id (import-file *tenant-conn* *error-tracker*
                                        {:dataset-name "origin-dataset"
                                         :kind "clj"
-                                        :data (i-c/sample-imported-dataset [:text :number :number :text] 2)})
+                                        :data (i-c/sample-imported-dataset [:text :number :number :date :multiple] 2)})
         apply-transformation (partial tf/apply {:tenant-conn *tenant-conn*} dataset-id)]
     (let [[tag _] (apply-transformation {:type :transformation
                                          :transformation {"op" "core/delete-column"
@@ -444,7 +444,7 @@
       (is (= ::lib/ok tag))
       (let [{:keys [columns transformations]} (latest-dataset-version-by-dataset-id *tenant-conn*
                                                                                     {:dataset-id dataset-id})]
-        (is (= ["c1" "c3" "c4"] (map #(get % "columnName") columns)))
+        (is (= ["c1" "c3" "c4" "c5"] (map #(get % "columnName") columns)))
         (let [{:strs [before after]} (get-in (last transformations) ["changedColumns" "c2"])]
           (is (= "c2" (get before "columnName")))
           (is (nil? after)))))))
@@ -493,7 +493,7 @@
       (assoc :rows (map #(assoc-in % [column-idx] (nth %2 column-idx)) (:rows target-data) (:rows origin-data)))))
 
 (deftest ^:functional merge-datasets-test
-  (let [origin-data (i-c/sample-imported-dataset [:text :number] 2)
+  (let [origin-data (i-c/sample-imported-dataset [:text :date] 2)
         target-data (replace-column origin-data (i-c/sample-imported-dataset [:text :number :number :text] 2) 0) 
         origin-dataset-id (import-file *tenant-conn* *error-tracker*
                                        {:dataset-name "origin-dataset"

--- a/backend/test/akvo/lumen/lib/transformation_test.sql
+++ b/backend/test/akvo/lumen/lib/transformation_test.sql
@@ -13,7 +13,7 @@ SELECT COUNT(*) AS total
   FROM :i:table-name
 
 -- :name get-data :? :*
-SELECT * FROM :i:table-name
+SELECT * FROM :i:table-name order by rnum
 
 -- :name table-exists :? :1
 SELECT EXISTS (


### PR DESCRIPTION
- [ ] **Update release notes if necessary**
All changes related to `test` and `spec` besides this commit https://github.com/akvo/akvo-lumen/pull/1878/commits/6698ffadebb7532a8fd06cd882559d2623ab5035 that makes possible fully import functionality of clj-data-importer `backend/test/akvo/lumen/lib/import/clj_data_importer.clj` 

- Add date generators
- Add core/merge-datasets transformation test
