### PR TITLE
Fix java.lang.IllegalArgumentException: No method in multimethod 'init-key' for dispatch value: :akvo.lumen.specs

### DIFF
--- a/backend/dev/resources/dev.edn
+++ b/backend/dev/resources/dev.edn
@@ -18,9 +18,9 @@
  :akvo.lumen.component.keycloak/data  {:url         "http://auth.lumen.local:8080/auth"
                                        :realm       "akvo"}
 
- :akvo.lumen.component.keycloak      {:credentials
-                                      {:client_id     "akvo-lumen-confidential"
-                                       :client_secret "caed3964-09dd-4752-b0bb-22c8e8ffd631"}}
+ :akvo.lumen.component.keycloak/keycloak      {:credentials
+                                               {:client_id     "akvo-lumen-confidential"
+                                                :client_secret "caed3964-09dd-4752-b0bb-22c8e8ffd631"}}
 
 
  :akvo.lumen.component.handler/wrap-stacktrace {}

--- a/backend/dev/resources/dev.edn
+++ b/backend/dev/resources/dev.edn
@@ -2,7 +2,7 @@
 
  :akvo.lumen.component.http/http               {:port 3000}
 
- :akvo.lumen.component.tenant-manager {:encryption-key  "secret"}
+ :akvo.lumen.component.tenant-manager/tenant-manager {:encryption-key  "secret"}
 
  :akvo.lumen.component.caddisfly/local                  {:local-schema-uri "./caddisfly/tests-schema.json"}
  :akvo.lumen.component.error-tracker/local              {}

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -129,7 +129,7 @@
  :akvo.lumen.component.error-tracker/prod {:dsn #duct/env "LUMEN_SENTRY_BACKEND_DSN"}
  :akvo.lumen.migrate   {:migrations {:tenant-manager "akvo/lumen/migrations/tenant_manager"
                                      :tenants        "akvo/lumen/migrations/tenants"}}
- :akvo.lumen.specs   {:conform-specs #duct/env [ "LUMEN_CONFORM_SPECS" Bool :or false]}
+ :akvo.lumen.specs/specs   {:conform-specs #duct/env [ "LUMEN_CONFORM_SPECS" Bool :or false]}
 
  :akvo.lumen.monitoring/dropwizard-registry {}
  :akvo.lumen.monitoring/collector {:dropwizard-registry #ig/ref :akvo.lumen.monitoring/dropwizard-registry}

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -6,7 +6,7 @@
                                           :minimum-idle 2
                                           :metric-registry #ig/ref :akvo.lumen.monitoring/dropwizard-registry}
 
- :akvo.lumen.component.tenant-manager {:dropwizard-registry #ig/ref :akvo.lumen.monitoring/dropwizard-registry
+ :akvo.lumen.component.tenant-manager/tenant-manager {:dropwizard-registry #ig/ref :akvo.lumen.monitoring/dropwizard-registry
                                        :encryption-key      #duct/env "LUMEN_ENCRYPTION_KEY"
                                        :db                  #ig/ref :akvo.lumen.component.hikaricp/hikaricp}
 
@@ -25,15 +25,15 @@
  :akvo.lumen.component.tenant-manager/wrap-label-tenant  {}
  :akvo.lumen.component.error-tracker/wrap-sentry         {:dsn #duct/env "LUMEN_SENTRY_BACKEND_DSN" :opts {:namespaces ["org.akvo" "akvo"]}}
 
- :akvo.lumen.endpoint.aggregation/aggregation         {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
- :akvo.lumen.endpoint.collection/collection           {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
- :akvo.lumen.endpoint.dashboard/dashboard             {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
- :akvo.lumen.endpoint.dataset/dataset                 {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager
+ :akvo.lumen.endpoint.aggregation/aggregation         {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+ :akvo.lumen.endpoint.collection/collection           {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+ :akvo.lumen.endpoint.dashboard/dashboard             {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+ :akvo.lumen.endpoint.dataset/dataset                 {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                                        :error-tracker  #ig/ref :akvo.lumen.component.error-tracker/error-tracker
                                                        :upload-config #ig/ref :akvo.lumen.upload/data
                                                        :import-config {:flow-api-url #duct/env "LUMEN_FLOW_API_URL"
                                                                        :keycloak #ig/ref :akvo.lumen.component.keycloak/data}}
- :akvo.lumen.endpoint.data-source/data-source         {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
+ :akvo.lumen.endpoint.data-source/data-source         {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
  :akvo.lumen.endpoint.env/env                         {:keycloak-public-client-id #duct/env [ "LUMEN_KEYCLOAK_PUBLIC_CLIENT_ID" :or "akvo-lumen" ]
                                                        :keycloak-url              #duct/env "LUMEN_KEYCLOAK_URL"
                                                        :flow-api-url              #duct/env "LUMEN_FLOW_API_URL"
@@ -47,28 +47,28 @@
  
  :akvo.lumen.endpoint.files/files                     {:upload-config #ig/ref :akvo.lumen.upload/data}
  :akvo.lumen.endpoint.healthz/healthz                 {}
- :akvo.lumen.endpoint.invite/invite                   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager
+ :akvo.lumen.endpoint.invite/invite                   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                                        :keycloak       #ig/ref :akvo.lumen.component.keycloak
                                                        :emailer        #ig/ref :akvo.lumen.component.emailer/emailer}
- :akvo.lumen.endpoint.invite/verify                   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager
+ :akvo.lumen.endpoint.invite/verify                   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                                        :keycloak       #ig/ref :akvo.lumen.component.keycloak}
- :akvo.lumen.endpoint.job-execution/job-execution     {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
+ :akvo.lumen.endpoint.job-execution/job-execution     {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
 
- :akvo.lumen.endpoint.library/library                 {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
+ :akvo.lumen.endpoint.library/library                 {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
  :akvo.lumen.endpoint.multiple-column/multiple-column {:caddisfly #ig/ref :akvo.lumen.component.caddisfly/caddisfly}
- :akvo.lumen.endpoint.public/public                   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager
+ :akvo.lumen.endpoint.public/public                   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                                        :windshaft-url  "http://localhost:4000"}
- :akvo.lumen.endpoint.raster/raster                   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager
+ :akvo.lumen.endpoint.raster/raster                   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                                        :upload-config #ig/ref :akvo.lumen.upload/data}
- :akvo.lumen.endpoint.resource/resource               {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
- :akvo.lumen.endpoint.root/root                       {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
- :akvo.lumen.endpoint.share/share                     {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
- :akvo.lumen.endpoint.split-column/endpoint           {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
- :akvo.lumen.endpoint.tier/tier                       {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager}
- :akvo.lumen.endpoint.transformation/transformation   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager
+ :akvo.lumen.endpoint.resource/resource               {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+ :akvo.lumen.endpoint.root/root                       {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+ :akvo.lumen.endpoint.share/share                     {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+ :akvo.lumen.endpoint.split-column/endpoint           {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+ :akvo.lumen.endpoint.tier/tier                       {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+ :akvo.lumen.endpoint.transformation/transformation   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                                        :caddisfly      #ig/ref :akvo.lumen.component.caddisfly/caddisfly}
  :akvo.lumen.endpoint.user/user                       {:keycloak #ig/ref :akvo.lumen.component.keycloak}
- :akvo.lumen.endpoint.visualisation/visualisation     {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager
+ :akvo.lumen.endpoint.visualisation/visualisation     {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                                        :windshaft-url             "http://localhost:4000"}
 
  :akvo.lumen.component.handler/handler

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -48,10 +48,10 @@
  :akvo.lumen.endpoint.files/files                     {:upload-config #ig/ref :akvo.lumen.upload/data}
  :akvo.lumen.endpoint.healthz/healthz                 {}
  :akvo.lumen.endpoint.invite/invite                   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
-                                                       :keycloak       #ig/ref :akvo.lumen.component.keycloak
+                                                       :keycloak       #ig/ref :akvo.lumen.component.keycloak/keycloak
                                                        :emailer        #ig/ref :akvo.lumen.component.emailer/emailer}
  :akvo.lumen.endpoint.invite/verify                   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
-                                                       :keycloak       #ig/ref :akvo.lumen.component.keycloak}
+                                                       :keycloak       #ig/ref :akvo.lumen.component.keycloak/keycloak}
  :akvo.lumen.endpoint.job-execution/job-execution     {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
 
  :akvo.lumen.endpoint.library/library                 {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
@@ -67,7 +67,7 @@
  :akvo.lumen.endpoint.tier/tier                       {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
  :akvo.lumen.endpoint.transformation/transformation   {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                                        :caddisfly      #ig/ref :akvo.lumen.component.caddisfly/caddisfly}
- :akvo.lumen.endpoint.user/user                       {:keycloak #ig/ref :akvo.lumen.component.keycloak}
+ :akvo.lumen.endpoint.user/user                       {:keycloak #ig/ref :akvo.lumen.component.keycloak/keycloak}
  :akvo.lumen.endpoint.visualisation/visualisation     {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                                        :windshaft-url             "http://localhost:4000"}
 
@@ -117,7 +117,7 @@
  :akvo.lumen.component.keycloak/data  {:url         #duct/env "LUMEN_KEYCLOAK_URL"
                                        :realm       "akvo"}
 
- :akvo.lumen.component.keycloak       {:data #ig/ref :akvo.lumen.component.keycloak/data
+ :akvo.lumen.component.keycloak/keycloak       {:data #ig/ref :akvo.lumen.component.keycloak/data
                                        :credentials {:client_id     #duct/env [ "LUMEN_KEYCLOAK_CLIENT_ID" :or "akvo-lumen-confidential" ]
                                                      :client_secret #duct/env "LUMEN_KEYCLOAK_CLIENT_SECRET"}}
 

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -127,7 +127,7 @@
                                                    :from-name      "Akvo Lumen"}
 
  :akvo.lumen.component.error-tracker/prod {:dsn #duct/env "LUMEN_SENTRY_BACKEND_DSN"}
- :akvo.lumen.migrate   {:migrations {:tenant-manager "akvo/lumen/migrations/tenant_manager"
+ :akvo.lumen.migrate/migrate   {:migrations {:tenant-manager "akvo/lumen/migrations/tenant_manager"
                                      :tenants        "akvo/lumen/migrations/tenants"}}
  :akvo.lumen.specs/specs   {:conform-specs #duct/env [ "LUMEN_CONFORM_SPECS" Bool :or false]}
 

--- a/backend/specs/akvo/lumen/specs.clj
+++ b/backend/specs/akvo/lumen/specs.clj
@@ -52,11 +52,11 @@
          (recur (inc attempt))
          (first res))))))
 
-(defmethod ig/init-key :akvo.lumen.specs [_ opts]
+(defmethod ig/init-key :akvo.lumen.specs/specs [_ opts]
   opts)
 
 (s/def ::conform-specs boolean?)
-(defmethod integrant-key :akvo.lumen.specs [_]
+(defmethod integrant-key :akvo.lumen.specs/specs [_]
   (s/cat :kw keyword?
          :config (s/keys :req-un [::conform-specs])))
 

--- a/backend/src/akvo/lumen/component/keycloak.clj
+++ b/backend/src/akvo/lumen/component/keycloak.clj
@@ -291,7 +291,7 @@
   (s/cat :kw keyword?
          :config ::data))
 
-(defmethod ig/init-key :akvo.lumen.component.keycloak  [_ {:keys [credentials data] :as opts}]
+(defmethod ig/init-key :akvo.lumen.component.keycloak/keycloak  [_ {:keys [credentials data] :as opts}]
   (let [{:keys [issuer openid-config api-root] :as this} (keycloak (assoc data :credentials credentials))
         openid-config (fetch-openid-configuration issuer)]
       (log/info "Successfully got openid-config from provider.")
@@ -307,6 +307,6 @@
 
 (s/def ::keycloak (partial satisfies? p/KeycloakUserManagement))
 
-(defmethod integrant-key :akvo.lumen.component.keycloak [_]
+(defmethod integrant-key :akvo.lumen.component.keycloak/keycloak [_]
   (s/cat :kw keyword?
          :config ::config))

--- a/backend/src/akvo/lumen/component/tenant_manager.clj
+++ b/backend/src/akvo/lumen/component/tenant_manager.clj
@@ -110,7 +110,7 @@
       this
       (assoc this :tenants (atom {})))))
 
-(defmethod ig/halt-key! :akvo.lumen.component.tenant-manager [_ this]
+(defmethod ig/halt-key! :akvo.lumen.component.tenant-manager/tenant-manager [_ this]
   (if-let [tenants (:tenants this)]
     (do
       (doseq [[_ {spec ::spec}] @tenants]
@@ -124,7 +124,7 @@
 (s/def ::dropwizard-registry ::monitoring/metric-registry)
 (s/def ::tenant-manager (partial instance? TenantManager))
 
-(defmethod integrant-key :akvo.lumen.component.tenant-manager [_]
+(defmethod integrant-key :akvo.lumen.component.tenant-manager/tenant-manager [_]
   (s/cat :kw keyword?
          :config (s/keys :req-un [::db
                                   ::encryption-key

--- a/backend/src/akvo/lumen/component/tenant_manager.clj
+++ b/backend/src/akvo/lumen/component/tenant_manager.clj
@@ -104,7 +104,7 @@
 (defn- tenant-manager [options]
   (map->TenantManager options))
 
-(defmethod ig/init-key :akvo.lumen.component.tenant-manager [_ {:keys [db encryption-key dropwizard-registry] :as opts}]
+(defmethod ig/init-key :akvo.lumen.component.tenant-manager/tenant-manager [_ {:keys [db encryption-key dropwizard-registry] :as opts}]
   (let [this (tenant-manager opts)]
     (if (:tenants this)
       this

--- a/backend/src/akvo/lumen/migrate.clj
+++ b/backend/src/akvo/lumen/migrate.clj
@@ -107,13 +107,13 @@
                         (:tenants migrations)
                         (count (:tenants migrations))))))
 
-(defmethod ig/init-key :akvo.lumen.migrate [_ opts]
+(defmethod ig/init-key :akvo.lumen.migrate/migrate [_ opts]
   opts)
 (s/def ::tenant-manager string?)
 (s/def ::tenants string?)
 (s/def ::migrations (s/keys :req-un [::tenant-manager ::tenants]))
 
-(defmethod integrant-key :akvo.lumen.migrate [_]
+(defmethod integrant-key :akvo.lumen.migrate/migrate [_]
   (s/cat :kw keyword?
          :config (s/keys :req-un [::migrations])))
 

--- a/backend/src/akvo/lumen/migrate.clj
+++ b/backend/src/akvo/lumen/migrate.clj
@@ -42,9 +42,9 @@
   "From a system definition get migrations for tenant manager and tenants."
   [system]
   {:tenant-manager (ragtime-jdbc/load-resources
-                    (get-in system [:akvo.lumen.migrate :migrations :tenant-manager]))
+                    (get-in system [:akvo.lumen.migrate/migrate :migrations :tenant-manager]))
    :tenants        (ragtime-jdbc/load-resources
-                    (get-in system [:akvo.lumen.migrate :migrations :tenants]))})
+                    (get-in system [:akvo.lumen.migrate/migrate :migrations :tenants]))})
 
 (defn migrate
   "Migrate tenant manager and tenants."
@@ -56,7 +56,7 @@
      (doseq [tenant (all-tenants tenant-manager-db)]
        (try
          (do-migrate (ragtime-jdbc/sql-database
-                          {:connection-uri (aes/decrypt (get-in config [:akvo.lumen.component.tenant-manager :encryption-key])
+                          {:connection-uri (aes/decrypt (get-in config [:akvo.lumen.component.tenant-manager/tenant-manager :encryption-key])
                                                         (:db_uri tenant))})
                         (:tenants migrations))
          (catch Exception e (throw (ex-info "Migration failed" {:tenant (:label tenant)} e))))))))
@@ -89,7 +89,7 @@
         tenant-manager-migrations (:tenant-manager migrations)
 
         tenant-manager-db {:connection-uri (get-in config [:akvo.lumen.component.hikaricp/hikaricp :uri])}
-        tenant-connection-uri-fn #(aes/decrypt (get-in config [:akvo.lumen.component.tenant-manager :encryption-key])
+        tenant-connection-uri-fn #(aes/decrypt (get-in config [:akvo.lumen.component.tenant-manager/tenant-manager :encryption-key])
                                        (:db_uri %))]
     (cond
       (= arg :tenant-manager)

--- a/backend/test/akvo/lumen/lib/user_test.clj
+++ b/backend/test/akvo/lumen/lib/user_test.clj
@@ -29,7 +29,7 @@
 (defn fixture [f]
   (migrate-tenant test-tenant)
   (binding [*emailer* (ig/init-key :akvo.lumen.component.emailer/dev-emailer {:config {:from-email "" :from-name ""}})
-            *keycloak* (ig/init-key :akvo.lumen.component.keycloak keycloak-config)
+            *keycloak* (ig/init-key :akvo.lumen.component.keycloak/keycloak keycloak-config)
             *tenant-conn* (test-tenant-conn test-tenant)]
     (f)))
 


### PR DESCRIPTION
This PR relates to following error
```
Caused by: java.lang.IllegalArgumentException: No method in multimethod 'init-key' for dispatch value: :akvo.lumen.specs
at clojure.lang.MultiFn.getFn (MultiFn.java:156)
at clojure.lang.MultiFn.invoke (MultiFn.java:233)
at integrant.core$try_build_action.invokeStatic (core.cljc:292)
```

https://weavejester.github.io/integrant/integrant.core.html#var-load-namespaces  impl doesn't work properly when component keys aren't fully qualified keywords. 
So `load-namespaces` doesn't work with `:akvo.lumen.specs` but integrant let's you use this identifier

Then adapting code to ensure that lumen can use this utility function https://github.com/weavejester/integrant#loading-namespaces 

- `akvo.lumen.specs` changes to `akvo.lumen.specs/specs`
- `akvo.lumen.migrate` changes to `akvo.lumen.migrate/migrate`
- `akvo.lumen.component.tenant-manager` changes to `akvo.lumen.component.tenant-manager/tenant-manager`
- `akvo.lumen.component.keycloak` changes to `akvo.lumen.component.keycloak/keycloak`


- [ ] **Update release notes if necessary**
