### PR TITLE
Add endpoint path to monitoring data

### DIFF
--- a/backend/src/akvo/lumen/endpoint/collection.clj
+++ b/backend/src/akvo/lumen/endpoint/collection.clj
@@ -14,16 +14,14 @@
       (POST "/" {:keys [body]}
         (collection/create tenant-conn body))
 
-      (context "/:id" [id]
+      (GET "/:id" [id]
+           (collection/fetch tenant-conn id))
 
-        (GET "/" _
-          (collection/fetch tenant-conn id))
+      (PUT "/:id" {:keys [body params]}
+           (collection/update tenant-conn (:id params) body))
 
-        (PUT "/" {:keys [body]}
-          (collection/update tenant-conn id body))
-
-        (DELETE "/" _
-          (collection/delete tenant-conn id))))))
+      (DELETE "/:id" [id]
+              (collection/delete tenant-conn id)))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.collection/collection  [_ opts]
   (endpoint opts))

--- a/backend/src/akvo/lumen/endpoint/dashboard.clj
+++ b/backend/src/akvo/lumen/endpoint/dashboard.clj
@@ -15,16 +15,14 @@
       (POST "/" {:keys [body jwt-claims]}
         (dashboard/create tenant-conn body jwt-claims))
 
-      (context "/:id" [id]
+      (GET "/:id" [id]
+           (dashboard/fetch tenant-conn id))
 
-        (GET "/" _
-          (dashboard/fetch tenant-conn id))
+      (PUT "/:id" {:keys [body params]}
+           (dashboard/upsert tenant-conn (:id params) body))
 
-        (PUT "/" {:keys [body]}
-          (dashboard/upsert tenant-conn id body))
-
-        (DELETE "/" _
-         (dashboard/delete tenant-conn id))))))
+      (DELETE "/:id" [id]
+              (dashboard/delete tenant-conn id)))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.dashboard/dashboard  [_ opts]
   (endpoint opts))

--- a/backend/src/akvo/lumen/endpoint/data_source.clj
+++ b/backend/src/akvo/lumen/endpoint/data_source.clj
@@ -7,9 +7,8 @@
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/data-source/job-execution" {:keys [tenant]}
     (let-routes [tenant-conn (p/connection tenant-manager tenant)]
-      (context "/:id/status/:status" [id status]
-               (DELETE "/" _
-                       (data-source/delete tenant-conn id status))))))
+      (DELETE "/:id/status/:status" [id status]
+              (data-source/delete tenant-conn id status)))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.data-source/data-source  [_ opts]
   (endpoint opts))

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -14,21 +14,20 @@
       (POST "/" {:keys [tenant body jwt-claims] :as request}
         (dataset/create tenant-conn config error-tracker jwt-claims body))
 
-      (context "/:id" [id]
-        (GET "/" _
-          (dataset/fetch tenant-conn id))
+      (GET "/:id" [id]
+           (dataset/fetch tenant-conn id))
 
-        (GET "/meta" _
-          (dataset/fetch-metadata tenant-conn id))
+      (GET "/:id/meta" [id]
+           (dataset/fetch-metadata tenant-conn id))
 
-        (DELETE "/" _
-          (dataset/delete tenant-conn id))
+      (DELETE "/:id" [id]
+              (dataset/delete tenant-conn id))
 
-        (PUT "/" {:keys [body]}
-          (dataset/update-meta tenant-conn id body))
+      (PUT "/:id" {:keys [body params]}
+           (dataset/update-meta tenant-conn (:id params) body))
 
-        (POST "/update" {:keys [body] :as request}
-          (dataset/update tenant-conn config error-tracker id body))))))
+      (POST "/:id/update" {:keys [body params]}
+            (dataset/update tenant-conn config error-tracker (:id params) body)))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.dataset/dataset  [_ opts]
   (endpoint (assoc opts :config (:config (:config opts)))))

--- a/backend/src/akvo/lumen/endpoint/invite.clj
+++ b/backend/src/akvo/lumen/endpoint/invite.clj
@@ -21,10 +21,8 @@
         (user/create-invite emailer keycloak tenant-conn tenant
                             (location (:invite-redirect config) request)
                             email jwt-claims))
-
-      (context "/:id" [id]
-        (DELETE "/" _
-          (user/delete-invite tenant-conn id))))))
+      (DELETE "/:id" [id]
+              (user/delete-invite tenant-conn id)))))
 
 (defn verify-endpoint [{:keys [config keycloak tenant-manager]}]
   (context "/verify" {:keys [tenant] :as request}

--- a/backend/src/akvo/lumen/endpoint/job_execution.clj
+++ b/backend/src/akvo/lumen/endpoint/job_execution.clj
@@ -7,9 +7,8 @@
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/job_executions" {:keys [tenant]}
     (let-routes [tenant-conn (p/connection tenant-manager tenant)]
-      (context "/:id" [id]
-        (GET "/" _
-          (job-execution/status tenant-conn id))))))
+      (GET "/:id" [id]
+           (job-execution/status tenant-conn id)))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.job-execution/job-execution  [_ opts]
   (endpoint opts))

--- a/backend/src/akvo/lumen/endpoint/raster.clj
+++ b/backend/src/akvo/lumen/endpoint/raster.clj
@@ -14,12 +14,11 @@
       (POST "/" {:keys [tenant body jwt-claims] :as request}
         (raster/create tenant-conn config jwt-claims body))
 
-      (context "/:id" [id]
-        (GET "/" _
-          (raster/fetch tenant-conn id))
+      (GET "/:id" [id]
+           (raster/fetch tenant-conn id))
 
-        (DELETE "/" _
-          (raster/delete tenant-conn id))))))
+      (DELETE "/:id" [id]
+              (raster/delete tenant-conn id)))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.raster/raster  [_ opts]
   (endpoint (assoc opts :config (:config (:config opts)))))

--- a/backend/src/akvo/lumen/endpoint/share.clj
+++ b/backend/src/akvo/lumen/endpoint/share.clj
@@ -9,11 +9,10 @@
     (let-routes [tenant-conn (p/connection tenant-manager tenant)]
 
       (POST "/" {:keys [body] :as request}
-        (share/fetch tenant-conn body))
-
-      (context "/:id" [id]
-        (PUT "/" {:keys [body]}
-          (share/put tenant-conn id body))))))
+            (share/fetch tenant-conn body))
+      
+      (PUT "/:id" {:keys [body params]}
+           (share/put tenant-conn (:id params) body)))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.share/share  [_ opts]
   (endpoint opts))

--- a/backend/src/akvo/lumen/endpoint/split_column.clj
+++ b/backend/src/akvo/lumen/endpoint/split_column.clj
@@ -17,18 +17,17 @@
 
 (defn endpoint [{:keys [tenant-manager]}]
   (context "/api/split-column" {:keys [query-params tenant] :as request}
-           (context "/:dataset-id" [dataset-id]
-                    (GET "/pattern-analysis" _
-                         (let [query           (json/parse-string (get query-params "query") keyword)
-                               tenant-conn     (p/connection tenant-manager tenant)
-                               dataset-version (latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id})
-                               sql-query       {:table-name  (:table-name dataset-version)
-                                                :column-name (:columnName query)
-                                                :limit       (str (:limit query "200"))}
-                               values          (map (comp str (keyword (:columnName query)))
-                                                    (select-random-column-data tenant-conn sql-query))
-                               pattern-analysis (transformation/pattern-analysis (re-pattern "[^a-zA-Z0-9\\s]") values)]
-                           (lib/ok {:analysis (sort-pattern-analysis-by pattern-analysis :total-row-coincidences)}))))))
+           (GET "/:dataset-id/pattern-analysis" [dataset-id]
+                (let [query           (json/parse-string (get query-params "query") keyword)
+                      tenant-conn     (p/connection tenant-manager tenant)
+                      dataset-version (latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id})
+                      sql-query       {:table-name  (:table-name dataset-version)
+                                       :column-name (:columnName query)
+                                       :limit       (str (:limit query "200"))}
+                      values          (map (comp str (keyword (:columnName query)))
+                                           (select-random-column-data tenant-conn sql-query))
+                      pattern-analysis (transformation/pattern-analysis (re-pattern "[^a-zA-Z0-9\\s]") values)]
+                  (lib/ok {:analysis (sort-pattern-analysis-by pattern-analysis :total-row-coincidences)})))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.split-column/endpoint  [_ opts]
   (endpoint opts))

--- a/backend/src/akvo/lumen/endpoint/transformation.clj
+++ b/backend/src/akvo/lumen/endpoint/transformation.clj
@@ -8,15 +8,15 @@
   (context "/api/transformations" {:keys [tenant] :as request}
     (let-routes [tenant-conn (p/connection tenant-manager tenant)]
       (context "/:dataset-id" [dataset-id]
-        (POST "/transform" {:keys [body] :as request}
+        (POST "/:dataset-id/transform" {:keys [body params] :as request}
               (t/apply {:tenant-conn tenant-conn :caddisfly caddisfly}
-                   dataset-id
+                   (:dataset-id params)
                    {:type :transformation
                     :transformation body}))
 
-        (POST "/undo" _
+        (POST "/:dataset-id/undo" [dataset-id]
               (t/apply {:tenant-conn tenant-conn :caddisfly caddisfly}
-                   dataset-id
+                   dataset-id 
                    {:type :undo}))))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.transformation/transformation  [_ opts]

--- a/backend/src/akvo/lumen/endpoint/user.clj
+++ b/backend/src/akvo/lumen/endpoint/user.clj
@@ -18,20 +18,18 @@
     (GET "/" _
       (user/users keycloak tenant))
 
-    (context "/:id" [id]
+    (PATCH "/:id/" {:keys [body params]}
+           (cond
+             (demote-user? body)
+             (user/demote-user-from-admin keycloak tenant jwt-claims (:id params))
 
-      (PATCH "/" {:keys [body]}
-        (cond
-          (demote-user? body)
-          (user/demote-user-from-admin keycloak tenant jwt-claims id)
+             (promote-user? body)
+             (user/promote-user-to-admin keycloak tenant jwt-claims (:id params))
 
-          (promote-user? body)
-          (user/promote-user-to-admin keycloak tenant jwt-claims id)
+             :else (http/not-implemented)))
 
-          :else (http/not-implemented)))
-
-      (DELETE "/" _
-        (user/remove-user keycloak tenant jwt-claims id)))))
+    (DELETE "/:id/" [id]
+            (user/remove-user keycloak tenant jwt-claims id))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.user/user  [_ opts]
   (endpoint opts))

--- a/backend/src/akvo/lumen/endpoint/visualisation.clj
+++ b/backend/src/akvo/lumen/endpoint/visualisation.clj
@@ -15,25 +15,21 @@
       (POST "/" {:keys [jwt-claims body]}
         (visualisation/create tenant-conn body jwt-claims))
 
-      (context "/maps" _
-        (POST "/" {{:strs [spec]} :body}
-          (let [layers (get-in spec ["layers"])]
-            (maps/create tenant-conn (:windshaft-url config) layers))))
+      (POST "/maps/" {{:strs [spec]} :body}
+            (let [layers (get-in spec ["layers"])]
+              (maps/create tenant-conn (:windshaft-url config) layers)))
+     
+      (POST "/rasters/" {{:strs [rasterId spec]} :body}
+            (maps/create-raster tenant-conn (:windshaft-url config) rasterId))
 
-      (context "/rasters" _
-        (POST "/" {{:strs [rasterId spec]} :body}
-          (maps/create-raster tenant-conn (:windshaft-url config) rasterId)))
+      (GET "/:id" [id]
+           (visualisation/fetch tenant-conn id))
 
-      (context "/:id" [id]
+      (PUT "/:id" {:keys [jwt-claims body params]}
+           (visualisation/upsert tenant-conn (assoc body "id" (:id params)) jwt-claims))
 
-        (GET "/" _
-          (visualisation/fetch tenant-conn id))
-
-        (PUT "/" {:keys [jwt-claims body]}
-          (visualisation/upsert tenant-conn (assoc body "id" id) jwt-claims))
-
-        (DELETE "/" _
-          (visualisation/delete tenant-conn id))))))
+      (DELETE "/:id" [id]
+              (visualisation/delete tenant-conn id)))))
 
 (defmethod ig/init-key :akvo.lumen.endpoint.visualisation/visualisation  [_ opts]
   (endpoint (assoc opts :config (:config (:config opts)))))

--- a/backend/src/akvo/lumen/monitoring.clj
+++ b/backend/src/akvo/lumen/monitoring.clj
@@ -16,10 +16,11 @@
       (ring/initialize {:labels [:tenant]})))
 
 (defmethod ig/init-key ::middleware [_ {:keys [collector]}]
-  #(-> %
-       (ring/wrap-metrics collector {:path-fn (constantly "unknown")
-                                     :label-fn (fn [request _]
-                                                 {:tenant (:tenant request)})})))
+  (fn [handler]
+    (ring/wrap-metrics handler collector {:path-fn (constantly "unknown")
+                                          :label-fn (fn [request response]
+                                                      {:tenant (:tenant request)
+                                                       :path (:metric-path response)})})))
 
 (comment
   (slurp "http://localhost:3000/metrics")


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

+ Add middleware to extract endpoint path with patterns instead of values
+ Use that value in monitoring

example metrics output from http://t1.lumen.local:3000/metrics ...
```
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="0.001",} 0.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="0.005",} 0.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="0.01",} 0.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="0.02",} 0.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="0.05",} 0.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="0.1",} 1.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="0.2",} 1.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="0.3",} 1.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="0.5",} 1.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="0.75",} 1.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="1.0",} 1.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="5.0",} 1.0
http_request_latency_seconds_bucket{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",le="+Inf",} 1.0
http_request_latency_seconds_count{method="GET",status="200",statusClass="2XX",path="/api/aggregation/:dataset-id/:visualisation-type",tenant="t1",} 1.0


```
