### PR TITLE
Fix for error protecting dashboards (Connect #2024)

### DIFF
--- a/client/src/components/modals/ShareEntity.scss
+++ b/client/src/components/modals/ShareEntity.scss
@@ -31,11 +31,8 @@
     }
 
     .alert {
-        height: 0.8rem;
         color: $darkLime;
         display: inline-block;
-
-        @include border-radius(100%);
 
         text-align: center;
         margin-right: 0.15rem;

--- a/client/src/containers/Dashboard.jsx
+++ b/client/src/containers/Dashboard.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isEmpty, cloneDeep } from 'lodash';
 import get from 'lodash/get';
-import set from 'lodash/set';
 import { intlShape, injectIntl } from 'react-intl';
 import BodyClassName from 'react-body-classname';
 

--- a/client/src/containers/Dashboard.jsx
+++ b/client/src/containers/Dashboard.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isEmpty, cloneDeep } from 'lodash';
 import get from 'lodash/get';
+import set from 'lodash/set';
 import { intlShape, injectIntl } from 'react-intl';
 import BodyClassName from 'react-body-classname';
 
@@ -432,8 +433,7 @@ class Dashboard extends Component {
 
   handleToggleShareProtected(isProtected) {
     this.setState({ passwordAlert: null });
-    const dashboard = getDashboardFromState(this.state.dashboard, true);
-    this.props.dispatch(actions.setShareProtection(dashboard.shareId, { protected: isProtected }));
+    set(this.state, 'dashboard.protected', isProtected);
   }
 
   toggleShareDashboard() {

--- a/client/src/containers/Dashboard.jsx
+++ b/client/src/containers/Dashboard.jsx
@@ -432,8 +432,13 @@ class Dashboard extends Component {
   }
 
   handleToggleShareProtected(isProtected) {
-    this.setState({ passwordAlert: null });
-    set(this.state, 'dashboard.protected', isProtected);
+    this.setState({
+      passwordAlert: null,
+      dashboard: {
+        ...this.state.dashboard,
+        protected: isProtected,
+      },
+    });
   }
 
   toggleShareDashboard() {

--- a/client/src/utilities/visualisation.js
+++ b/client/src/utilities/visualisation.js
@@ -13,7 +13,7 @@ export const remapVisualisationDataColumnMappings = (visualisation, newVisualisa
   const mappings = specMappings[visualisation.visualisationType][newVisualisationType] || {};
 
   if (!specMappings[visualisation.visualisationType][newVisualisationType]) {
-    console.warn(`visualization data column mappings not defined for ${visualisation.visualisationType} -> ${newVisualisationType}`);  /* eslint-disable-line no-console */
+    console.warn(`visualization data column mappings not defined for ${visualisation.visualisationType} -> ${newVisualisationType}`);  /* eslint-disable-line */
   }
   return Object.keys(mappings)
     .reduce((acc, key) => {


### PR DESCRIPTION
There are some outstanding issues. For example, if a password is set. And then the user tries to update the password to a too short one. He/she will get an error dialog at the bottom of the screen (the backend responded with error) but the alert in the modal will be all happy with a green succeded. But I think that is another issue than this initial one. I tried to fix that one too, but backed out of it since it looked to me like a little bit of rearchitecting is needed. @finnfiddle if you think different ping me.