### PR TITLE
Support filter out all values in Pivot table (Connect #741)

### DIFF
--- a/backend/test/akvo/lumen/lib/aggregation_test.clj
+++ b/backend/test/akvo/lumen/lib/aggregation_test.clj
@@ -115,6 +115,22 @@
                           {:title "a2" :type "number"}]
                 :rows [["b1" 10.5 10.0]
                        ["b2" 9.5 10.333333333333334]]
+                :metadata {:categoryColumnTitle "A"}}))))
+
+
+    (testing "Row & Category Column with count aggregation and rows filtered out"
+      (let [[tag query-result] (query {:aggregation "count",
+                                       :categoryColumn "c1",
+                                       :rowColumn "c2",
+                                       :valueColumn "c3",
+                                       :filters
+                                       [{:column "c3",
+                                         :value "1",
+                                         :operation "remove",
+                                         :strategy "isHigher"}]})]
+        (is (= query-result
+               {:columns []
+                :rows [[]]
                 :metadata {:categoryColumnTitle "A"}}))))))
 
 (deftest pie-tests


### PR DESCRIPTION
It's possible to filter out all rows that is needed as categories for
crosstab(text source_sql, text category_sql) in postgres. According to Postgres docs
this is not valid:
"category_sql is a SQL statement that produces the set of categories. This
statement must return only one column. It must produce at least one row,
or an error will be generated" (https://www.postgresql.org/docs/11/tablefunc.html).

Hence when there is no categores we return an empty table.

- [ ] **Update release notes if necessary**
