### PR TITLE
Change transformation.op to string type

### DIFF
--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -78,24 +78,24 @@
 
 (s/def ::transformation.engine/onError #{"leave-empty" "fail" "delete-row" "default-value"})
 
-(s/def ::transformation.engine/op #{:core/change-datatype
-				    :core/combine
-				    :core/delete-column
-				    :core/derive
-                                    :core/extract-multiple
-				    :core/filter-column
-				    :core/generate-geopoints
-				    :core/merge-datasets
-				    :core/remove-sort
-				    :core/rename-column
-				    :core/reverse-geocode
-				    :core/sort-column
-                                    :core/split-column
-				    :core/to-lowercase
-				    :core/to-titlecase
-				    :core/to-uppercase
-				    :core/trim
-				    :core/trim-doublespace})
+(s/def ::transformation.engine/op #{"core/change-datatype"
+				    "core/combine"
+				    "core/delete-column"
+				    "core/derive"
+                                    "core/extract-multiple"
+				    "core/filter-column"
+				    "core/generate-geopoints"
+				    "core/merge-datasets"
+				    "core/remove-sort"
+				    "core/rename-column"
+				    "core/reverse-geocode"
+				    "core/sort-column"
+                                    "core/split-column"
+				    "core/to-lowercase"
+				    "core/to-titlecase"
+				    "core/to-uppercase"
+				    "core/trim"
+				    "core/trim-doublespace"})
 
 (defmulti op-spec :op)
 
@@ -108,7 +108,7 @@
 (s/def ::transformation.delete-column/args
   (s/keys :req-un [::db.dsv.column/columnName]))
 
-(defmethod op-spec :core/delete-column  [_]
+(defmethod op-spec "core/delete-column"  [_]
   (s/keys
    :req-un [::transformation.delete-column/args
 	    ::transformation.engine/onError
@@ -128,7 +128,7 @@
                    ::transformation.change-datatype/parseFormat
                    ::transformation.change-datatype/newType]))
 
-(defmethod op-spec :core/change-datatype  [_]
+(defmethod op-spec "core/change-datatype"  [_]
   (s/keys
    :req-un [::transformation.change-datatype/args
 	    ::transformation.engine/onError
@@ -147,7 +147,7 @@
                    ::transformation.combine/newColumnTitle
                    ::transformation.combine/separator]))
 
-(defmethod op-spec :core/combine  [_]
+(defmethod op-spec "core/combine"  [_]
   (s/keys
    :req-un [::transformation.combine/args
 	    ::transformation.engine/onError
@@ -168,7 +168,7 @@
                    ::transformation.derive/code
                    ::transformation.derive/newColumnType]))
 
-(defmethod op-spec :core/derive  [_]
+(defmethod op-spec "core/derive"  [_]
   (s/keys
    :req-un [::transformation.derive/args
 	    ::transformation.engine/onError
@@ -188,7 +188,7 @@
   (s/keys :req-un [::db.dsv.column/columnName
                    ::transformation.filter-column/expression]))
 
-(defmethod op-spec :core/filter-column  [_]
+(defmethod op-spec "core/filter-column"  [_]
   (s/keys
    :req-un [::transformation.filter-column/args
 	    ::transformation.engine/onError
@@ -208,7 +208,7 @@
                    ::transformation.generate-geopoints/columnNameLong
                    ::transformation.generate-geopoints/columnTitleGeo]))
 
-(defmethod op-spec :core/generate-geopoints  [_]
+(defmethod op-spec "core/generate-geopoints"  [_]
   (s/keys
    :req-un [::transformation.generate-geopoints/args
 	    ::transformation.engine/onError
@@ -250,7 +250,7 @@
   (s/keys :req-un [::transformation.merge-datasets/source
                    ::transformation.merge-datasets/target]))
 
-(defmethod op-spec :core/merge-datasets  [_]
+(defmethod op-spec "core/merge-datasets"  [_]
   (s/keys
    :req-un [::transformation.merge-datasets/args
             ::transformation.engine/op]))
@@ -282,7 +282,7 @@
                    ::transformation.extract-multiple/selectedColumn
                    ::transformation.extract-multiple/extractImage]))
 
-(defmethod op-spec :core/extract-multiple  [_]
+(defmethod op-spec "core/extract-multiple"  [_]
   (s/keys
    :req-un [::transformation.extract-multiple/args
 	    ::transformation.engine/onError
@@ -299,7 +299,7 @@
   (s/keys :req-un [::transformation.derive/newColumnTitle
                    ::transformation.rename-column/columnName]))
 
-(defmethod op-spec :core/rename-column  [_]
+(defmethod op-spec "core/rename-column"  [_]
   (s/keys
    :req-un [::transformation.rename-column/args
 	    ::transformation.engine/onError
@@ -338,7 +338,7 @@
   (s/keys :req-un [::transformation.reverse-geocode/source
                    ::transformation.reverse-geocode/target]))
 
-(defmethod op-spec :core/reverse-geocode  [_]
+(defmethod op-spec "core/reverse-geocode"  [_]
   (s/keys
    :req-un [::transformation.reverse-geocode/args
             ::transformation.engine/op]))
@@ -353,7 +353,7 @@
   (s/keys :req-un [::transformation.sort-column/sortDirection
                    ::transformation.sort-column/columnName]))
 
-(defmethod op-spec :core/sort-column  [_]
+(defmethod op-spec "core/sort-column"  [_]
   (s/keys
    :req-un [::transformation.sort-column/args
 	    ::transformation.engine/onError
@@ -367,7 +367,7 @@
 (s/def ::transformation.remove-sort/args
   (s/keys :req-un [::transformation.remove-sort/columnName]))
 
-(defmethod op-spec :core/remove-sort  [_]
+(defmethod op-spec "core/remove-sort"  [_]
   (s/keys
    :req-un [::transformation.remove-sort/args
 	    ::transformation.engine/onError
@@ -388,7 +388,7 @@
                    ::transformation.split-column/selectedColumn
                    ::transformation.split-column/pattern]))
 
-(defmethod op-spec :core/split-column  [_]
+(defmethod op-spec "core/split-column"  [_]
   (s/keys
    :req-un [::transformation.split-column/args
 	    ::transformation.engine/onError
@@ -400,7 +400,7 @@
 (s/def ::transformation.trim/args
   (s/keys :req-un [::db.dsv.column/columnName]))
 
-(defmethod op-spec :core/trim  [_]
+(defmethod op-spec "core/trim"  [_]
   (s/keys
    :req-un [::transformation.trim/args
 	    ::transformation.engine/onError
@@ -412,7 +412,7 @@
 (s/def ::transformation.to-lowercase/args
   (s/keys :req-un [::db.dsv.column/columnName]))
 
-(defmethod op-spec :core/to-lowercase  [_]
+(defmethod op-spec "core/to-lowercase"  [_]
   (s/keys
    :req-un [::transformation.to-lowercase/args
 	    ::transformation.engine/onError
@@ -424,7 +424,7 @@
 (s/def ::transformation.to-uppercase/args
   (s/keys :req-un [::db.dsv.column/columnName]))
 
-(defmethod op-spec :core/to-uppercase  [_]
+(defmethod op-spec "core/to-uppercase"  [_]
   (s/keys
    :req-un [::transformation.to-uppercase/args
 	    ::transformation.engine/onError
@@ -436,7 +436,7 @@
 (s/def ::transformation.to-titlecase/args
   (s/keys :req-un [::db.dsv.column/columnName]))
 
-(defmethod op-spec :core/to-titlecase  [_]
+(defmethod op-spec "core/to-titlecase"  [_]
   (s/keys
    :req-un [::transformation.to-titlecase/args
 	    ::transformation.engine/onError
@@ -448,7 +448,7 @@
 (s/def ::transformation.trim-doublespace/args
   (s/keys :req-un [::db.dsv.column/columnName]))
 
-(defmethod op-spec :core/trim-doublespace  [_]
+(defmethod op-spec "core/trim-doublespace"  [_]
   (s/keys
    :req-un [::transformation.trim-doublespace/args
 	    ::transformation.engine/onError

--- a/backend/src/akvo/lumen/lib/transformation/change_datatype.clj
+++ b/backend/src/akvo/lumen/lib/transformation/change_datatype.clj
@@ -9,7 +9,7 @@
 
 (hugsql/def-db-fns "akvo/lumen/lib/transformation/change_datatype.sql")
 
-(defmethod engine/valid? :core/change-datatype
+(defmethod engine/valid? "core/change-datatype"
   [op-spec]
   (let [{column-name "columnName"
          new-type "newType"
@@ -99,7 +99,7 @@
     (engine/ensure-number default-value)
     (change-datatype tenant-conn table-name column-name on-error alter-table-sql)))
 
-(defmethod engine/apply-operation :core/change-datatype
+(defmethod engine/apply-operation "core/change-datatype"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (let [{column-name "columnName"
          new-type "newType"} (engine/args op-spec)]

--- a/backend/src/akvo/lumen/lib/transformation/combine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/combine.clj
@@ -7,7 +7,7 @@
 (hugsql/def-db-fns "akvo/lumen/lib/transformation/combine.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/transformation/engine.sql")
 
-(defmethod engine/valid? :core/combine
+(defmethod engine/valid? "core/combine"
   [op-spec]
   (let [{[column-name-1 column-name-2] "columnNames"
          column-title "newColumnTitle"
@@ -17,7 +17,7 @@
                   (string? separator)
                   (= (engine/error-strategy op-spec) "fail")))))
 
-(defmethod engine/apply-operation :core/combine
+(defmethod engine/apply-operation "core/combine"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (let [new-column-name (engine/next-column-name columns)
         {[first-column-name second-column-name] "columnNames"

--- a/backend/src/akvo/lumen/lib/transformation/delete_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/delete_column.clj
@@ -11,7 +11,7 @@
 (defn col-name [op-spec]
   (get (engine/args op-spec) "columnName"))
 
-(defmethod engine/valid? :core/delete-column
+(defmethod engine/valid? "core/delete-column"
   [op-spec]
   (util/valid-column-name? (col-name op-spec)))
 
@@ -23,7 +23,7 @@
        (filter (fn [[distinct-columns _]]
                  (not-empty (filter #(= % column-name) distinct-columns))))))
 
-(defmethod engine/apply-operation :core/delete-column
+(defmethod engine/apply-operation "core/delete-column"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (let [column-name (col-name op-spec)
         merged-sources (merged-sources-with-column tenant-conn column-name (:dataset-id op-spec))]

--- a/backend/src/akvo/lumen/lib/transformation/derive.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive.clj
@@ -54,7 +54,7 @@
            "references" []}
           (parse-row-object-references code)))
 
-(defmethod engine/adapt-transformation :core/derive
+(defmethod engine/adapt-transformation "core/derive"
   [op-spec older-columns new-columns]
   (update-in op-spec ["args" "code"]
              #(columnName>columnTitle (compute-transformation-code % older-columns) new-columns)))
@@ -71,7 +71,7 @@
          column-type  "newColumnType"} (engine/args op-spec)]
     {::code code ::column-title column-title ::column-type column-type}))
 
-(defmethod engine/valid? :core/derive
+(defmethod engine/valid? "core/derive"
   [op-spec]
   (let [{:keys [::code
                 ::column-title
@@ -97,7 +97,7 @@
        (map (fn [[i]] (delete-row conn (merge {:rnum i} opts))))
        doall))
 
-(defmethod engine/apply-operation :core/derive
+(defmethod engine/apply-operation "core/derive"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (jdbc/with-db-transaction [conn tenant-conn]
     (let [{:keys [::code

--- a/backend/src/akvo/lumen/lib/transformation/engine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/engine.clj
@@ -16,7 +16,7 @@
 (defmulti valid?
   "Validate transformation spec"
   (fn [op-spec]
-    (keyword (op-spec "op"))))
+    (op-spec "op")))
 
 (defmethod valid? :default
   [op-spec]
@@ -33,7 +33,7 @@
    - \"args\" : map with arguments to the operation
    - \"onError\" : Error strategy"
   (fn [deps table-name columns op-spec]
-    (keyword (get op-spec "op"))))
+    (get op-spec "op")))
 
 (defmethod apply-operation :default
   [deps table-name columns op-spec]
@@ -205,7 +205,7 @@
 
 (defmulti adapt-transformation
   (fn [op-spec older-columns new-columns]
-    (keyword (get op-spec "op"))))
+    (get op-spec "op")))
 
 (defmethod adapt-transformation :default
   [op-spec older-columns new-columns]

--- a/backend/src/akvo/lumen/lib/transformation/filter_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/filter_column.clj
@@ -5,11 +5,11 @@
 
 (hugsql/def-db-fns "akvo/lumen/lib/transformation/filter_column.sql")
 
-(defmethod engine/valid? :core/filter-column
+(defmethod engine/valid? "core/filter-column"
   [op-spec]
   (boolean (not-empty (get (engine/args op-spec) "expression"))))
 
-(defmethod engine/apply-operation :core/filter-column
+(defmethod engine/apply-operation "core/filter-column"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (let [{expr "expression"
          column-name "columnName"} (engine/args op-spec)

--- a/backend/src/akvo/lumen/lib/transformation/geo.clj
+++ b/backend/src/akvo/lumen/lib/transformation/geo.clj
@@ -17,14 +17,14 @@
     (boolean
       (every? util/valid-column-name? [columnNameLat columnNameLong]))))
 
-(defmethod engine/valid? :core/generate-geopoints
+(defmethod engine/valid? "core/generate-geopoints"
   [op-spec]
   (valid? op-spec))
 
 (defn add-index [conn table-name column-name]
   (jdbc/execute! conn (postgres/geo-index table-name column-name)))
 
-(defmethod engine/apply-operation :core/generate-geopoints
+(defmethod engine/apply-operation "core/generate-geopoints"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (let [{:strs [columnNameLat columnNameLong columnTitleGeo]} (engine/args op-spec)
         get-client-type (partial engine/column-type columns)

--- a/backend/src/akvo/lumen/lib/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/lib/transformation/merge_datasets.clj
@@ -15,7 +15,7 @@
 (hugsql/def-db-fns "akvo/lumen/lib/transformation.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/transformation/engine.sql")
 
-(defmethod engine/valid? :core/merge-datasets
+(defmethod engine/valid? "core/merge-datasets"
   [op-spec]
   (let [source (get-in op-spec ["args" "source"])
         target (get-in op-spec ["args" "target"])]
@@ -163,7 +163,7 @@
                              table-name)]
      :columns (into columns target-merge-columns)}))
 
-(defmethod engine/apply-operation :core/merge-datasets
+(defmethod engine/apply-operation "core/merge-datasets"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (apply-merge-operation tenant-conn table-name columns op-spec))
 

--- a/backend/src/akvo/lumen/lib/transformation/multiple_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/multiple_column.clj
@@ -6,7 +6,7 @@
             [clojure.tools.logging :as log]
             [clojure.walk :refer (keywordize-keys stringify-keys)]))
 
-(defmethod t.engine/valid? :core/extract-multiple
+(defmethod t.engine/valid? "core/extract-multiple"
   [op-spec]
   (let [{:keys [onError op args]} (keywordize-keys op-spec)
         columns-to-extract        (filter :extract (:columns args))]
@@ -21,7 +21,7 @@
     (condp = (-> args :selectedColumn :multipleType)
       "caddisfly" (t.m-c.caddisfly/apply-operation deps table-name columns op-spec))))
 
-(defmethod t.engine/apply-operation :core/extract-multiple
+(defmethod t.engine/apply-operation "core/extract-multiple"
   [deps table-name columns op-spec]
   (-> (apply-operation deps table-name columns op-spec)
       (update :columns stringify-keys)))

--- a/backend/src/akvo/lumen/lib/transformation/rename_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/rename_column.clj
@@ -9,12 +9,12 @@
 (defn new-col-title [op-spec]
   (get (engine/args op-spec) "newColumnTitle"))
 
-(defmethod engine/valid? :core/rename-column
+(defmethod engine/valid? "core/rename-column"
   [op-spec]
   (and (util/valid-column-name? (col-name op-spec))
        (string? (new-col-title op-spec))))
 
-(defmethod engine/apply-operation :core/rename-column
+(defmethod engine/apply-operation "core/rename-column"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (let [column-name (col-name op-spec)
         column-idx (engine/column-index columns column-name)

--- a/backend/src/akvo/lumen/lib/transformation/reverse_geocode.clj
+++ b/backend/src/akvo/lumen/lib/transformation/reverse_geocode.clj
@@ -8,7 +8,7 @@
 (hugsql/def-db-fns "akvo/lumen/lib/transformation/engine.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/transformation/reverse_geocode.sql")
 
-(defmethod engine/valid? :core/reverse-geocode
+(defmethod engine/valid? "core/reverse-geocode"
   [op-spec]
   (let [{:strs [target source]} (get op-spec "args")]
     (and (string? (get target "title"))
@@ -24,7 +24,7 @@
   (-> (latest-dataset-version-by-dataset-id conn {:dataset-id datasetId})
       :table-name))
 
-(defmethod engine/apply-operation :core/reverse-geocode
+(defmethod engine/apply-operation "core/reverse-geocode"
   [{:keys [tenant-conn]} table-name columns {:strs [args] :as op-spec}]
   (let [column-name (engine/next-column-name columns)
         {:strs [target source]} args

--- a/backend/src/akvo/lumen/lib/transformation/sort_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/sort_column.clj
@@ -5,12 +5,12 @@
 
 (hugsql/def-db-fns "akvo/lumen/lib/transformation/sort_column.sql")
 
-(defmethod engine/valid? :core/sort-column
+(defmethod engine/valid? "core/sort-column"
   [op-spec]
   (and (util/valid-column-name? (get (engine/args op-spec) "columnName"))
        (boolean (#{"ASC" "DESC"} (get (engine/args op-spec) "sortDirection")))))
 
-(defmethod engine/valid? :core/remove-sort
+(defmethod engine/valid? "core/remove-sort"
   [op-spec]
   (util/valid-column-name? (get (engine/args op-spec) "columnName")))
 
@@ -19,7 +19,7 @@
   [columns]
   (inc (count (filter #(get % "sort") columns))))
 
-(defmethod engine/apply-operation :core/sort-column
+(defmethod engine/apply-operation "core/sort-column"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (let [{column-name "columnName"
          sort-direction "sortDirection"} (engine/args op-spec)
@@ -36,7 +36,7 @@
     {:success? true
      :columns new-cols}))
 
-(defmethod engine/apply-operation :core/remove-sort
+(defmethod engine/apply-operation "core/remove-sort"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (let [{column-name "columnName"} (engine/args op-spec)
         idx-name (str table-name "_" column-name)

--- a/backend/src/akvo/lumen/lib/transformation/split_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/split_column.clj
@@ -42,7 +42,7 @@
 (defn new-column-name [args]
   (-> args :newColumnName))
 
-(defmethod engine/valid? :core/split-column
+(defmethod engine/valid? "core/split-column"
   [op-spec]
   (let [{:keys [onError op args] :as op-spec} (keywordize-keys op-spec)]
     (and (util/valid-column-name? (col-name args))
@@ -80,7 +80,7 @@
           :else                 (apply conj default-values (reverse values))))
       default-values)))
 
-(defmethod engine/apply-operation :core/split-column
+(defmethod engine/apply-operation "core/split-column"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (jdbc/with-db-transaction [tenant-conn tenant-conn]
     (let [{:keys [onError op args]} (keywordize-keys op-spec)

--- a/backend/src/akvo/lumen/lib/transformation/text.clj
+++ b/backend/src/akvo/lumen/lib/transformation/text.clj
@@ -20,38 +20,38 @@
 (defn valid? [op-spec]
   (util/valid-column-name? (get (engine/args op-spec) "columnName")))
 
-(defmethod engine/valid? :core/trim [op-spec]
+(defmethod engine/valid? "core/trim" [op-spec]
   (valid? op-spec))
 
-(defmethod engine/apply-operation :core/trim
+(defmethod engine/apply-operation "core/trim"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (transform tenant-conn table-name columns op-spec "trim"))
 
-(defmethod engine/valid? :core/to-lowercase [op-spec]
+(defmethod engine/valid? "core/to-lowercase" [op-spec]
   (valid? op-spec))
 
-(defmethod engine/apply-operation :core/to-lowercase
+(defmethod engine/apply-operation "core/to-lowercase"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (transform tenant-conn table-name columns op-spec "lower"))
 
-(defmethod engine/valid? :core/to-uppercase [op-spec]
+(defmethod engine/valid? "core/to-uppercase" [op-spec]
   (valid? op-spec))
 
-(defmethod engine/apply-operation :core/to-uppercase
+(defmethod engine/apply-operation "core/to-uppercase"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (transform tenant-conn table-name columns op-spec "upper"))
 
-(defmethod engine/valid? :core/to-titlecase [op-spec]
+(defmethod engine/valid? "core/to-titlecase" [op-spec]
   (valid? op-spec))
 
-(defmethod engine/apply-operation :core/to-titlecase
+(defmethod engine/apply-operation "core/to-titlecase"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (transform tenant-conn table-name columns op-spec "initcap"))
 
-(defmethod engine/valid? :core/trim-doublespace [op-spec]
+(defmethod engine/valid? "core/trim-doublespace" [op-spec]
   (valid? op-spec))
 
-(defmethod engine/apply-operation :core/trim-doublespace
+(defmethod engine/apply-operation "core/trim-doublespace"
   [{:keys [tenant-conn]} table-name columns op-spec]
   (let [{column-name "columnName"} (engine/args op-spec)]
     (trim-doublespace tenant-conn {:table-name table-name

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -85,20 +85,22 @@
   "due some specs issues we need to generate merge specs step by step
   issues related to s/merge or generating false/nil values"
   [t-type  gens & kvs]
-  (let [gens (when gens
+  (let [t-type (keyword t-type)
+        op-name (str (namespace t-type) "/" (name t-type))
+        gens (when gens
                (reduce-kv (fn [c k v]
                             (if (fn? v)
                               (assoc c k v)
                               (assoc c k #(s/gen #{v})))
                             ) {} gens))
-        s (first (lumen.s/sample-with-gen (transformation.s/op-spec {:op t-type}) gens 1))
+        s (first (lumen.s/sample-with-gen (transformation.s/op-spec {:op op-name}) gens 1))
         args (first (lumen.s/sample-with-gen (keyword (str "akvo.lumen.specs.transformation." (name t-type) "/args")) gens 1))
         args (if (and kvs (not-empty kvs) (even? (count kvs)))
                (reduce #((if (vector? (first %2))  assoc-in assoc) % (first %2) (last %2)) args (partition 2 kvs))
                args)
         
-        op-name (str (namespace t-type) "/" (name t-type))]
-    (conform ::transformation.engine.s/op-spec (assoc s :op (keyword op-name) :args args))
+]
+    (conform ::transformation.engine.s/op-spec (assoc s :op op-name :args args))
 
     (tu/clj>json>clj (assoc s :op op-name :args args))))
 
@@ -117,13 +119,13 @@
 
 (deftest ^:functional test-import-and-transform
   (testing "Import CSV and transform"
-    (let [t-log      [(gen-transformation :core/trim {::db.dataset-version.column.s/columnName "c5"
+    (let [t-log      [(gen-transformation "core/trim" {::db.dataset-version.column.s/columnName "c5"
                                                       ::transformation.engine.s/onError        "fail"})
-                      (gen-transformation :core/change-datatype {::db.dataset-version.column.s/columnName        "c5"
+                      (gen-transformation "core/change-datatype" {::db.dataset-version.column.s/columnName        "c5"
                                                                  ::transformation.change-datatype.s/defaultValue 0
                                                                  ::transformation.change-datatype.s/newType      "number"
                                                                  ::transformation.engine.s/onError               "default-value"})
-                      (gen-transformation :core/filter-column {::db.dataset-version.column.s/columnName    "c4"
+                      (gen-transformation "core/filter-column" {::db.dataset-version.column.s/columnName    "c4"
                                                                ::transformation.filter-column.s/expression {"contains" "broken"}
                                                                ::transformation.engine.s/onError           "fail"})]
           dataset-id (import-file *tenant-conn* *error-tracker* {:name                "GDP Test"
@@ -156,11 +158,11 @@
         apply-transformation (partial transformation/apply {:tenant-conn *tenant-conn*} dataset-id)]
     (is (= ::lib/ok (first (apply-transformation {:type :undo}))))
     (let [[tag _] (do (apply-transformation {:type :transformation
-                                             :transformation (gen-transformation :core/to-lowercase
+                                             :transformation (gen-transformation "core/to-lowercase"
                                                                                  {::db.dataset-version.column.s/columnName "c1"
                                                                                   ::transformation.engine.s/onError "fail"})})
                       (apply-transformation {:type :transformation
-                                             :transformation (gen-transformation :core/change-datatype
+                                             :transformation (gen-transformation "core/change-datatype"
                                                                                  {::db.dataset-version.column.s/columnName "c5"
                                                                                   ::transformation.engine.s/onError "default-value"
                                                                                   ::transformation.change-datatype.s/newType "number"
@@ -195,7 +197,7 @@
                                                                :file "name.csv"})
         apply-transformation (partial transformation/apply {:tenant-conn *tenant-conn*} dataset-id)
         [tag _] (apply-transformation {:type :transformation
-                                       :transformation (gen-transformation :core/combine
+                                       :transformation (gen-transformation "core/combine"
                                                                            {::transformation.combine.s/columnNames ["c1" "c2"]
                                                                             ::transformation.engine.s/onError "fail"
                                                                             ::transformation.combine.s/newColumnTitle "full name"
@@ -214,7 +216,7 @@
     (testing "Combining columns where one of the columns has empty values"
       (let [[tag _] (apply-transformation {:type :transformation
                                            :transformation
-                                         (gen-transformation :core/combine
+                                         (gen-transformation "core/combine"
                                                              {:akvo.lumen.specs.transformation.combine/columnNames ["c2" "c3"]                                                                          ::transformation.engine.s/onError "fail"
                                                               :akvo.lumen.specs.transformation.combine/newColumnTitle "issue1517"
                                                               :akvo.lumen.specs.transformation.combine/separator " "})})]
@@ -233,7 +235,7 @@
                               {:type           :transformation
                                :transformation
                                (gen-transformation
-                                :core/change-datatype {:akvo.lumen.specs.db.dataset-version.column/columnName column-name
+                                "core/change-datatype" {:akvo.lumen.specs.db.dataset-version.column/columnName column-name
                                                        :akvo.lumen.specs.transformation.change-datatype/defaultValue 0
                                                        :akvo.lumen.specs.transformation.change-datatype/newType "date"
                                                        :akvo.lumen.specs.transformation.change-datatype/parseFormat format*
@@ -277,7 +279,7 @@
                                          {:type :transformation
                                           :transformation
                                           (-> (gen-transformation
-                                               :core/change-datatype {::db.dataset-version.column.s/columnName "column-name"
+                                               "core/change-datatype" {::db.dataset-version.column.s/columnName "column-name"
                                                                       ::transformation.change-datatype.s/newType "number"
                                                                       ::transformation.engine.s/onError "default-value"})
                                               (assoc-in ["args" "defaultValue"] nil))})
@@ -296,7 +298,7 @@
     (testing "Basic text transform"
       (apply-transformation {:type :transformation
                              :transformation
-                             (gen-transformation :core/derive
+                             (gen-transformation "core/derive"
                                                  {::transformation.derive.s/newColumnTitle "Derived 1"
                                                   ::transformation.derive.s/code "row['foo'].toUpperCase()"
                                                   ::transformation.derive.s/newColumnType "text"
@@ -306,7 +308,7 @@
     (testing "Basic text transform with drop row on error"
       (apply-transformation {:type :transformation
                              :transformation
-                             (gen-transformation :core/derive
+                             (gen-transformation "core/derive"
                                                  {::transformation.derive.s/newColumnTitle "Derived 3"
                                                   ::transformation.derive.s/code "row['foo'].replace('a', 'b')"
                                                   ::transformation.derive.s/newColumnType "text"
@@ -318,7 +320,7 @@
     (testing "Basic text transform with abort"
       (apply-transformation {:type :transformation
                              :transformation
-                             (gen-transformation :core/derive
+                             (gen-transformation "core/derive"
                                                  {::transformation.derive.s/newColumnTitle "Derived 2"
                                                   ::transformation.derive.s/code "row['foo'].length"
                                                   ::transformation.derive.s/newColumnType "number"
@@ -333,7 +335,7 @@
     (testing "Nested string transform"
       (apply-transformation {:type :transformation
                              :transformation
-                             (gen-transformation :core/derive
+                             (gen-transformation "core/derive"
                                                  {::transformation.derive.s/newColumnTitle "Derived 4"
                                                   ::transformation.derive.s/code "row['foo'].toUpperCase()"
                                                   ::transformation.derive.s/newColumnType "text"
@@ -342,7 +344,7 @@
 
       (apply-transformation {:type :transformation
                              :transformation
-                             (gen-transformation :core/derive
+                             (gen-transformation "core/derive"
                                                  {::transformation.derive.s/newColumnTitle "Derived 5"
                                                   ::transformation.derive.s/code "row['Derived 4'].toLowerCase()"
                                                   ::transformation.derive.s/newColumnType "text"
@@ -352,7 +354,7 @@
     (testing "Date transform"
       (let [[tag _] (apply-transformation {:type :transformation
                                            :transformation
-                                           (gen-transformation :core/derive
+                                           (gen-transformation "core/derive"
                                                                {::transformation.derive.s/newColumnTitle "Derived 5"
                                                                 ::transformation.derive.s/code "new Date()"
                                                                 ::transformation.derive.s/newColumnType "date"
@@ -363,7 +365,7 @@
     (testing "Valid type check"
       (let [[tag _] (apply-transformation {:type :transformation
                                            :transformation
-                                           (gen-transformation :core/derive
+                                           (gen-transformation "core/derive"
                                                                {::transformation.derive.s/newColumnTitle "Derived 6"
                                                                 ::transformation.derive.s/code "new Date()"
                                                                 ::transformation.derive.s/newColumnType "number"
@@ -373,7 +375,7 @@
     (testing "Sandboxing java interop"
       (let [[tag _] (apply-transformation {:type :transformation
                                            :transformation
-                                           (gen-transformation :core/derive
+                                           (gen-transformation "core/derive"
                                                                {::transformation.derive.s/newColumnTitle "Derived 7"
                                                                 ::transformation.derive.s/code "new java.util.Date()"
                                                                 ::transformation.derive.s/newColumnType "number"
@@ -383,7 +385,7 @@
     (testing "Sandboxing dangerous js functions"
       (let [[tag _] (apply-transformation {:type :transformation
                                            :transformation
-                                           (gen-transformation :core/derive
+                                           (gen-transformation "core/derive"
                                                                {::transformation.derive.s/newColumnTitle "Derived 7"
                                                                 ::transformation.derive.s/code "quit()"
                                                                 ::transformation.derive.s/newColumnType "number"
@@ -393,7 +395,7 @@
     (testing "Fail early on syntax error"
       (let [[tag _] (apply-transformation {:type :transformation
                                            :transformation
-                                           (gen-transformation :core/derive
+                                           (gen-transformation "core/derive"
                                                                {::transformation.derive.s/newColumnTitle "Derived 8"
                                                                 ::transformation.derive.s/code ")"
                                                                 ::transformation.derive.s/newColumnType "text"
@@ -403,7 +405,7 @@
     (testing "Fail infinite loop"
       (let [[tag _] (apply-transformation {:type :transformation
                                            :transformation
-                                           (gen-transformation :core/derive
+                                           (gen-transformation "core/derive"
                                                                {::transformation.derive.s/newColumnTitle "Derived 9"
                                                                 ::transformation.derive.s/code "while(true) {}"
                                                                 ::transformation.derive.s/newColumnType "text"
@@ -414,7 +416,7 @@
     (testing "Disallow anonymous functions"
       (let [[tag _] (apply-transformation {:type :transformation
                                            :transformation
-                                           (gen-transformation :core/derive
+                                           (gen-transformation "core/derive"
                                                                {::transformation.derive.s/newColumnTitle "Derived 10"
                                                                 ::transformation.derive.s/code "(function() {})()"
                                                                 ::transformation.derive.s/newColumnType "text"
@@ -423,7 +425,7 @@
 
       (let [[tag _] (apply-transformation {:type :transformation
                                            :transformation
-                                           (gen-transformation :core/derive
+                                           (gen-transformation "core/derive"
                                                                {::transformation.derive.s/newColumnTitle "Derived 11"
                                                                 ::transformation.derive.s/code "(() => 'foo')()"
                                                                 ::transformation.derive.s/newColumnType "text"
@@ -502,7 +504,7 @@
         apply-transformation (partial transformation/apply {:tenant-conn *tenant-conn*} dataset-id)
         [tag _]              (apply-transformation {:type :transformation
                                                     :transformation
-                                                    (gen-transformation :core/delete-column
+                                                    (gen-transformation "core/delete-column"
                                                                         {::db.dataset-version.column.s/columnName "c2"
                                                                          :transformation.engine.s/onError         "fail"})})]
     (is (= ::lib/ok tag))
@@ -576,17 +578,15 @@
                                            :kind         "clj"
                                            :data         target-data})
         apply-transformation (partial transformation/apply {:tenant-conn *tenant-conn*} origin-dataset-id)
-        tx                   (gen-transformation :core/merge-datasets
+        tx                   (gen-transformation "core/merge-datasets"
                                                  {::transformation.merge-datasets.source.s/datasetId            target-dataset-id
                                                   ::transformation.merge-datasets.source.s/mergeColumn          "c1"
                                                   ::transformation.merge-datasets.source.s/aggregationDirection "DESC"
-                                                  ::transformation.merge-datasets.source.s/aggregationColumn    ""
                                                   ::transformation.merge-datasets.source.s/mergeColumns         ["c4" "c3" "c2"]
                                                   ::transformation.merge-datasets.target.s/mergeColumn          "c1"}
                                                  [:source :aggregationColumn] nil)
         [tag _ :as res] (apply-transformation {:type           :transformation
                                                :transformation tx})]
-         
     (is (= ::lib/ok tag))
     (let [{:keys [columns transformations table-name]} (latest-dataset-version-by-dataset-id *tenant-conn* {:dataset-id origin-dataset-id})
           data-db                                      (get-data *tenant-conn* {:table-name table-name})]
@@ -635,7 +635,7 @@
         apply-transformation (partial transformation/apply {:tenant-conn *tenant-conn*} dataset-id)
         [tag _]              (apply-transformation {:type :transformation
                                                     :transformation
-                                                    (gen-transformation :core/rename-column
+                                                    (gen-transformation "core/rename-column"
                                                                         {::transformation.derive.s/newColumnTitle    "New Title"
                                                                          ::transformation.rename-column.s/columnName "c2"
                                                                          ::transformation.engine.s/onError           "fail"})})]
@@ -650,7 +650,7 @@
 ;; Regression #808
 (deftest valid-column-names
   (is (engine/valid?
-       (gen-transformation :core/sort-column
+       (gen-transformation "core/sort-column"
                            {::transformation.sort-column.s/sortDirection "ASC"
                             ::transformation.sort-column.s/columnName    "submitted_at"
                             ::transformation.engine.s/onError            "fail"})))
@@ -672,7 +672,7 @@
         apply-transformation (partial transformation/apply {:tenant-conn *tenant-conn*} dataset-id)
         [tag _]              (apply-transformation {:type :transformation
                                                     :transformation
-                                                    (gen-transformation :core/generate-geopoints
+                                                    (gen-transformation "core/generate-geopoints"
                                                                         {::transformation.generate-geopoints.s/columnTitleGeo "Geopoints"
                                                                          ::transformation.generate-geopoints.s/columnNameLong "c3"
                                                                          ::transformation.generate-geopoints.s/columnNameLat  "c2"

--- a/backend/test/akvo/lumen/test_utils.clj
+++ b/backend/test/akvo/lumen/test_utils.clj
@@ -40,11 +40,10 @@
                          (assoc c (name k) {:before (>column before) :after (>column after)})
                          ) {} cc))]
     (let [res  (-> (keywordize-keys dsv)
-                   (update :transformations #(mapv (fn [t] (update t :op keyword)) %))
                    (update :columns #(mapv >column %))
                    (update :transformations #(mapv (fn [t]
-                                                     (let [t (if (or (= :core/split-column (:op t))
-                                                                     (= :core/extract-multiple (:op t)))
+                                                     (let [t (if (or (= "core/split-column" (:op t))
+                                                                     (= "core/extract-multiple" (:op t)))
                                                                (update-in t [:args :selectedColumn] >column)
                                                                t)]
                                                        (update t :changedColumns >changedColumns))) %)))]


### PR DESCRIPTION
Keyword aren't jsonables in db (postgres/json) nor client
side (javascript/json)

So far we change `op` value to keyword when backend tries to
process/dispatch the transformation client request, that force
implementation to manage the same data with different types, firstly
as string, later as keyword, finally as string.

Also the approach is not the dafault one. Dispatching aggregation is based on
strings, also dispatching import process is based on strings too

So this commit will unify the dispatching approach to be always based
on strings

- [ ] **Update release notes if necessary**
