### PR TITLE
Admin view returns blank page “TypeError: a.map is not a function” #1940

### DIFF
--- a/client/src/components/Users.jsx
+++ b/client/src/components/Users.jsx
@@ -178,7 +178,7 @@ class Users extends Component {
 
   getUsers() {
     api.get('/api/admin/users')
-      .then(({ body }) => this.setState({ users: body }))
+      .then(({ body: { users } }) => this.setState({ users }))
       .catch(() => {
         this.props.dispatch(showNotification('error', 'Failed to fetch users.'));
       });


### PR DESCRIPTION
- [ ] **Update release notes if necessary**
