### PR TITLE
WIP Issue 1949 filter library

### DIFF
--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -77,7 +77,8 @@
 
  :akvo.lumen.endpoint.job-execution/job-execution {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
 
- :akvo.lumen.endpoint.library/library {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+ :akvo.lumen.endpoint.library/library {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
+                                       :flow-api #ig/ref :akvo.lumen.component.flow/api}
 
  :akvo.lumen.endpoint.multiple-column/multiple-column {:caddisfly #ig/ref :akvo.lumen.component.caddisfly/caddisfly}
 

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -41,20 +41,21 @@
  :akvo.lumen.endpoint.collection/collection {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
  
  :akvo.lumen.endpoint.dashboard/dashboard {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+ :akvo.lumen.component.flow/api {:url #duct/env "LUMEN_FLOW_API_URL"}
  
  :akvo.lumen.endpoint.dataset/dataset {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                        :error-tracker #ig/ref :akvo.lumen.component.error-tracker/error-tracker
                                        :upload-config #ig/ref :akvo.lumen.upload/data
-                                       :import-config {:flow-api-url #duct/env "LUMEN_FLOW_API_URL"
+                                       :import-config {:flow-api #ig/ref :akvo.lumen.component.flow/api
                                                        :keycloak #ig/ref :akvo.lumen.component.keycloak/data}}
 
  :akvo.lumen.endpoint.data-source/data-source {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
 
  :akvo.lumen.endpoint.env/env {:routes-opts
                                {:middleware [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant]}
+                               :keycloak #ig/ref :akvo.lumen.component.keycloak/data
                                :keycloak-public-client-id #duct/env [ "LUMEN_KEYCLOAK_PUBLIC_CLIENT_ID" :or "akvo-lumen" ]
-                               :keycloak-url #duct/env "LUMEN_KEYCLOAK_URL"
-                               :flow-api-url #duct/env "LUMEN_FLOW_API_URL"
+                               :flow-api #ig/ref :akvo.lumen.component.flow/api
                                :sentry-client-dsn #duct/env "LUMEN_SENTRY_CLIENT_DSN"
                                :piwik-site-id #duct/env "LUMEN_PIWIK_SITE_ID"}
 

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -41,13 +41,14 @@
  :akvo.lumen.endpoint.collection/collection {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
  
  :akvo.lumen.endpoint.dashboard/dashboard {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
- :akvo.lumen.component.flow/api {:url #duct/env "LUMEN_FLOW_API_URL"}
+
+ :akvo.lumen.component.flow/api {:url #duct/env "LUMEN_FLOW_API_URL"
+                                 :keycloak #ig/ref :akvo.lumen.component.keycloak/data}
  
  :akvo.lumen.endpoint.dataset/dataset {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                        :error-tracker #ig/ref :akvo.lumen.component.error-tracker/error-tracker
                                        :upload-config #ig/ref :akvo.lumen.upload/data
-                                       :import-config {:flow-api #ig/ref :akvo.lumen.component.flow/api
-                                                       :keycloak #ig/ref :akvo.lumen.component.keycloak/data}}
+                                       :import-config {:flow-api #ig/ref :akvo.lumen.component.flow/api}}
 
  :akvo.lumen.endpoint.data-source/data-source {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
 

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -29,6 +29,9 @@
 
  :akvo.lumen.auth/wrap-auth {}
 
+ :akvo.lumen.auth/wrap-ds-auth {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
+                                :flow-api #ig/ref :akvo.lumen.component.flow/api}
+
  :akvo.lumen.auth/wrap-jwt {:keycloak #ig/ref :akvo.lumen.component.keycloak/data}
 
  :akvo.lumen.component.tenant-manager/wrap-label-tenant {}
@@ -110,6 +113,7 @@
                                             :middleware [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant
                                                          #ig/ref :akvo.lumen.auth/wrap-jwt
                                                          #ig/ref :akvo.lumen.auth/wrap-auth
+                                                         #ig/ref :akvo.lumen.auth/wrap-ds-auth
                                                          #ig/ref :akvo.lumen.component.handler/common-middleware
                                                          #ig/ref :akvo.lumen.monitoring/middleware]
                                             :routes [#ig/ref :akvo.lumen.endpoint.aggregation/aggregation

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -29,8 +29,8 @@
 
  :akvo.lumen.auth/wrap-auth {}
 
- :akvo.lumen.auth/wrap-ds-auth {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
-                                :flow-api #ig/ref :akvo.lumen.component.flow/api}
+ :akvo.lumen.auth/wrap-auth-datasets {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
+                                      :flow-api #ig/ref :akvo.lumen.component.flow/api}
 
  :akvo.lumen.auth/wrap-jwt {:keycloak #ig/ref :akvo.lumen.component.keycloak/data}
 
@@ -113,7 +113,7 @@
                                             :middleware [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant
                                                          #ig/ref :akvo.lumen.auth/wrap-jwt
                                                          #ig/ref :akvo.lumen.auth/wrap-auth
-                                                         #ig/ref :akvo.lumen.auth/wrap-ds-auth
+                                                         #ig/ref :akvo.lumen.auth/wrap-auth-datasets
                                                          #ig/ref :akvo.lumen.component.handler/common-middleware
                                                          #ig/ref :akvo.lumen.monitoring/middleware]
                                             :routes [#ig/ref :akvo.lumen.endpoint.aggregation/aggregation

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -104,7 +104,7 @@
                        (with-meta ["/api/visualisations"] {:methods #{:get :post}})
                        (with-meta ["/api/visualisations/:id"] {:methods #{:get :put :delete}})
                        (with-meta ["/api/collections"] {:methods #{:get #_:post}})
-                       #_(with-meta ["/api/collections/:id"] {:methods #{:get :put :delete}})}]
+                       (with-meta ["/api/collections/:id"] {:methods #{:get}})}]
       (fn [{:keys [jwt-claims tenant] :as request}]
         (log/warn :AUTH??? [(:template (:reitit.core/match request)) (:request-method request)]
                    (-> (get auth-calls [(:template (:reitit.core/match request))])

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -94,7 +94,9 @@
   (fn [handler]
     (let [auth-calls #{(with-meta ["/api/library"] {:methods #{:get}})
                        (with-meta ["/api/datasets"] {:methods #{:get}})
-                       (with-meta ["/api/datasets/:id"] {:methods #{:get :put :delete}})}]
+                       (with-meta ["/api/datasets/:id"] {:methods #{:get :put :delete}})
+                       (with-meta ["/api/datasets/:id/meta"] {:methods #{:get}})
+                       (with-meta ["/api/datasets/:id/update"] {:methods #{:post}})}]
       (fn [{:keys [jwt-claims tenant] :as request}]
         (log/debug :wrap-ds-auth [(:template (:reitit.core/match request)) (:request-method request)])
         (let [dss (all-datasets (p/connection tenant-manager tenant))
@@ -128,3 +130,8 @@
 (defmethod ig/pre-init-spec :akvo.lumen.auth/wrap-ds-auth [_]
   ;; todo
   any?)
+
+(defmacro auth-ds [id auth-datasets & body]
+  `(if (contains? (set ~auth-datasets) ~id)
+     ~@body
+     (lib/not-found {:error "Not found"})))

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -98,6 +98,7 @@
                        (with-meta ["/api/datasets/:id/meta"] {:methods #{:get}})
                        (with-meta ["/api/datasets/:id/update"] {:methods #{:post}})
                        (with-meta ["/api/aggregation/:dataset-id/:visualisation-type"] {:methods #{:get}})
+                       (with-meta ["/api/dashboards"] {:methods #{:get :post}})
                        (with-meta ["/api/visualisations/maps"] {:methods #{:post}})
                        (with-meta ["/api/visualisations"] {:methods #{:get :post}})
                        (with-meta ["/api/visualisations/:id"] {:methods #{:get :put :delete}})}]

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -96,7 +96,8 @@
                        (with-meta ["/api/datasets"] {:methods #{:get}})
                        (with-meta ["/api/datasets/:id"] {:methods #{:get :put :delete}})
                        (with-meta ["/api/datasets/:id/meta"] {:methods #{:get}})
-                       (with-meta ["/api/datasets/:id/update"] {:methods #{:post}})}]
+                       (with-meta ["/api/datasets/:id/update"] {:methods #{:post}})
+                       (with-meta ["/api/aggregation/:dataset-id/:visualisation-type"] {:methods #{:get}})}]
       (fn [{:keys [jwt-claims tenant] :as request}]
         (log/debug :wrap-ds-auth [(:template (:reitit.core/match request)) (:request-method request)])
         (let [dss (all-datasets (p/connection tenant-manager tenant))
@@ -139,6 +140,7 @@
           auth-datasets :auth-datasets
           :as request}]
       (let [dataset-id (id-key path-params)]
+        (log/error :authenticate-dataset-middleware (contains? (set auth-datasets) dataset-id) dataset-id (set auth-datasets))
         (if (contains? (set auth-datasets) dataset-id)
           (handler request)
           not-authorized)))))

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -103,8 +103,8 @@
                        (with-meta ["/api/visualisations/maps"] {:methods #{:post}})
                        (with-meta ["/api/visualisations"] {:methods #{:get :post}})
                        (with-meta ["/api/visualisations/:id"] {:methods #{:get :put :delete}})
-                       (with-meta ["/api/collections"] {:methods #{:get #_:post}})
-                       (with-meta ["/api/collections/:id"] {:methods #{:get}})}]
+                       (with-meta ["/api/collections"] {:methods #{:get :post}})
+                       (with-meta ["/api/collections/:id"] {:methods #{:get :put :delete}})}]
       (fn [{:keys [jwt-claims tenant] :as request}]
         (log/warn :AUTH??? [(:template (:reitit.core/match request)) (:request-method request)]
                    (-> (get auth-calls [(:template (:reitit.core/match request))])

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -97,9 +97,10 @@
                        (with-meta ["/api/datasets/:id"] {:methods #{:get :put :delete}})
                        (with-meta ["/api/datasets/:id/meta"] {:methods #{:get}})
                        (with-meta ["/api/datasets/:id/update"] {:methods #{:post}})
-                       (with-meta ["/api/aggregation/:dataset-id/:visualisation-type"] {:methods #{:get}})}]
+                       (with-meta ["/api/aggregation/:dataset-id/:visualisation-type"] {:methods #{:get}})
+                       (with-meta ["/api/visualisations"] {:methods #{:get :post}})
+                       (with-meta ["/api/visualisations/:id"] {:methods #{:get :put :delete}})}]
       (fn [{:keys [jwt-claims tenant] :as request}]
-        (log/debug :wrap-ds-auth [(:template (:reitit.core/match request)) (:request-method request)])
         (let [dss (all-datasets (p/connection tenant-manager tenant))
               _ (log/debug :all-datasets (map :id dss))
               request (if (-> (get auth-calls [(:template (:reitit.core/match request))])

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -99,6 +99,7 @@
                        (with-meta ["/api/datasets/:id/update"] {:methods #{:post}})
                        (with-meta ["/api/aggregation/:dataset-id/:visualisation-type"] {:methods #{:get}})
                        (with-meta ["/api/dashboards"] {:methods #{:get :post}})
+                       (with-meta ["/api/dashboards/:id"] {:methods #{:get :put :delete}})
                        (with-meta ["/api/visualisations/maps"] {:methods #{:post}})
                        (with-meta ["/api/visualisations"] {:methods #{:get :post}})
                        (with-meta ["/api/visualisations/:id"] {:methods #{:get :put :delete}})}]

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -92,29 +92,35 @@
   using flow-api check_permissions"
   [tenant-manager flow-api]
   (fn [handler]
-    (fn [{:keys [jwt-claims tenant] :as request}]
-      (log/debug :before-authenticating (:template (:reitit.core/match request)))
-      (let [dss (all-datasets (p/connection tenant-manager tenant))
-            _ (log/debug :all-datasets (map :id dss))
-            request (if (contains? #{"/api/library"} (:template (:reitit.core/match request)))
-                      (let [permissions (->> (map :source dss)
-                                             (filter #(and (= (get % "instance") "uat1") (= "AKVO_FLOW" (get % "kind"))))
-                                             (map c.flow/>api-model)
-                                             (c.flow/check-permissions flow-api (jwt/jwt-token request))
-                                             :body
-                                             set)
-                            
-                            auth-datasets (->> dss
-                                               (filter
-                                                (fn [ds]
-                                                  (let [source (:source ds)]
-                                                    (if (= "AKVO_FLOW" (get source "kind"))
-                                                      (contains? permissions (c.flow/>api-model source))
-                                                      true))))
-                                               (mapv :id))]
-                        (assoc request :auth-datasets auth-datasets))
-                      request)]
-        (handler request)))))
+    (let [auth-calls #{(with-meta ["/api/library"] {:methods #{:get}})
+                       (with-meta ["/api/datasets"] {:methods #{:get}})
+                       (with-meta ["/api/datasets/:id"] {:methods #{:get :put :delete}})}]
+      (fn [{:keys [jwt-claims tenant] :as request}]
+        (log/debug :wrap-ds-auth [(:template (:reitit.core/match request)) (:request-method request)])
+        (let [dss (all-datasets (p/connection tenant-manager tenant))
+              _ (log/debug :all-datasets (map :id dss))
+              request (if (-> (get auth-calls [(:template (:reitit.core/match request))])
+                              meta
+                              :methods
+                              (contains? (:request-method request)))
+                        (let [permissions (->> (map :source dss)
+                                               (filter #(and (= (get % "instance") "uat1") (= "AKVO_FLOW" (get % "kind"))))
+                                               (map c.flow/>api-model)
+                                               (c.flow/check-permissions flow-api (jwt/jwt-token request))
+                                               :body
+                                               set)
+                              
+                              auth-datasets (->> dss
+                                                 (filter
+                                                  (fn [ds]
+                                                    (let [source (:source ds)]
+                                                      (if (= "AKVO_FLOW" (get source "kind"))
+                                                        (contains? permissions (c.flow/>api-model source))
+                                                        true))))
+                                                 (mapv :id))]
+                          (assoc request :auth-datasets auth-datasets))
+                        request)]
+          (handler request))))))
 
 (defmethod ig/init-key :akvo.lumen.auth/wrap-ds-auth  [_ {:keys [tenant-manager flow-api] :as opts}]
  (wrap-ds-auth tenant-manager flow-api))

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -98,6 +98,7 @@
                        (with-meta ["/api/datasets/:id/meta"] {:methods #{:get}})
                        (with-meta ["/api/datasets/:id/update"] {:methods #{:post}})
                        (with-meta ["/api/aggregation/:dataset-id/:visualisation-type"] {:methods #{:get}})
+                       (with-meta ["/api/visualisations/maps"] {:methods #{:post}})
                        (with-meta ["/api/visualisations"] {:methods #{:get :post}})
                        (with-meta ["/api/visualisations/:id"] {:methods #{:get :put :delete}})}]
       (fn [{:keys [jwt-claims tenant] :as request}]

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -97,13 +97,14 @@
                        (with-meta ["/api/datasets/:id"] {:methods #{:get :put :delete}})
                        (with-meta ["/api/datasets/:id/meta"] {:methods #{:get}})
                        (with-meta ["/api/datasets/:id/update"] {:methods #{:post}})
-;;                       (with-meta ["/job_executions/:kind/:id"] {:methods #{:get}})
                        (with-meta ["/api/aggregation/:dataset-id/:visualisation-type"] {:methods #{:get}})
                        (with-meta ["/api/dashboards"] {:methods #{:get :post}})
                        (with-meta ["/api/dashboards/:id"] {:methods #{:get :put :delete}})
                        (with-meta ["/api/visualisations/maps"] {:methods #{:post}})
                        (with-meta ["/api/visualisations"] {:methods #{:get :post}})
-                       (with-meta ["/api/visualisations/:id"] {:methods #{:get :put :delete}})}]
+                       (with-meta ["/api/visualisations/:id"] {:methods #{:get :put :delete}})
+                       (with-meta ["/api/collections"] {:methods #{:get #_:post}})
+                       #_(with-meta ["/api/collections/:id"] {:methods #{:get :put :delete}})}]
       (fn [{:keys [jwt-claims tenant] :as request}]
         (log/warn :AUTH??? [(:template (:reitit.core/match request)) (:request-method request)]
                    (-> (get auth-calls [(:template (:reitit.core/match request))])

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -29,13 +29,16 @@
      "Accept" "application/vnd.akvo.flow.v2+json"
      "X-Akvo-Email" "akvo.flow.user.test2@gmail.com"}))
 
-(defn check-permissions [flow-api refresh-token body headers]
-  (http/post
-   (str (:url flow-api) "/check_permissions")
-   {:as :json
-    :headers (if headers headers (api-headers flow-api refresh-token))
-    :form-params body
-    :content-type :json}))
+(defn check-permissions
+  ([flow-api refresh-token body]
+   (check-permissions flow-api refresh-token body (api-headers flow-api refresh-token)))
+  ([flow-api refresh-token body headers]
+   (http/post
+    (str (:url flow-api) "/check_permissions")
+    {:as :json
+     :headers headers
+     :form-params body
+     :content-type :json})))
 
 
 (defmethod ig/init-key ::api  [_ {:keys [url] :as opts}]

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -1,0 +1,13 @@
+(ns akvo.lumen.component.flow
+  "wrap flow and flow api logic and data related"
+  (:require [integrant.core :as ig]
+            [clojure.spec.alpha :as s]))
+
+(defmethod ig/init-key ::api  [_ {:keys [url] :as opts}]
+  opts)
+
+(s/def ::url string?)
+(s/def ::config (s/keys :req-un [::url]))
+
+(defmethod ig/pre-init-spec ::api [_]
+  ::config)

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -1,13 +1,38 @@
 (ns akvo.lumen.component.flow
   "wrap flow and flow api logic and data related"
   (:require [integrant.core :as ig]
+            [akvo.lumen.component.keycloak :as c.keycloak]
+            [clj-http.client :as http]
             [clojure.spec.alpha :as s]))
+
+(defn access-token
+  "Fetch a new access token using a refresh token"
+  [token-endpoint refresh-token]
+  (-> (http/post token-endpoint
+                 {:form-params {"client_id" "akvo-lumen"
+                                "refresh_token" refresh-token
+                                "grant_type" "refresh_token"}
+                  :as :json})
+      :body
+      :access_token))
+
+(defn api-headers
+  [this refresh-token]
+  (let [token-endpoint (format "%s/realms/%s/protocol/openid-connect/token"
+                               (-> this :keycloak :url)
+                               (-> this :keycloak :realm))]
+    {"Authorization" (format "Bearer %s" (access-token token-endpoint refresh-token))
+     "User-Agent" "lumen"
+     "Accept" "application/vnd.akvo.flow.v2+json"
+     "X-Akvo-Email" "akvo.flow.user.test2@gmail.com"}))
+
 
 (defmethod ig/init-key ::api  [_ {:keys [url] :as opts}]
   opts)
 
 (s/def ::url string?)
-(s/def ::config (s/keys :req-un [::url]))
+(s/def ::keycloak :akvo.lumen.component.keycloak/data)
+(s/def ::config (s/keys :req-un [::url ::keycloak]))
 
 (defmethod ig/pre-init-spec ::api [_]
   ::config)

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -3,28 +3,39 @@
   (:require [integrant.core :as ig]
             [akvo.lumen.component.keycloak :as c.keycloak]
             [clj-http.client :as http]
+            [clojure.tools.logging :as log]
             [clojure.spec.alpha :as s]))
 
 (defn access-token
   "Fetch a new access token using a refresh token"
-  [token-endpoint refresh-token]
-  (-> (http/post token-endpoint
-                 {:form-params {"client_id" "akvo-lumen"
-                                "refresh_token" refresh-token
-                                "grant_type" "refresh_token"}
-                  :as :json})
-      :body
-      :access_token))
-
-(defn api-headers
   [this refresh-token]
   (let [token-endpoint (format "%s/realms/%s/protocol/openid-connect/token"
                                (-> this :keycloak :url)
                                (-> this :keycloak :realm))]
-    {"Authorization" (format "Bearer %s" (access-token token-endpoint refresh-token))
+    (-> (http/post token-endpoint
+                   {:form-params {"client_id" "akvo-lumen"
+                                  "refresh_token" refresh-token
+                                  "grant_type" "refresh_token"}
+                    :as :json})
+        :body
+        :access_token)))
+
+
+(defn api-headers
+  [this refresh-token]
+  (let [access-token (access-token this refresh-token)]
+    {"Authorization" (format "Bearer %s" access-token)
      "User-Agent" "lumen"
      "Accept" "application/vnd.akvo.flow.v2+json"
      "X-Akvo-Email" "akvo.flow.user.test2@gmail.com"}))
+
+(defn check-permissions [flow-api refresh-token body headers]
+  (http/post
+   (str (:url flow-api) "/check_permissions")
+   {:as :json
+    :headers (if headers headers (api-headers flow-api refresh-token))
+    :form-params body
+    :content-type :json}))
 
 
 (defmethod ig/init-key ::api  [_ {:keys [url] :as opts}]

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -22,23 +22,19 @@
 
 
 (defn api-headers
-  [this refresh-token]
-  (let [access-token (access-token this refresh-token)]
-    {"Authorization" (format "Bearer %s" access-token)
-     "User-Agent" "lumen"
-     "Accept" "application/vnd.akvo.flow.v2+json"
-     "X-Akvo-Email" "akvo.flow.user.test2@gmail.com"}))
+  [token]
+  {"Authorization" (format "Bearer %s" token)
+   "User-Agent" "lumen"
+   "Accept" "application/vnd.akvo.flow.v2+json"})
 
 (defn check-permissions
-  ([flow-api refresh-token body]
-   (check-permissions flow-api refresh-token body (api-headers flow-api refresh-token)))
-  ([flow-api refresh-token body headers]
-   (http/post
-    (str (:url flow-api) "/check_permissions")
-    {:as :json
-     :headers headers
-     :form-params body
-     :content-type :json})))
+  [flow-api body token]
+  (http/post
+   (str (:url flow-api) "/check_permissions")
+   {:as :json
+    :headers (api-headers token)
+    :form-params body
+    :content-type :json}))
 
 
 (defmethod ig/init-key ::api  [_ {:keys [url] :as opts}]

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -28,13 +28,15 @@
    "Accept" "application/vnd.akvo.flow.v2+json"})
 
 (defn check-permissions
-  [flow-api body token]
-  (http/post
-   (str (:url flow-api) "/check_permissions")
-   {:as :json
-    :headers (api-headers token)
-    :form-params body
-    :content-type :json}))
+  [flow-api token body]
+  (try
+    (http/post
+     (str (:url flow-api) "/check_permissions")
+     {:as :json
+      :headers (api-headers token)
+      :form-params body
+      :content-type :json})
+    (catch Exception e (log/error :fail body (.getMessage e)))))
 
 
 (defmethod ig/init-key ::api  [_ {:keys [url] :as opts}]
@@ -46,3 +48,9 @@
 
 (defmethod ig/pre-init-spec ::api [_]
   ::config)
+
+(defn >api-model [ds-source]
+  (let [instance (get ds-source "instance")
+        survey (get ds-source "surveyId")]
+    {:instance_id (if (= "uat1" instance) (str "akvoflow-" instance) instance)
+     :survey_id survey}))

--- a/backend/src/akvo/lumen/component/handler.clj
+++ b/backend/src/akvo/lumen/component/handler.clj
@@ -20,21 +20,21 @@
   (if-not handler
     (let [router (ring/router endpoints
                               (merge {:conflicts (constantly nil)}
-                                     (when middleware {:data {:middleware middleware}})))
-          _ (pprint (map (juxt first (comp #(disj % :middleware) set keys second))
-                                        (rc/routes router)) )
+                                     (when middleware {:data {:middleware (vec (flatten middleware))}})))
+          _ (pprint (map (juxt first (comp #(disj % :middleware) set keys second)) (rc/routes router)) )
+          _ (pprint {"/api/datasets/:id" (:middleware (:data (rc/match-by-path router "/api/datasets/:id")))})
           handler (ring/ring-handler router)]
       (assoc opts :handler handler))
     opts))
 
 (defmethod ig/init-key :akvo.lumen.component.handler/handler-api  [_ {:keys [path middleware routes] :as opts}]
-  [path {:middleware (flatten middleware)} routes])
+  [path {:middleware (vec (flatten middleware))} routes])
 
 (defmethod ig/init-key :akvo.lumen.component.handler/handler-verify  [_ {:keys [path middleware routes] :as opts}]
-  [path {:middleware (flatten middleware)} routes])
+  [path {:middleware (vec (flatten middleware))} routes])
 
 (defmethod ig/init-key :akvo.lumen.component.handler/handler-share  [_ {:keys [path middleware routes] :as opts}]
-  [path {:middleware (flatten middleware)} routes])
+  [path {:middleware (vec (flatten middleware))} routes])
 
 (s/def ::endpoints  (s/coll-of ::rs/raw-routes))
 

--- a/backend/src/akvo/lumen/component/handler.clj
+++ b/backend/src/akvo/lumen/component/handler.clj
@@ -10,6 +10,7 @@
             [reitit.core :as rc]
             [reitit.ring.coercion :as rrc]
             [reitit.spec :as rs]
+            [clojure.pprint :refer (pprint)]
             [ring.middleware.defaults]
             [ring.middleware.json]
             [ring.middleware.stacktrace]
@@ -20,7 +21,7 @@
     (let [router (ring/router endpoints
                               (merge {:conflicts (constantly nil)}
                                      (when middleware {:data {:middleware middleware}})))
-          _ (clojure.pprint/pprint (map (juxt first (comp #(disj % :middleware) set keys second))
+          _ (pprint (map (juxt first (comp #(disj % :middleware) set keys second))
                                         (rc/routes router)) )
           handler (ring/ring-handler router)]
       (assoc opts :handler handler))

--- a/backend/src/akvo/lumen/component/handler.clj
+++ b/backend/src/akvo/lumen/component/handler.clj
@@ -1,14 +1,15 @@
 (ns akvo.lumen.component.handler
-  (:require [compojure.response :as compojure.res]
-            [integrant.core :as ig]
-            [akvo.lumen.endpoint.commons :as commons]
-            [reitit.ring :as ring]
-            [reitit.spec :as rs]
-            [reitit.coercion.spec]
-            [clojure.tools.logging :as log]
-            [muuntaja.core :as m]
-            [reitit.ring.coercion :as rrc]
+  (:require [akvo.lumen.endpoint.commons :as commons]
             [clojure.spec.alpha :as s]
+            [clojure.tools.logging :as log]
+            [compojure.response :as compojure.res]
+            [integrant.core :as ig]
+            [muuntaja.core :as m]
+            [reitit.coercion.spec]
+            [reitit.ring :as ring]
+            [reitit.core :as rc]
+            [reitit.ring.coercion :as rrc]
+            [reitit.spec :as rs]
             [ring.middleware.defaults]
             [ring.middleware.json]
             [ring.middleware.stacktrace]
@@ -16,10 +17,12 @@
 
 (defmethod ig/init-key :akvo.lumen.component.handler/handler  [_ {:keys [endpoints middleware handler] :as opts}]
   (if-not handler
-    (let [handler (ring/ring-handler
-                   (ring/router endpoints
-                                (merge {:conflicts (constantly nil)}
-                                       (when middleware {:data {:middleware middleware}}))))]
+    (let [router (ring/router endpoints
+                              (merge {:conflicts (constantly nil)}
+                                     (when middleware {:data {:middleware middleware}})))
+          _ (clojure.pprint/pprint (map (juxt first (comp #(disj % :middleware) set keys second))
+                                        (rc/routes router)) )
+          handler (ring/ring-handler router)]
       (assoc opts :handler handler))
     opts))
 

--- a/backend/src/akvo/lumen/endpoint/aggregation.clj
+++ b/backend/src/akvo/lumen/endpoint/aggregation.clj
@@ -1,10 +1,11 @@
 (ns akvo.lumen.endpoint.aggregation
-  (:require [akvo.lumen.protocols :as p]
+  (:require [akvo.lumen.auth :as auth]
+            [akvo.lumen.component.tenant-manager :as tenant-manager]
             [akvo.lumen.endpoint.commons.http :as http]
             [akvo.lumen.lib.aggregation :as aggregation]
+            [akvo.lumen.protocols :as p]
             [cheshire.core :as json]
             [clojure.spec.alpha :as s]
-            [akvo.lumen.component.tenant-manager :as tenant-manager]
             [integrant.core :as ig])
   (:import [com.fasterxml.jackson.core JsonParseException]))
 
@@ -28,10 +29,10 @@
 
 (defn routes [{:keys [tenant-manager] :as opts}]
   ["/aggregation"
-   ["/:dataset-id/:visualisation-type"
-    {:get {:parameters {:path-params {:dataset-id string?
-                                      :visualisation-type string?}}
-           :handler (handler opts)}}]])
+   ["/:dataset-id/:visualisation-type" {:middleware [(auth/authenticate-dataset :dataset-id)]}
+    ["" {:get {:parameters {:path-params {:dataset-id string?
+                                          :visualisation-type string?}}
+               :handler (handler opts)}}]]])
 
 (defmethod ig/init-key :akvo.lumen.endpoint.aggregation/aggregation  [_ opts]
   (routes opts))

--- a/backend/src/akvo/lumen/endpoint/collection.clj
+++ b/backend/src/akvo/lumen/endpoint/collection.clj
@@ -10,17 +10,19 @@
 
 (defn routes [{:keys [tenant-manager] :as opts}]
   ["/collections"
-   ["" {:get {:handler (fn [{tenant :tenant}]
-                       (log/error tenant (collection/all (p/connection tenant-manager tenant)))
-                       (collection/all (p/connection tenant-manager tenant)))}
+   ["" {:get {:handler (fn [{tenant :tenant
+                             auth-datasets :auth-datasets}]
+                         (collection/all (p/connection tenant-manager tenant) auth-datasets))}
         :post {:responses {200 {}}
-             :parameters {:body map?}
-             :handler (fn [{tenant :tenant
-                            body :body}]
-                        (collection/create (p/connection tenant-manager tenant) (stringify-keys body)))}}]
+               :parameters {:body map?}
+               :handler (fn [{tenant :tenant
+                              auth-datasets :auth-datasets
+                              body :body}]
+                          (collection/create (p/connection tenant-manager tenant) (stringify-keys body)))}}]
    ["/:id" {:get {:responses {200 {}}
                   :parameters {:path-params {:id string?}}
                   :handler (fn [{tenant :tenant
+                                 auth-datasets :auth-datasets
                                  {:keys [id]} :path-params}]
                              (collection/fetch (p/connection tenant-manager tenant) id))}
             :put {:responses {200 {}}
@@ -28,12 +30,14 @@
                                :path-params {:id string?}}
                   :handler (fn [{tenant :tenant
                                  body :body
+                                 auth-datasets :auth-datasets
                                  {:keys [id]} :path-params}]
                              (collection/update (p/connection tenant-manager tenant) id body))}
             :delete {:parameters {:path-params {:id string?}}
-                         :handler (fn [{tenant :tenant
-                                        {:keys [id]} :path-params}]
-                                    (collection/delete (p/connection tenant-manager tenant) id))}}]])
+                     :handler (fn [{tenant :tenant
+                                    auth-datasets :auth-datasets
+                                    {:keys [id]} :path-params}]
+                                (collection/delete (p/connection tenant-manager tenant) id))}}]])
 
 (defmethod ig/init-key :akvo.lumen.endpoint.collection/collection  [_ opts]
   (routes opts))

--- a/backend/src/akvo/lumen/endpoint/collection.clj
+++ b/backend/src/akvo/lumen/endpoint/collection.clj
@@ -18,7 +18,7 @@
                :handler (fn [{tenant :tenant
                               auth-datasets :auth-datasets
                               body :body}]
-                          (collection/create (p/connection tenant-manager tenant) (stringify-keys body)))}}]
+                          (collection/create (p/connection tenant-manager tenant) (stringify-keys body) auth-datasets))}}]
    ["/:id" {:get {:responses {200 {}}
                   :parameters {:path-params {:id string?}}
                   :handler (fn [{tenant :tenant
@@ -32,12 +32,12 @@
                                  body :body
                                  auth-datasets :auth-datasets
                                  {:keys [id]} :path-params}]
-                             (collection/update (p/connection tenant-manager tenant) id body))}
+                             (collection/update (p/connection tenant-manager tenant) id body auth-datasets))}
             :delete {:parameters {:path-params {:id string?}}
                      :handler (fn [{tenant :tenant
                                     auth-datasets :auth-datasets
                                     {:keys [id]} :path-params}]
-                                (collection/delete (p/connection tenant-manager tenant) id))}}]])
+                                (collection/delete (p/connection tenant-manager tenant) id auth-datasets))}}]])
 
 (defmethod ig/init-key :akvo.lumen.endpoint.collection/collection  [_ opts]
   (routes opts))

--- a/backend/src/akvo/lumen/endpoint/collection.clj
+++ b/backend/src/akvo/lumen/endpoint/collection.clj
@@ -24,7 +24,7 @@
                   :handler (fn [{tenant :tenant
                                  auth-datasets :auth-datasets
                                  {:keys [id]} :path-params}]
-                             (collection/fetch (p/connection tenant-manager tenant) id))}
+                             (collection/fetch (p/connection tenant-manager tenant) id auth-datasets))}
             :put {:responses {200 {}}
                   :parameters {:body map?
                                :path-params {:id string?}}

--- a/backend/src/akvo/lumen/endpoint/dashboard.clj
+++ b/backend/src/akvo/lumen/endpoint/dashboard.clj
@@ -7,13 +7,15 @@
 
 (defn routes [{:keys [tenant-manager] :as opts}]
   ["/dashboards"
-   ["" {:get {:handler (fn [{tenant :tenant}]
-                         (dashboard/all (p/connection tenant-manager tenant)))}
+   ["" {:get {:handler (fn [{tenant :tenant
+                             auth-datasets :auth-datasets}]
+                         (dashboard/all (p/connection tenant-manager tenant) auth-datasets))}
         :post {:parameters {:body map?}
                :handler (fn [{tenant :tenant
                               jwt-claims :jwt-claims
+                              auth-datasets :auth-datasets
                               body :body}]
-                          (dashboard/create (p/connection tenant-manager tenant) body jwt-claims))}}]
+                          (dashboard/create (p/connection tenant-manager tenant) body jwt-claims auth-datasets))}}]
    ["/:id" {:get {:parameters {:path-params {:id string?}}
                   :handler (fn [{tenant :tenant
                                  {:keys [id]} :path-params}]

--- a/backend/src/akvo/lumen/endpoint/dashboard.clj
+++ b/backend/src/akvo/lumen/endpoint/dashboard.clj
@@ -18,18 +18,21 @@
                           (dashboard/create (p/connection tenant-manager tenant) body jwt-claims auth-datasets))}}]
    ["/:id" {:get {:parameters {:path-params {:id string?}}
                   :handler (fn [{tenant :tenant
+                                 auth-datasets :auth-datasets
                                  {:keys [id]} :path-params}]
-                             (dashboard/fetch (p/connection tenant-manager tenant) id))}
+                             (dashboard/fetch (p/connection tenant-manager tenant) id auth-datasets))}
             :put {:parameters {:body map?
                                :path-params {:id string?}}
                   :handler (fn [{tenant :tenant
                                  body :body
+                                 auth-datasets :auth-datasets
                                  {:keys [id]} :path-params}]
-                             (dashboard/upsert (p/connection tenant-manager tenant) id body))}
+                             (dashboard/upsert (p/connection tenant-manager tenant) id body auth-datasets))}
             :delete {:parameters {:path-params {:id string?}}
                      :handler (fn [{tenant :tenant
+                                    auth-datasets :auth-datasets
                                     {:keys [id]} :path-params}]
-                                (dashboard/delete (p/connection tenant-manager tenant) id))}}]])
+                                (dashboard/delete (p/connection tenant-manager tenant) id auth-datasets))}}]])
 
 (defmethod ig/init-key :akvo.lumen.endpoint.dashboard/dashboard  [_ opts]
   (routes opts))

--- a/backend/src/akvo/lumen/endpoint/dashboard.clj
+++ b/backend/src/akvo/lumen/endpoint/dashboard.clj
@@ -20,7 +20,7 @@
                   :handler (fn [{tenant :tenant
                                  auth-datasets :auth-datasets
                                  {:keys [id]} :path-params}]
-                             (dashboard/fetch (p/connection tenant-manager tenant) id auth-datasets))}
+                             (dashboard/auth-fetch (p/connection tenant-manager tenant) id auth-datasets))}
             :put {:parameters {:body map?
                                :path-params {:id string?}}
                   :handler (fn [{tenant :tenant

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -15,8 +15,9 @@
 (defn routes [{:keys [upload-config import-config error-tracker tenant-manager] :as opts}]
   ["/datasets"
    ["" {:get {:handler (fn [{tenant :tenant
+                             auth-datasets :auth-datasets
                              :as request}]
-                         (dataset/all (p/connection tenant-manager tenant) (:flow-api import-config) (jwt/jwt-token request)))}
+                         (dataset/all (p/connection tenant-manager tenant) (:flow-api import-config) auth-datasets))}
         :post {:parameters {:body map?}
                :handler (fn [{tenant :tenant
                               jwt-claims :jwt-claims
@@ -25,34 +26,29 @@
                                           error-tracker jwt-claims (w/stringify-keys body)))}}]
    ["/:id" [["" {:get {:parameters {:path-params {:id string?}}
                        :handler (fn [{tenant :tenant
-                                      {:keys [id]} :path-params
-                                      :as request}]
-                                  (dataset/fetch (p/connection tenant-manager tenant) id (jwt/jwt-token request)))}
+                                      {:keys [id]} :path-params}]
+                                  (dataset/fetch (p/connection tenant-manager tenant) id))}
                  :put {:parameters {:body map?
                                     :path-params {:id string?}}
                        :handler (fn [{tenant :tenant
                                       body :body
-                                      {:keys [id]} :path-params
-                                      :as request}]
-                                  (dataset/update-meta (p/connection tenant-manager tenant) id body (jwt/jwt-token request)))}
+                                      {:keys [id]} :path-params}]
+                                  (dataset/update-meta (p/connection tenant-manager tenant) id body))}
                  :delete {:parameters {:path-params {:id string?}}
                           :handler (fn [{tenant :tenant
-                                         {:keys [id]} :path-params
-                                         :as request}]
-                                     (dataset/delete (p/connection tenant-manager tenant) id (jwt/jwt-token request)))}}]
+                                         {:keys [id]} :path-params}]
+                                     (dataset/delete (p/connection tenant-manager tenant) id))}}]
             ["/meta" {:get {:parameters {:path-params {:id string?}}
                             :handler (fn [{tenant :tenant
-                                           {:keys [id]} :path-params
-                                           :as request}]
-                                       (dataset/fetch-metadata (p/connection tenant-manager tenant) id (jwt/jwt-token request)))}}]
+                                           {:keys [id]} :path-params}]
+                                       (dataset/fetch-metadata (p/connection tenant-manager tenant) id))}}]
             ["/update" {:post {:parameters {:path-params {:id string?}}
                                :handler (fn [{tenant :tenant
                                               jwt-claims :jwt-claims
                                               body :body
-                                              {:keys [id]} :path-params
-                                              :as request}]
+                                              {:keys [id]} :path-params}]
                                           (dataset/update (p/connection tenant-manager tenant) (merge import-config upload-config)
-                                                          error-tracker id (w/stringify-keys body) (jwt/jwt-token request)))}}]]]])
+                                                          error-tracker id (w/stringify-keys body)))}}]]]])
 
 
 (defmethod ig/init-key :akvo.lumen.endpoint.dataset/dataset  [_ opts]

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -10,6 +10,7 @@
             [akvo.lumen.component.error-tracker :as error-tracker]
             [akvo.lumen.upload :as upload]
             [akvo.commons.jwt :as jwt]
+            [akvo.lumen.auth :as auth]
             [integrant.core :as ig]))
 
 (defn routes [{:keys [upload-config import-config error-tracker tenant-manager] :as opts}]
@@ -24,36 +25,32 @@
                               body :body}]
                           (dataset/create (p/connection tenant-manager tenant) (merge import-config upload-config)
                                           error-tracker jwt-claims (w/stringify-keys body)))}}]
-   ["/:id" [["" {:get {:parameters {:path-params {:id string?}}
-                       :handler (fn [{tenant :tenant
-                                      auth-datasets :auth-datasets
-                                      {:keys [id]} :path-params}]
-                                  (dataset/fetch (p/connection tenant-manager tenant) id auth-datasets))}
-                 :put {:parameters {:body map?
-                                    :path-params {:id string?}}
-                       :handler (fn [{tenant :tenant
-                                      auth-datasets :auth-datasets
-                                      body :body
-                                      {:keys [id]} :path-params}]
-                                  (dataset/update-meta (p/connection tenant-manager tenant) id body auth-datasets))}
-                 :delete {:parameters {:path-params {:id string?}}
-                          :handler (fn [{tenant :tenant
-                                         auth-datasets :auth-datasets
-                                         {:keys [id]} :path-params}]
-                                     (dataset/delete (p/connection tenant-manager tenant) id auth-datasets))}}]
-            ["/meta" {:get {:parameters {:path-params {:id string?}}
-                            :handler (fn [{tenant :tenant
-                                            auth-datasets :auth-datasets
-                                           {:keys [id]} :path-params}]
-                                       (dataset/fetch-metadata (p/connection tenant-manager tenant) id auth-datasets))}}]
-            ["/update" {:post {:parameters {:path-params {:id string?}}
-                               :handler (fn [{tenant :tenant
-                                              auth-datasets :auth-datasets
-                                              jwt-claims :jwt-claims
-                                              body :body
-                                              {:keys [id]} :path-params}]
-                                          (dataset/update (p/connection tenant-manager tenant) (merge import-config upload-config)
-                                                          error-tracker id (w/stringify-keys body) auth-datasets))}}]]]])
+   ["/:id" {:middleware [(auth/authenticate-dataset :id)]}
+    [["" {:get {:parameters {:path-params {:id string?}}
+                :handler (fn [{tenant :tenant
+                               {:keys [id]} :path-params}]
+                           (dataset/fetch (p/connection tenant-manager tenant) id))}
+          :put {:parameters {:body map?
+                             :path-params {:id string?}}
+                :handler (fn [{tenant :tenant
+                               body :body
+                               {:keys [id]} :path-params}]
+                           (dataset/update-meta (p/connection tenant-manager tenant) id body))}
+          :delete {:parameters {:path-params {:id string?}}
+                   :handler (fn [{tenant :tenant
+                                  {:keys [id]} :path-params}]
+                              (dataset/delete (p/connection tenant-manager tenant) id))}}]
+     ["/meta" {:get {:parameters {:path-params {:id string?}}
+                     :handler (fn [{tenant :tenant
+                                    {:keys [id]} :path-params}]
+                                (dataset/fetch-metadata (p/connection tenant-manager tenant) id))}}]
+     ["/update" {:post {:parameters {:path-params {:id string?}}
+                        :handler (fn [{tenant :tenant
+                                       jwt-claims :jwt-claims
+                                       body :body
+                                       {:keys [id]} :path-params}]
+                                   (dataset/update (p/connection tenant-manager tenant) (merge import-config upload-config)
+                                                    error-tracker id (w/stringify-keys body)))}}]]]])
 
 
 (defmethod ig/init-key :akvo.lumen.endpoint.dataset/dataset  [_ opts]

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -14,7 +14,7 @@
 (defn routes [{:keys [upload-config import-config error-tracker tenant-manager] :as opts}]
   ["/datasets"
    ["" {:get {:handler (fn [{tenant :tenant}]
-                         (dataset/all (p/connection tenant-manager tenant)))}
+                         (dataset/all (p/connection tenant-manager tenant) (:flow-api import-config)))}
         :post {:parameters {:body map?}
                :handler (fn [{tenant :tenant
                               jwt-claims :jwt-claims

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -54,7 +54,7 @@
 (s/def ::upload-config ::upload/config)
 (s/def ::flow-api :akvo.lumen.component.flow/config)
 (s/def ::keycloak ::keycloak/data)
-(s/def ::import-config (s/keys :req-un [::flow-api ::keycloak]))
+(s/def ::import-config (s/keys :req-un [::flow-api]))
 (s/def ::config (s/keys :req-un [::tenant-manager/tenant-manager
                                  ::error-tracker/error-tracker
                                  ::upload-config

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.endpoint.dataset
   (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.dataset :as dataset]
+            [akvo.lumen.component.flow :as c.flow]
             [clojure.tools.logging :as log]
             [clojure.spec.alpha :as s]
             [akvo.lumen.component.tenant-manager :as tenant-manager]
@@ -51,9 +52,9 @@
   (routes opts))
 
 (s/def ::upload-config ::upload/config)
-(s/def ::flow-api-url string?)
+(s/def ::flow-api :akvo.lumen.component.flow/config)
 (s/def ::keycloak ::keycloak/data)
-(s/def ::import-config (s/keys :req-un [::flow-api-url ::keycloak]))
+(s/def ::import-config (s/keys :req-un [::flow-api ::keycloak]))
 (s/def ::config (s/keys :req-un [::tenant-manager/tenant-manager
                                  ::error-tracker/error-tracker
                                  ::upload-config

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -14,7 +14,8 @@
 
 (defn routes [{:keys [upload-config import-config error-tracker tenant-manager] :as opts}]
   ["/datasets"
-   ["" {:get {:handler (fn [{tenant :tenant :as request}]
+   ["" {:get {:handler (fn [{tenant :tenant
+                             :as request}]
                          (dataset/all (p/connection tenant-manager tenant) (:flow-api import-config) (jwt/jwt-token request)))}
         :post {:parameters {:body map?}
                :handler (fn [{tenant :tenant
@@ -24,29 +25,34 @@
                                           error-tracker jwt-claims (w/stringify-keys body)))}}]
    ["/:id" [["" {:get {:parameters {:path-params {:id string?}}
                        :handler (fn [{tenant :tenant
-                                      {:keys [id]} :path-params}]
-                                  (dataset/fetch (p/connection tenant-manager tenant) id))}
+                                      {:keys [id]} :path-params
+                                      :as request}]
+                                  (dataset/fetch (p/connection tenant-manager tenant) id (jwt/jwt-token request)))}
                  :put {:parameters {:body map?
                                     :path-params {:id string?}}
                        :handler (fn [{tenant :tenant
                                       body :body
-                                      {:keys [id]} :path-params}]
-                                  (dataset/update-meta (p/connection tenant-manager tenant) id body))}
+                                      {:keys [id]} :path-params
+                                      :as request}]
+                                  (dataset/update-meta (p/connection tenant-manager tenant) id body (jwt/jwt-token request)))}
                  :delete {:parameters {:path-params {:id string?}}
                           :handler (fn [{tenant :tenant
-                                         {:keys [id]} :path-params}]
-                                     (dataset/delete (p/connection tenant-manager tenant) id))}}]
+                                         {:keys [id]} :path-params
+                                         :as request}]
+                                     (dataset/delete (p/connection tenant-manager tenant) id (jwt/jwt-token request)))}}]
             ["/meta" {:get {:parameters {:path-params {:id string?}}
                             :handler (fn [{tenant :tenant
-                                           {:keys [id]} :path-params}]
-                                       (dataset/fetch-metadata (p/connection tenant-manager tenant) id))}}]
+                                           {:keys [id]} :path-params
+                                           :as request}]
+                                       (dataset/fetch-metadata (p/connection tenant-manager tenant) id (jwt/jwt-token request)))}}]
             ["/update" {:post {:parameters {:path-params {:id string?}}
                                :handler (fn [{tenant :tenant
                                               jwt-claims :jwt-claims
                                               body :body
-                                              {:keys [id]} :path-params}]
+                                              {:keys [id]} :path-params
+                                              :as request}]
                                           (dataset/update (p/connection tenant-manager tenant) (merge import-config upload-config)
-                                                          error-tracker id (w/stringify-keys body)))}}]]]])
+                                                          error-tracker id (w/stringify-keys body) (jwt/jwt-token request)))}}]]]])
 
 
 (defmethod ig/init-key :akvo.lumen.endpoint.dataset/dataset  [_ opts]

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -9,12 +9,13 @@
             [clojure.walk :as w]
             [akvo.lumen.component.error-tracker :as error-tracker]
             [akvo.lumen.upload :as upload]
+            [akvo.commons.jwt :as jwt]
             [integrant.core :as ig]))
 
 (defn routes [{:keys [upload-config import-config error-tracker tenant-manager] :as opts}]
   ["/datasets"
-   ["" {:get {:handler (fn [{tenant :tenant}]
-                         (dataset/all (p/connection tenant-manager tenant) (:flow-api import-config)))}
+   ["" {:get {:handler (fn [{tenant :tenant :as request}]
+                         (dataset/all (p/connection tenant-manager tenant) (:flow-api import-config) (jwt/jwt-token request)))}
         :post {:parameters {:body map?}
                :handler (fn [{tenant :tenant
                               jwt-claims :jwt-claims

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -26,29 +26,34 @@
                                           error-tracker jwt-claims (w/stringify-keys body)))}}]
    ["/:id" [["" {:get {:parameters {:path-params {:id string?}}
                        :handler (fn [{tenant :tenant
+                                      auth-datasets :auth-datasets
                                       {:keys [id]} :path-params}]
-                                  (dataset/fetch (p/connection tenant-manager tenant) id))}
+                                  (dataset/fetch (p/connection tenant-manager tenant) id auth-datasets))}
                  :put {:parameters {:body map?
                                     :path-params {:id string?}}
                        :handler (fn [{tenant :tenant
+                                      auth-datasets :auth-datasets
                                       body :body
                                       {:keys [id]} :path-params}]
-                                  (dataset/update-meta (p/connection tenant-manager tenant) id body))}
+                                  (dataset/update-meta (p/connection tenant-manager tenant) id body auth-datasets))}
                  :delete {:parameters {:path-params {:id string?}}
                           :handler (fn [{tenant :tenant
+                                         auth-datasets :auth-datasets
                                          {:keys [id]} :path-params}]
-                                     (dataset/delete (p/connection tenant-manager tenant) id))}}]
+                                     (dataset/delete (p/connection tenant-manager tenant) id auth-datasets))}}]
             ["/meta" {:get {:parameters {:path-params {:id string?}}
                             :handler (fn [{tenant :tenant
+                                            auth-datasets :auth-datasets
                                            {:keys [id]} :path-params}]
-                                       (dataset/fetch-metadata (p/connection tenant-manager tenant) id))}}]
+                                       (dataset/fetch-metadata (p/connection tenant-manager tenant) id auth-datasets))}}]
             ["/update" {:post {:parameters {:path-params {:id string?}}
                                :handler (fn [{tenant :tenant
+                                              auth-datasets :auth-datasets
                                               jwt-claims :jwt-claims
                                               body :body
                                               {:keys [id]} :path-params}]
                                           (dataset/update (p/connection tenant-manager tenant) (merge import-config upload-config)
-                                                          error-tracker id (w/stringify-keys body)))}}]]]])
+                                                          error-tracker id (w/stringify-keys body) auth-datasets))}}]]]])
 
 
 (defmethod ig/init-key :akvo.lumen.endpoint.dataset/dataset  [_ opts]

--- a/backend/src/akvo/lumen/endpoint/env.clj
+++ b/backend/src/akvo/lumen/endpoint/env.clj
@@ -3,13 +3,13 @@
             [clojure.spec.alpha :as s]
             [ring.util.response :refer [response]]))
 
-(defn handler [{:keys [keycloak-public-client-id keycloak-url flow-api-url
+(defn handler [{:keys [keycloak-public-client-id keycloak flow-api
                         piwik-site-id sentry-client-dsn] :as opts}]
   (fn [{tenant :tenant :as request}]
     (response
         (cond-> {"keycloakClient" keycloak-public-client-id
-                 "keycloakURL" keycloak-url
-                 "flowApiUrl" flow-api-url
+                 "keycloakURL" (:url keycloak)
+                 "flowApiUrl" (:url flow-api)
                  "piwikSiteId" piwik-site-id
                  "tenant" (:tenant request)}
           (string? sentry-client-dsn)
@@ -23,14 +23,14 @@
   (routes opts))
 
 (s/def ::keycloak-public-client-id string?)
-(s/def ::keycloak-url string?)
-(s/def ::flow-api-url string?)
+(s/def ::keycloak :akvo.lumen.component.keycloak/data)
+(s/def ::flow-api :akvo.lumen.component.flow/config)
 (s/def ::sentry-client-dsn string?)
 (s/def ::piwik-site-id string?)
 
 (defmethod ig/pre-init-spec :akvo.lumen.endpoint.env/env [_]
   (s/keys :req-un [::keycloak-public-client-id
-                   ::keycloak-url
-                   ::flow-api-url
+                   ::keycloak
+                   ::flow-api
                    ::sentry-client-dsn
                    ::piwik-site-id]))

--- a/backend/src/akvo/lumen/endpoint/library.clj
+++ b/backend/src/akvo/lumen/endpoint/library.clj
@@ -24,7 +24,7 @@
           :datasets (variant/value (dataset/all tenant-conn flow-api auth-datasets))
           :rasters (variant/value (raster/all tenant-conn))
           :visualisations (variant/value (visualisation/all tenant-conn auth-datasets))
-          :collections (variant/value (collection/all tenant-conn))}))))
+          :collections (variant/value (collection/all tenant-conn auth-datasets))}))))
 
 (s/def ::flow-api :akvo.lumen.component.flow/config)
 

--- a/backend/src/akvo/lumen/endpoint/library.clj
+++ b/backend/src/akvo/lumen/endpoint/library.clj
@@ -20,7 +20,7 @@
         :as request}]
     (let [tenant-conn (p/connection tenant-manager tenant)]
       (lib/ok
-         {:dashboards (variant/value (dashboard/all tenant-conn))
+         {:dashboards (variant/value (dashboard/all tenant-conn auth-datasets))
           :datasets (variant/value (dataset/all tenant-conn flow-api auth-datasets))
           :rasters (variant/value (raster/all tenant-conn))
           :visualisations (variant/value (visualisation/all tenant-conn auth-datasets))

--- a/backend/src/akvo/lumen/endpoint/library.clj
+++ b/backend/src/akvo/lumen/endpoint/library.clj
@@ -15,11 +15,13 @@
             [integrant.core :as ig]))
 
 (defn handler [{:keys [tenant-manager flow-api] :as opts}]
-  (fn [{tenant :tenant :as request}]
+  (fn [{tenant :tenant
+        auth-datasets :auth-datasets
+        :as request}]
     (let [tenant-conn (p/connection tenant-manager tenant)]
       (lib/ok
          {:dashboards (variant/value (dashboard/all tenant-conn))
-          :datasets (variant/value (dataset/all tenant-conn flow-api (jwt/jwt-token request)))
+          :datasets (variant/value (dataset/all tenant-conn flow-api auth-datasets))
           :rasters (variant/value (raster/all tenant-conn))
           :visualisations (variant/value (visualisation/all tenant-conn))
           :collections (variant/value (collection/all tenant-conn))}))))

--- a/backend/src/akvo/lumen/endpoint/library.clj
+++ b/backend/src/akvo/lumen/endpoint/library.clj
@@ -2,6 +2,7 @@
   (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.dataset :as dataset]
             [akvo.lumen.lib :as lib]
+            [akvo.lumen.component.flow :as c.flow]
             [akvo.lumen.lib
              [dashboard :as dashboard]
              [visualisation :as visualisation]
@@ -12,18 +13,20 @@
             [akvo.lumen.component.tenant-manager :as tenant-manager]
             [integrant.core :as ig]))
 
-(defn handler [{:keys [tenant-manager] :as opts}]
+(defn handler [{:keys [tenant-manager flow-api] :as opts}]
   (fn [{tenant :tenant}]
     (let [tenant-conn (p/connection tenant-manager tenant)]
       (lib/ok
          {:dashboards (variant/value (dashboard/all tenant-conn))
-          :datasets (variant/value (dataset/all tenant-conn))
+          :datasets (variant/value (dataset/all tenant-conn flow-api))
           :rasters (variant/value (raster/all tenant-conn))
           :visualisations (variant/value (visualisation/all tenant-conn))
           :collections (variant/value (collection/all tenant-conn))}))))
 
+(s/def ::flow-api :akvo.lumen.component.flow/config)
+
 (defmethod ig/pre-init-spec :akvo.lumen.endpoint.library/library [_]
-  (s/keys :req-un [::tenant-manager/tenant-manager] ))
+  (s/keys :req-un [::tenant-manager/tenant-manager ::flow-api] ))
 
 (defn routes [{:keys [tenant-manager] :as opts}]
   ["/library"

--- a/backend/src/akvo/lumen/endpoint/library.clj
+++ b/backend/src/akvo/lumen/endpoint/library.clj
@@ -23,7 +23,7 @@
          {:dashboards (variant/value (dashboard/all tenant-conn))
           :datasets (variant/value (dataset/all tenant-conn flow-api auth-datasets))
           :rasters (variant/value (raster/all tenant-conn))
-          :visualisations (variant/value (visualisation/all tenant-conn))
+          :visualisations (variant/value (visualisation/all tenant-conn auth-datasets))
           :collections (variant/value (collection/all tenant-conn))}))))
 
 (s/def ::flow-api :akvo.lumen.component.flow/config)

--- a/backend/src/akvo/lumen/endpoint/library.clj
+++ b/backend/src/akvo/lumen/endpoint/library.clj
@@ -11,14 +11,15 @@
             [akvo.lumen.endpoint.commons.variant :as variant]
             [clojure.spec.alpha :as s]
             [akvo.lumen.component.tenant-manager :as tenant-manager]
+            [akvo.commons.jwt :as jwt]
             [integrant.core :as ig]))
 
 (defn handler [{:keys [tenant-manager flow-api] :as opts}]
-  (fn [{tenant :tenant}]
+  (fn [{tenant :tenant :as request}]
     (let [tenant-conn (p/connection tenant-manager tenant)]
       (lib/ok
          {:dashboards (variant/value (dashboard/all tenant-conn))
-          :datasets (variant/value (dataset/all tenant-conn flow-api))
+          :datasets (variant/value (dataset/all tenant-conn flow-api (jwt/jwt-token request)))
           :rasters (variant/value (raster/all tenant-conn))
           :visualisations (variant/value (visualisation/all tenant-conn))
           :collections (variant/value (collection/all tenant-conn))}))))

--- a/backend/src/akvo/lumen/endpoint/visualisation.clj
+++ b/backend/src/akvo/lumen/endpoint/visualisation.clj
@@ -2,6 +2,7 @@
   (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.visualisation :as visualisation]
             [akvo.lumen.lib.visualisation.maps :as maps]
+            [akvo.lumen.auth :as auth]
             [clojure.spec.alpha :as s]
             [akvo.lumen.component.tenant-manager :as tenant-manager]
             [clojure.walk :as w]
@@ -21,11 +22,13 @@
                           (visualisation/create (p/connection tenant-manager tenant) body jwt-claims auth-datasets))}}]
    ["/maps" ["" {:post {:parameters {:body map?}
                         :handler (fn [{tenant :tenant
+                                       auth-datasets :auth-datasets
                                        body :body}]
                                    (let [{:strs [spec]} body
                                          layers (get-in spec ["layers"])]
-                                     ;; TODO: AUTH dataset in layers
-                                     (maps/create (p/connection tenant-manager tenant) windshaft-url (w/keywordize-keys layers))))}}]]
+                                     (if (visualisation/auth-vis body auth-datasets)
+                                       (maps/create (p/connection tenant-manager tenant) windshaft-url (w/keywordize-keys layers))
+                                       auth/not-authorized)))}}]]
    ["/rasters" ["" {:post {:parameters {:body map?}
                            :handler (fn [{tenant :tenant
                                           body :body}]

--- a/backend/src/akvo/lumen/endpoint/visualisation.clj
+++ b/backend/src/akvo/lumen/endpoint/visualisation.clj
@@ -16,9 +16,9 @@
         :post {:parameters {:body map?}
                :handler (fn [{tenant :tenant
                               jwt-claims :jwt-claims
+                              auth-datasets :auth-datasets
                               body :body}]
-                          ;; TODO AUTHENTICATE DSs
-                          (visualisation/create (p/connection tenant-manager tenant) body jwt-claims))}}]
+                          (visualisation/create (p/connection tenant-manager tenant) body jwt-claims auth-datasets))}}]
    ["/maps" ["" {:post {:parameters {:body map?}
                         :handler (fn [{tenant :tenant
                                        body :body}]
@@ -34,22 +34,22 @@
    ;; todo: fix path routing inconsistency here 
    ["/:id" ["" {:get {:parameters {:path-params {:id string?}}
                       :handler (fn [{tenant :tenant
+                                     auth-datasets :auth-datasets
                                      {:keys [id]} :path-params}]
-                                 ;; TODO AUTH dataset!
-                                 (visualisation/fetch (p/connection tenant-manager tenant) id))}
+                                 (visualisation/fetch (p/connection tenant-manager tenant) id auth-datasets))}
                 :put {:parameters {:body map?
                                    :path-params {:id string?}}
                       :handler (fn [{tenant :tenant
                                      jwt-claims :jwt-claims
+                                     auth-datasets :auth-datasets
                                      {:keys [id]} :path-params
                                      body :body}]
-                                 ;; TODO: AUTH DATASET!
-                                 (visualisation/upsert (p/connection tenant-manager tenant) (assoc body "id" id) jwt-claims))}
+                                 (visualisation/upsert (p/connection tenant-manager tenant) (assoc body "id" id) jwt-claims auth-datasets))}
                 :delete {:parameters {:path-params {:id string?}}
                          :handler (fn [{tenant :tenant
+                                        auth-datasets :auth-datasets
                                         {:keys [id]} :path-params}]
-                                    ;; TODO: AUTH DATASET!
-                                    (visualisation/delete (p/connection tenant-manager tenant) id))}}]]])
+                                    (visualisation/delete (p/connection tenant-manager tenant) id auth-datasets))}}]]])
 
 (defmethod ig/init-key :akvo.lumen.endpoint.visualisation/visualisation  [_ opts]
   (routes opts))

--- a/backend/src/akvo/lumen/lib/collection.clj
+++ b/backend/src/akvo/lumen/lib/collection.clj
@@ -3,6 +3,7 @@
   (:require [akvo.lumen.lib :as lib]
             [clojure.java.jdbc :as jdbc]
             [clojure.set :as set]
+            [clojure.string :as str]
             [hugsql.core :as hugsql])
   (:import [java.sql SQLException Connection]))
 
@@ -12,7 +13,10 @@
 
 (defn all [tenant-conn]
   (lib/ok (mapv (fn [collection]
-                  (core/update collection :entities #(vec (.getArray %))))
+                  (->> (.getArray (:entities collection))
+                       (mapv (fn [e]
+                               (first (str/split e #"::"))) )
+                       (core/assoc collection :entities)))
                 (all-collections tenant-conn {}))))
 
 (defn fetch [tenant-conn id]

--- a/backend/src/akvo/lumen/lib/collection.sql
+++ b/backend/src/akvo/lumen/lib/collection.sql
@@ -25,10 +25,10 @@ SELECT collection.id,
        collection.created,
        collection.modified,
        array_remove(array_agg(coalesce(
-           collection_entity.visualisation_id,
-           collection_entity.dataset_id,
-           collection_entity.dashboard_id,
-           collection_entity.raster_dataset_id
+           collection_entity.visualisation_id || '::visualisation-id',
+           collection_entity.dataset_id || '::dataset-id',
+           collection_entity.dashboard_id || '::dashboard-id',
+           collection_entity.raster_dataset_id || '::raster-dataset-id'
        )), NULL) AS entities
 FROM collection
 LEFT JOIN collection_entity ON collection_entity.collection_id = collection.id

--- a/backend/src/akvo/lumen/lib/collection.sql
+++ b/backend/src/akvo/lumen/lib/collection.sql
@@ -5,10 +5,10 @@ SELECT collection.id,
        collection.created,
        collection.modified,
        array_remove(array_agg(coalesce(
-           collection_entity.visualisation_id,
-           collection_entity.dataset_id,
-           collection_entity.dashboard_id,
-           collection_entity.raster_dataset_id
+           collection_entity.visualisation_id || '::visualisation-id',
+           collection_entity.dataset_id || '::dataset-id',
+           collection_entity.dashboard_id || '::dashboard-id',
+           collection_entity.raster_dataset_id || '::raster-dataset-id'
        )), NULL) AS entities
 FROM collection
 LEFT JOIN collection_entity ON collection_entity.collection_id = collection.id

--- a/backend/src/akvo/lumen/lib/dashboard.clj
+++ b/backend/src/akvo/lumen/lib/dashboard.clj
@@ -1,6 +1,5 @@
 (ns akvo.lumen.lib.dashboard
   (:require [akvo.lumen.lib :as lib]
-            [akvo.lumen.auth :as auth]
             [akvo.lumen.util :refer [squuid]]
             [clojure.walk :refer [keywordize-keys]]
             [akvo.lumen.lib.visualisation :as vis]
@@ -118,7 +117,7 @@
                      :visualisation-id visualisation-id
                      :layout layout}))))
           (lib/ok (handle-dashboard-by-id tenant-conn dashboard-id)))
-        auth/not-authorized))
+        (lib/not-authorized nil)))
     (lib/bad-request {:error "Entities and layout dashboard keys does not match."})))
 
 (defn auth-fetch [tenant-conn id auth-datasets]
@@ -126,7 +125,7 @@
     (let [d* (handle-dashboard-by-id tenant-conn id)]
       (if (auth-dashboard? tenant-conn d* auth-datasets)
         (lib/ok d*)
-        auth/not-authorized))
+        (lib/not-authorized nil)))
     (lib/not-found {:error "Not found"})))
 
 (defn fetch [tenant-conn id]
@@ -161,7 +160,7 @@
                  :visualisation-id visualisation-id
                  :layout visualisations-layout}))))
       (lib/ok (handle-dashboard-by-id tenant-conn id)))
-    auth/not-authorized))
+    (lib/not-authorized nil)))
 
 (defn delete [tenant-conn id auth-datasets]
   (if (auth-dashboard? tenant-conn (handle-dashboard-by-id tenant-conn id) auth-datasets)
@@ -170,4 +169,4 @@
       (if (zero? (delete-dashboard-by-id tenant-conn {:id id}))
         (lib/not-found {:error "Not round"})
         (lib/ok {:id id})))
-    auth/not-authorized))
+    (lib/not-authorized nil)))

--- a/backend/src/akvo/lumen/lib/dashboard.clj
+++ b/backend/src/akvo/lumen/lib/dashboard.clj
@@ -115,7 +115,7 @@
         auth/not-authorized))
     (lib/bad-request {:error "Entities and layout dashboard keys does not match."})))
 
-(defn fetch [tenant-conn id]
+(defn fetch [tenant-conn id auth-datasets]
   (if-let [d (dashboard-by-id tenant-conn {:id id})]
     (lib/ok (handle-dashboard-by-id tenant-conn id))
     (lib/not-found {:error "Not found"})))
@@ -128,7 +128,7 @@
   3. Remove old dashboard_visualisations
   4. Add new dashboard_visualisations
   "
-  [tenant-conn id spec]
+  [tenant-conn id spec auth-datasets]
   (let [{:keys [texts visualisations]} (part-by-entity-type spec)
         visualisations-layouts (:layout visualisations)]
     (jdbc/with-db-transaction [tx tenant-conn]
@@ -147,7 +147,7 @@
                :layout visualisations-layout}))))
     (lib/ok (handle-dashboard-by-id tenant-conn id))))
 
-(defn delete [tenant-conn id]
+(defn delete [tenant-conn id auth-datasets]
   (delete-dashboard_visualisation tenant-conn {:dashboard-id id})
   (if (zero? (delete-dashboard-by-id tenant-conn {:id id}))
     (lib/not-found {:error "Not round"})

--- a/backend/src/akvo/lumen/lib/dashboard.sql
+++ b/backend/src/akvo/lumen/lib/dashboard.sql
@@ -1,6 +1,6 @@
 -- :name all-dashboards :? :*
 -- :doc Return all dashboards
-SELECT id, title, 'ok' AS status, 'dashboard' AS type, created, modified, author
+SELECT id, title, 'ok' AS status, 'dashboard' AS type, created, modified, author, (spec->'entities')::jsonb AS entities
 FROM dashboard;
 
 -- :name insert-dashboard :<!

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -3,6 +3,7 @@
   (:require [akvo.lumen.endpoint.job-execution :as job-execution]
             [akvo.lumen.lib.import :as import]
             [akvo.lumen.lib :as lib]
+            [akvo.lumen.auth :refer [auth-ds]]
             [akvo.lumen.lib.transformation.merge-datasets :as transformation.merge-datasets]
             [akvo.lumen.lib.update :as update]
             [akvo.lumen.component.flow :as c.flow]
@@ -53,7 +54,7 @@
 
 (defn fetch-metadata
   "Fetch dataset metadata (everything apart from rows)"
-  [conn id]
+  [conn id auth-datasets]
   (if-let [dataset (dataset-by-id conn {:id id})]
     (let [columns (remove #(get % "hidden") (:columns dataset))]
       (lib/ok
@@ -68,44 +69,48 @@
     (lib/not-found {:error "Not found"})))
 
 (defn fetch
-  [conn id]
-  (if-let [dataset (dataset-by-id conn {:id id})]
-    (let [columns (remove #(get % "hidden") (:columns dataset))
-          data (rest (jdbc/query conn
-                                 [(select-data-sql (:table-name dataset) columns)]
-                                 {:as-arrays? true}))]
-      (lib/ok
-       (-> dataset
-           (select-keys [:created :id :modified :status :title :transformations :updated :author :source])
-           (rename-keys {:title :name})
-           (assoc :rows data :columns columns :status "OK"))))
-    (lib/not-found {:error "Not found"})))
+  [conn id auth-datasets]
+  (auth-ds id auth-datasets
+           (if-let [dataset (dataset-by-id conn {:id id})]
+             (let [columns (remove #(get % "hidden") (:columns dataset))
+                   data (rest (jdbc/query conn
+                                          [(select-data-sql (:table-name dataset) columns)]
+                                          {:as-arrays? true}))]
+               (lib/ok
+                (-> dataset
+                    (select-keys [:created :id :modified :status :title :transformations :updated :author :source])
+                    (rename-keys {:title :name})
+                    (assoc :rows data :columns columns :status "OK"))))
+             (lib/not-found {:error "Not found"}))))
 
 (defn delete
-  [tenant-conn id]
-  (if-let [datasets-merged-with (transformation.merge-datasets/datasets-related tenant-conn id)]
-    (lib/conflict {:error (format "This dataset is used in merge tranformations with other datasets: %s"
-                                  (str/join ", " datasets-merged-with))})
-    (let [c (delete-dataset-by-id tenant-conn {:id id})]
-      (if (zero? c)
-        (do
-          (delete-failed-job-execution-by-id tenant-conn {:id id})
-          (lib/not-found {:error "Not found"}))
-        (let [v (delete-maps-by-dataset-id tenant-conn {:id id})](lib/ok {:id id}))))))
+  [tenant-conn id auth-datasets]
+  (auth-ds id auth-datasets
+           (if-let [datasets-merged-with (transformation.merge-datasets/datasets-related tenant-conn id)]
+             (lib/conflict {:error (format "This dataset is used in merge tranformations with other datasets: %s"
+                                           (str/join ", " datasets-merged-with))})
+             (let [c (delete-dataset-by-id tenant-conn {:id id})]
+               (if (zero? c)
+                 (do
+                   (delete-failed-job-execution-by-id tenant-conn {:id id})
+                   (lib/not-found {:error "Not found"}))
+                 (let [v (delete-maps-by-dataset-id tenant-conn {:id id})](lib/ok {:id id})))))))
 
 (defn update
-  [tenant-conn import-config error-tracker dataset-id {refresh-token "refreshToken"}]
-  (if-let [{data-source-spec :spec
-            data-source-id   :id} (data-source-by-dataset-id tenant-conn {:dataset-id dataset-id})]
-    (if-let [error (transformation.merge-datasets/consistency-error? tenant-conn dataset-id)]
-      (lib/conflict error)
-      (if-not (= (get-in data-source-spec ["source" "kind"]) "DATA_FILE")
-        (update/update-dataset tenant-conn import-config error-tracker dataset-id data-source-id
-                               (assoc-in data-source-spec ["source" "refreshToken"] refresh-token))
-        (lib/bad-request {:error "Can't update uploaded dataset"})))
-    (lib/not-found {:id dataset-id})))
+  [tenant-conn import-config error-tracker dataset-id {refresh-token "refreshToken"} auth-datasets]
+  (auth-ds dataset-id auth-datasets
+           (if-let [{data-source-spec :spec
+                     data-source-id   :id} (data-source-by-dataset-id tenant-conn {:dataset-id dataset-id})]
+             (if-let [error (transformation.merge-datasets/consistency-error? tenant-conn dataset-id)]
+               (lib/conflict error)
+               (if-not (= (get-in data-source-spec ["source" "kind"]) "DATA_FILE")
+                 (update/update-dataset tenant-conn import-config error-tracker dataset-id data-source-id
+                                        (assoc-in data-source-spec ["source" "refreshToken"] refresh-token))
+                 (lib/bad-request {:error "Can't update uploaded dataset"})))
+             (lib/not-found {:id dataset-id}))))
 
 (defn update-meta
-  [tenant-conn id {:strs [name]}]
-  (update-dataset-meta tenant-conn {:id id :title name})
-  (lib/ok {}))
+  [tenant-conn id {:strs [name]} auth-datasets]
+  (auth-ds id auth-datasets
+           (do (update-dataset-meta tenant-conn {:id id :title name})
+               (lib/ok {}))))

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -18,10 +18,7 @@
 
 (defn all
   [tenant-conn flow-api auth-datasets]
-  (let [dss (all-auth-datasets tenant-conn {:ids auth-datasets})]
-    (log/warn :all-dss (map :id dss))
-    (log/warn :auth? auth-datasets)
-    (lib/ok dss)))
+  (lib/ok (all-auth-datasets tenant-conn {:ids auth-datasets})))
 
 (defn create
   [tenant-conn import-config error-tracker claims data-source]

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -28,11 +28,13 @@
                                 survey (get ds "surveyId")]
                             [instance survey
                              (try 
-                                  (when-let [rt (str/replace (get ds "refreshToken") #" " "")]
-                                    (c.flow/access-token flow-api rt)
-                                 #_(c.flow/api-headers flow-api rt)
-                                 #_(c.flow/check-permissions flow-api rt [[{:instance_id instance :survey_id survey}]])
-                                 )
+                               (when-let [rt (str/replace (get ds "refreshToken") #" " "")]
+                                 (:body
+                                  (c.flow/check-permissions flow-api rt
+                                                            [{:instance_id (if (= "uat1" instance)
+                                                                             (str "akvoflow-" instance)
+                                                                             instance)
+                                                              :survey_id survey}])))
 
                                (catch Exception e (log/error :fail [instance survey] (.getMessage e))))]))))))
 

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -67,7 +67,7 @@
 
 (defn fetch-metadata
   "Fetch dataset metadata (everything apart from rows)"
-  [conn id]
+  [conn id token]
   (if-let [dataset (dataset-by-id conn {:id id})]
     (let [columns (remove #(get % "hidden") (:columns dataset))]
       (lib/ok
@@ -82,7 +82,7 @@
     (lib/not-found {:error "Not found"})))
 
 (defn fetch
-  [conn id]
+  [conn id token]
   (if-let [dataset (dataset-by-id conn {:id id})]
     (let [columns (remove #(get % "hidden") (:columns dataset))
           data (rest (jdbc/query conn
@@ -96,7 +96,7 @@
     (lib/not-found {:error "Not found"})))
 
 (defn delete
-  [tenant-conn id]
+  [tenant-conn id token]
   (if-let [datasets-merged-with (transformation.merge-datasets/datasets-related tenant-conn id)]
     (lib/conflict {:error (format "This dataset is used in merge tranformations with other datasets: %s"
                                   (str/join ", " datasets-merged-with))})
@@ -108,7 +108,7 @@
         (let [v (delete-maps-by-dataset-id tenant-conn {:id id})](lib/ok {:id id}))))))
 
 (defn update
-  [tenant-conn import-config error-tracker dataset-id {refresh-token "refreshToken"}]
+  [tenant-conn import-config error-tracker dataset-id {refresh-token "refreshToken"} token]
   (if-let [{data-source-spec :spec
             data-source-id   :id} (data-source-by-dataset-id tenant-conn {:dataset-id dataset-id})]
     (if-let [error (transformation.merge-datasets/consistency-error? tenant-conn dataset-id)]
@@ -120,6 +120,6 @@
     (lib/not-found {:id dataset-id})))
 
 (defn update-meta
-  [tenant-conn id {:strs [name]}]
+  [tenant-conn id {:strs [name]} token]
   (update-dataset-meta tenant-conn {:id id :title name})
   (lib/ok {}))

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -3,7 +3,6 @@
   (:require [akvo.lumen.endpoint.job-execution :as job-execution]
             [akvo.lumen.lib.import :as import]
             [akvo.lumen.lib :as lib]
-            [akvo.lumen.auth :refer [auth-ds]]
             [akvo.lumen.lib.transformation.merge-datasets :as transformation.merge-datasets]
             [akvo.lumen.lib.update :as update]
             [akvo.lumen.component.flow :as c.flow]
@@ -54,7 +53,7 @@
 
 (defn fetch-metadata
   "Fetch dataset metadata (everything apart from rows)"
-  [conn id auth-datasets]
+  [conn id]
   (if-let [dataset (dataset-by-id conn {:id id})]
     (let [columns (remove #(get % "hidden") (:columns dataset))]
       (lib/ok
@@ -69,48 +68,44 @@
     (lib/not-found {:error "Not found"})))
 
 (defn fetch
-  [conn id auth-datasets]
-  (auth-ds id auth-datasets
-           (if-let [dataset (dataset-by-id conn {:id id})]
-             (let [columns (remove #(get % "hidden") (:columns dataset))
-                   data (rest (jdbc/query conn
-                                          [(select-data-sql (:table-name dataset) columns)]
-                                          {:as-arrays? true}))]
-               (lib/ok
-                (-> dataset
-                    (select-keys [:created :id :modified :status :title :transformations :updated :author :source])
-                    (rename-keys {:title :name})
-                    (assoc :rows data :columns columns :status "OK"))))
-             (lib/not-found {:error "Not found"}))))
+  [conn id]
+  (if-let [dataset (dataset-by-id conn {:id id})]
+    (let [columns (remove #(get % "hidden") (:columns dataset))
+          data (rest (jdbc/query conn
+                                 [(select-data-sql (:table-name dataset) columns)]
+                                 {:as-arrays? true}))]
+      (lib/ok
+       (-> dataset
+           (select-keys [:created :id :modified :status :title :transformations :updated :author :source])
+           (rename-keys {:title :name})
+           (assoc :rows data :columns columns :status "OK"))))
+    (lib/not-found {:error "Not found"})))
 
 (defn delete
-  [tenant-conn id auth-datasets]
-  (auth-ds id auth-datasets
-           (if-let [datasets-merged-with (transformation.merge-datasets/datasets-related tenant-conn id)]
-             (lib/conflict {:error (format "This dataset is used in merge tranformations with other datasets: %s"
-                                           (str/join ", " datasets-merged-with))})
-             (let [c (delete-dataset-by-id tenant-conn {:id id})]
-               (if (zero? c)
-                 (do
-                   (delete-failed-job-execution-by-id tenant-conn {:id id})
-                   (lib/not-found {:error "Not found"}))
-                 (let [v (delete-maps-by-dataset-id tenant-conn {:id id})](lib/ok {:id id})))))))
+  [tenant-conn id]
+  (if-let [datasets-merged-with (transformation.merge-datasets/datasets-related tenant-conn id)]
+    (lib/conflict {:error (format "This dataset is used in merge tranformations with other datasets: %s"
+                                  (str/join ", " datasets-merged-with))})
+    (let [c (delete-dataset-by-id tenant-conn {:id id})]
+      (if (zero? c)
+        (do
+          (delete-failed-job-execution-by-id tenant-conn {:id id})
+          (lib/not-found {:error "Not found"}))
+        (let [v (delete-maps-by-dataset-id tenant-conn {:id id})](lib/ok {:id id}))))))
 
 (defn update
-  [tenant-conn import-config error-tracker dataset-id {refresh-token "refreshToken"} auth-datasets]
-  (auth-ds dataset-id auth-datasets
-           (if-let [{data-source-spec :spec
-                     data-source-id   :id} (data-source-by-dataset-id tenant-conn {:dataset-id dataset-id})]
-             (if-let [error (transformation.merge-datasets/consistency-error? tenant-conn dataset-id)]
-               (lib/conflict error)
-               (if-not (= (get-in data-source-spec ["source" "kind"]) "DATA_FILE")
-                 (update/update-dataset tenant-conn import-config error-tracker dataset-id data-source-id
-                                        (assoc-in data-source-spec ["source" "refreshToken"] refresh-token))
-                 (lib/bad-request {:error "Can't update uploaded dataset"})))
-             (lib/not-found {:id dataset-id}))))
+  [tenant-conn import-config error-tracker dataset-id {refresh-token "refreshToken"}]
+  (if-let [{data-source-spec :spec
+            data-source-id   :id} (data-source-by-dataset-id tenant-conn {:dataset-id dataset-id})]
+    (if-let [error (transformation.merge-datasets/consistency-error? tenant-conn dataset-id)]
+      (lib/conflict error)
+      (if-not (= (get-in data-source-spec ["source" "kind"]) "DATA_FILE")
+        (update/update-dataset tenant-conn import-config error-tracker dataset-id data-source-id
+                               (assoc-in data-source-spec ["source" "refreshToken"] refresh-token))
+        (lib/bad-request {:error "Can't update uploaded dataset"})))
+    (lib/not-found {:id dataset-id})))
 
 (defn update-meta
-  [tenant-conn id {:strs [name]} auth-datasets]
-  (auth-ds id auth-datasets
-           (do (update-dataset-meta tenant-conn {:id id :title name})
-               (lib/ok {}))))
+  [tenant-conn id {:strs [name]}]
+  (do (update-dataset-meta tenant-conn {:id id :title name})
+      (lib/ok {})))

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -18,7 +18,9 @@
 
 (defn all
   [tenant-conn flow-api auth-datasets]
-  (lib/ok (all-auth-datasets tenant-conn {:ids auth-datasets})))
+  (lib/ok (if (empty? auth-datasets)
+            []
+            (all-auth-datasets tenant-conn {:ids auth-datasets}))))
 
 (defn create
   [tenant-conn import-config error-tracker claims data-source]

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -2,7 +2,7 @@
 -- :doc All datasets. Including pending datasets and datasets that failed to import
 WITH
 source_data AS (
- SELECT dataset.id as dataset_id, (spec->'source')::jsonb as source
+ SELECT dataset.id as dataset_id, (spec->'source')::jsonb - 'refreshToken' as source
    FROM data_source, dataset_version, job_execution, dataset
   WHERE dataset_version.dataset_id = dataset.id
     AND dataset_version.version = 1

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -2,7 +2,7 @@
 -- :doc All datasets. Including pending datasets and datasets that failed to import
 WITH
 source_data AS (
- SELECT dataset.id as dataset_id, (spec->'source')::jsonb - 'refreshToken' as source
+ SELECT dataset.id as dataset_id, (spec->'source')::jsonb as source
    FROM data_source, dataset_version, job_execution, dataset
   WHERE dataset_version.dataset_id = dataset.id
     AND dataset_version.version = 1

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -1,10 +1,11 @@
--- :name all-datasets :? :*
+-- :name all-auth-datasets :? :*
 -- :doc All datasets. Including pending datasets and datasets that failed to import
 WITH
 source_data AS (
  SELECT dataset.id as dataset_id, (spec->'source')::jsonb - 'refreshToken' as source
    FROM data_source, dataset_version, job_execution, dataset
   WHERE dataset_version.dataset_id = dataset.id
+    AND dataset.id IN (:v*:ids)
     AND dataset_version.version = 1
     AND dataset_version.job_execution_id = job_execution.id
     AND job_execution.data_source_id = data_source.id
@@ -32,6 +33,23 @@ SELECT id, name, error_log as reason, status, modified, created, '{}'::jsonb AS 
 SELECT id, name, NULL, status, modified, created, '{}'::jsonb AS author, '{}'::jsonb AS source
   FROM pending_imports
  UNION
+SELECT id, title, NULL, 'OK', modified, created, author, source_data.source::jsonb
+  FROM dataset, source_data
+  WHERE source_data.dataset_id = dataset.id;
+
+
+
+-- :name all-datasets :? :*
+-- :doc All datasets. Including pending datasets and datasets that failed to import
+WITH
+source_data AS (
+ SELECT dataset.id as dataset_id, (spec->'source')::jsonb - 'refreshToken' as source
+   FROM data_source, dataset_version, job_execution, dataset
+  WHERE dataset_version.dataset_id = dataset.id
+    AND dataset_version.version = 1
+    AND dataset_version.job_execution_id = job_execution.id
+    AND job_execution.data_source_id = data_source.id
+)
 SELECT id, title, NULL, 'OK', modified, created, author, source_data.source::jsonb
   FROM dataset, source_data
   WHERE source_data.dataset_id = dataset.id;

--- a/backend/src/akvo/lumen/lib/import/flow.clj
+++ b/backend/src/akvo/lumen/lib/import/flow.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.import.flow
   (:require [akvo.commons.psql-util :as pg]
             [akvo.lumen.lib.import.common :as import]
+            [akvo.lumen.component.flow :as c.flow]
             [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.import.flow-common :as flow-common]
             [akvo.lumen.lib.import.flow-v2 :as v2]
@@ -9,12 +10,9 @@
 
 (defmethod import/dataset-importer "AKVO_FLOW"
   [{:strs [instance surveyId formId refreshToken version] :as spec}
-   {:keys [flow-api keycloak] :as config}]
+   {:keys [flow-api] :as config}]
   (let [version (if version version 1)
-        token-endpoint (format "%s/realms/%s/protocol/openid-connect/token"
-                               (:url keycloak)
-                               (:realm keycloak))
-        headers-fn #(flow-common/flow-api-headers token-endpoint refreshToken)
+        headers-fn #(c.flow/api-headers flow-api refreshToken)
         survey (delay (flow-common/survey-definition (:url flow-api)
                                                      headers-fn
                                                      instance

--- a/backend/src/akvo/lumen/lib/import/flow.clj
+++ b/backend/src/akvo/lumen/lib/import/flow.clj
@@ -9,13 +9,13 @@
 
 (defmethod import/dataset-importer "AKVO_FLOW"
   [{:strs [instance surveyId formId refreshToken version] :as spec}
-   {:keys [flow-api-url keycloak] :as config}]
+   {:keys [flow-api keycloak] :as config}]
   (let [version (if version version 1)
         token-endpoint (format "%s/realms/%s/protocol/openid-connect/token"
                                (:url keycloak)
                                (:realm keycloak))
         headers-fn #(flow-common/flow-api-headers token-endpoint refreshToken)
-        survey (delay (flow-common/survey-definition flow-api-url
+        survey (delay (flow-common/survey-definition (:url flow-api)
                                                      headers-fn
                                                      instance
                                                      surveyId))]

--- a/backend/src/akvo/lumen/lib/import/flow.clj
+++ b/backend/src/akvo/lumen/lib/import/flow.clj
@@ -12,7 +12,7 @@
   [{:strs [instance surveyId formId refreshToken version] :as spec}
    {:keys [flow-api] :as config}]
   (let [version (if version version 1)
-        headers-fn #(c.flow/api-headers flow-api refreshToken)
+        headers-fn #(c.flow/api-headers (c.flow/access-token flow-api refreshToken))
         survey (delay (flow-common/survey-definition (:url flow-api)
                                                      headers-fn
                                                      instance

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -6,24 +6,6 @@
             [clojure.string :as str])
   (:import [java.time Instant]))
 
-(defn access-token
-  "Fetch a new access token using a refresh token"
-  [token-endpoint refresh-token]
-  (-> (http/post token-endpoint
-                 {:form-params {"client_id" "akvo-lumen"
-                                "refresh_token" refresh-token
-                                "grant_type" "refresh_token"}
-                  :as :json})
-      :body
-      :access_token))
-
-(defn flow-api-headers
-  [token-endpoint refresh-token]
-  {"Authorization" (format "Bearer %s" (access-token token-endpoint refresh-token))
-   "User-Agent" "lumen"
-   "Accept" "application/vnd.akvo.flow.v2+json"
-   "X-Akvo-Email" "akvo.flow.user.test2@gmail.com"})
-
 (defn survey-definition
   [api-root headers-fn instance survey-id]
   (-> (format "%s/orgs/%s/surveys/%s"

--- a/backend/src/akvo/lumen/lib/public.clj
+++ b/backend/src/akvo/lumen/lib/public.clj
@@ -31,7 +31,7 @@
   [tenant-conn visualisation]
   (let [visualisation (walk/keywordize-keys visualisation)
         dataset-id (:datasetId visualisation)
-        [dataset-tag dataset] (dataset/fetch-metadata tenant-conn dataset-id [dataset-id])
+        [dataset-tag dataset] (dataset/fetch-metadata tenant-conn dataset-id)
         aggregation-type (get vis-aggregation-mapper (:visualisationType visualisation))
         [tag query-result] (aggregation/query tenant-conn
                                               dataset-id
@@ -48,7 +48,7 @@
     (if (some #(get % "datasetId") layers)
       (let [dataset-id (some #(get % "datasetId") layers)
               [map-data-tag map-data] (maps/create tenant-conn windshaft-url (walk/keywordize-keys layers))
-              [dataset-tag dataset] (dataset/fetch-metadata tenant-conn dataset-id [dataset-id])]
+              [dataset-tag dataset] (dataset/fetch-metadata tenant-conn dataset-id)]
           (when (and (= map-data-tag ::lib/ok)
                      (= dataset-tag ::lib/ok))
             {:datasets {dataset-id dataset}
@@ -62,7 +62,7 @@
 (defn run-unknown-type-visualisation 
   [tenant-conn visualisation]
   (let [dataset-id (:datasetId visualisation)
-        [tag dataset] (dataset/fetch-metadata tenant-conn dataset-id [dataset-id])]
+        [tag dataset] (dataset/fetch-metadata tenant-conn dataset-id)]
     (when (= tag ::lib/ok)
       {:datasets {dataset-id dataset}
        :visualisations {(:id visualisation) visualisation}})))

--- a/backend/src/akvo/lumen/lib/public.clj
+++ b/backend/src/akvo/lumen/lib/public.clj
@@ -30,10 +30,11 @@
 (defn run-visualisation 
   [tenant-conn visualisation]
   (let [visualisation (walk/keywordize-keys visualisation)
-        [dataset-tag dataset] (dataset/fetch-metadata tenant-conn (:datasetId visualisation) [])
+        dataset-id (:datasetId visualisation)
+        [dataset-tag dataset] (dataset/fetch-metadata tenant-conn dataset-id [dataset-id])
         aggregation-type (get vis-aggregation-mapper (:visualisationType visualisation))
         [tag query-result] (aggregation/query tenant-conn
-                                              (:datasetId visualisation)
+                                              dataset-id
                                               aggregation-type
                                               (:spec visualisation))]
     (when (and (= tag ::lib/ok)
@@ -47,7 +48,7 @@
     (if (some #(get % "datasetId") layers)
       (let [dataset-id (some #(get % "datasetId") layers)
               [map-data-tag map-data] (maps/create tenant-conn windshaft-url (walk/keywordize-keys layers))
-              [dataset-tag dataset] (dataset/fetch-metadata tenant-conn dataset-id [])]
+              [dataset-tag dataset] (dataset/fetch-metadata tenant-conn dataset-id [dataset-id])]
           (when (and (= map-data-tag ::lib/ok)
                      (= dataset-tag ::lib/ok))
             {:datasets {dataset-id dataset}
@@ -61,7 +62,7 @@
 (defn run-unknown-type-visualisation 
   [tenant-conn visualisation]
   (let [dataset-id (:datasetId visualisation)
-        [tag dataset] (dataset/fetch-metadata tenant-conn dataset-id [])]
+        [tag dataset] (dataset/fetch-metadata tenant-conn dataset-id [dataset-id])]
     (when (= tag ::lib/ok)
       {:datasets {dataset-id dataset}
        :visualisations {(:id visualisation) visualisation}})))

--- a/backend/src/akvo/lumen/lib/public.clj
+++ b/backend/src/akvo/lumen/lib/public.clj
@@ -69,7 +69,7 @@
 
 (defn visualisation-response-data [tenant-conn id windshaft-url]
   (try
-    (let [[tag vis] (visualisation/fetch tenant-conn id)]
+    (let [[tag vis] (visualisation/public-fetch tenant-conn id)]
       (when (= tag ::lib/ok)
         (condp contains? (:visualisationType vis)
           #{"map"} (run-map-visualisation tenant-conn vis windshaft-url)

--- a/backend/src/akvo/lumen/lib/public.clj
+++ b/backend/src/akvo/lumen/lib/public.clj
@@ -30,7 +30,7 @@
 (defn run-visualisation 
   [tenant-conn visualisation]
   (let [visualisation (walk/keywordize-keys visualisation)
-        [dataset-tag dataset] (dataset/fetch-metadata tenant-conn (:datasetId visualisation))
+        [dataset-tag dataset] (dataset/fetch-metadata tenant-conn (:datasetId visualisation) [])
         aggregation-type (get vis-aggregation-mapper (:visualisationType visualisation))
         [tag query-result] (aggregation/query tenant-conn
                                               (:datasetId visualisation)
@@ -47,7 +47,7 @@
     (if (some #(get % "datasetId") layers)
       (let [dataset-id (some #(get % "datasetId") layers)
               [map-data-tag map-data] (maps/create tenant-conn windshaft-url (walk/keywordize-keys layers))
-              [dataset-tag dataset] (dataset/fetch-metadata tenant-conn dataset-id)]
+              [dataset-tag dataset] (dataset/fetch-metadata tenant-conn dataset-id [])]
           (when (and (= map-data-tag ::lib/ok)
                      (= dataset-tag ::lib/ok))
             {:datasets {dataset-id dataset}
@@ -61,7 +61,7 @@
 (defn run-unknown-type-visualisation 
   [tenant-conn visualisation]
   (let [dataset-id (:datasetId visualisation)
-        [tag dataset] (dataset/fetch-metadata tenant-conn dataset-id)]
+        [tag dataset] (dataset/fetch-metadata tenant-conn dataset-id [])]
     (when (= tag ::lib/ok)
       {:datasets {dataset-id dataset}
        :visualisations {(:id visualisation) visualisation}})))

--- a/backend/src/akvo/lumen/lib/visualisation.clj
+++ b/backend/src/akvo/lumen/lib/visualisation.clj
@@ -28,8 +28,9 @@
                                                  {:ids auth-datasets}
                                                  {}
                                                  {:identifiers identity})
-           auth-vis* (partial auth-vis (set auth-datasets)) 
-           filtered (filter auth-vis* auth-vis-col)]
+           auth-vis* (partial auth-vis auth-datasets) 
+           filtered (filter auth-vis* auth-vis-col)
+           ]
        (log/error (count auth-vis-col) (count filtered))
        filtered)
      [])))

--- a/backend/src/akvo/lumen/lib/visualisation.clj
+++ b/backend/src/akvo/lumen/lib/visualisation.clj
@@ -2,11 +2,22 @@
   (:require [akvo.lumen.lib :as lib]
             [akvo.lumen.util :refer [squuid]]
             [clojure.set :as set]
+            [akvo.lumen.auth :as auth]
             [clojure.tools.logging :as log]
             [hugsql.core :as hugsql])
   (:import [java.sql SQLException]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/visualisation.sql")
+
+(defn check-vis-ds [ds-id auth-datasets]
+  (or (nil? ds-id) (contains? (set auth-datasets) ds-id)))
+
+(defn auth-vis [auth-datasets-set vis]
+  (if (= "map" (:visualisationType vis))
+    (set/superset? auth-datasets-set
+                   (set (map #(get % "datasetId")
+                             (get-in vis [:spec "layers"]))))
+    (check-vis-ds (:datasetId vis) auth-datasets-set)))
 
 (defn all [tenant-conn auth-datasets]
   (lib/ok
@@ -15,53 +26,55 @@
                                                  {:ids auth-datasets}
                                                  {}
                                                  {:identifiers identity})
-           auth-datasets-set (set auth-datasets)
-           filtered (filter (fn [vis]
-                              (if (not= "map" (:visualisationType vis))
-                                true
-                                (set/superset? auth-datasets-set
-                                               (set (map #(get % "datasetId")
-                                                         (get-in vis [:spec "layers"]))))))
-                            auth-vis-col)]
-       (log/error (count auth-vis-col)
-                  (count filtered))
+           auth-vis* (partial auth-vis (set auth-datasets)) 
+           filtered (filter auth-vis* auth-vis-col)]
+       (log/error (count auth-vis-col) (count filtered))
        filtered)
      [])))
 
-(defn create [tenant-conn body jwt-claims]
-  (let [id (squuid)
-        v (first (upsert-visualisation tenant-conn
-                                       {:id id
-                                        :dataset-id (get body "datasetId")
-                                        :type (get body "visualisationType")
-                                        :name (get body "name")
-                                        :spec (get body "spec")
-                                        :author jwt-claims}))]
-    (lib/ok (assoc body
-                   "id" (str id)
-                   "status" "OK"
-                   "created" (:created v)
-                   "modified" (:modified v)))))
+(defn create [tenant-conn body jwt-claims auth-datasets]
+  (if (check-vis-ds (get body "datasetId") auth-datasets)
+    (let [id (squuid)
+          v (first (upsert-visualisation tenant-conn
+                                         {:id id
+                                          :dataset-id (get body "datasetId")
+                                          :type (get body "visualisationType")
+                                          :name (get body "name")
+                                          :spec (get body "spec")
+                                          :author jwt-claims}))]
+      (lib/ok (assoc body
+                     "id" (str id)
+                     "status" "OK"
+                     "created" (:created v)
+                     "modified" (:modified v))))
+    auth/not-authorized))
 
-(defn fetch [tenant-conn id]
+(defn fetch [tenant-conn id auth-datasets]
   (if-let [v (visualisation-by-id tenant-conn
                                   {:id id}
                                   {}
                                   {:identifiers identity})]
-    (lib/ok (dissoc v :author))
+    (if (check-vis-ds (:datasetId v) auth-datasets)
+      (lib/ok (dissoc v :author))
+      auth/not-authorized)
     (lib/not-found {:error "Not found"})))
 
-(defn upsert [tenant-conn body jwt-claims]
-  (let [v (upsert-visualisation tenant-conn
-                                {:id (get body "id")
-                                 :dataset-id (get body "datasetId")
-                                 :type (get body "visualisationType")
-                                 :name (get body "name")
-                                 :spec (get body "spec")
-                                 :author jwt-claims})]
-    (lib/ok {:id (-> v first :id)})))
+(defn upsert [tenant-conn body jwt-claims auth-datasets]
+  (if (check-vis-ds (get body "datasetId") auth-datasets)
+    (let [v (upsert-visualisation tenant-conn
+                                  {:id (get body "id")
+                                   :dataset-id (get body "datasetId")
+                                   :type (get body "visualisationType")
+                                   :name (get body "name")
+                                   :spec (get body "spec")
+                                   :author jwt-claims})]
+      (lib/ok {:id (-> v first :id)}))
+    auth/not-authorized))
 
-(defn delete [tenant-conn id]
-  (if (zero? (delete-visualisation-by-id tenant-conn {:id id}))
-    (lib/not-found {:error "Not found"})
-    (lib/ok {:id id})))
+(defn delete [tenant-conn id auth-datasets]
+  (if (check-vis-ds (:datasetId (visualisation-by-id tenant-conn {:id id} {} {:identifiers identity}))
+                    auth-datasets)
+    (if (zero? (delete-visualisation-by-id tenant-conn {:id id}))
+      (lib/not-found {:error "Not found"})
+      (lib/ok {:id id}))
+    auth/not-authorized))

--- a/backend/src/akvo/lumen/lib/visualisation.clj
+++ b/backend/src/akvo/lumen/lib/visualisation.clj
@@ -2,7 +2,6 @@
   (:require [akvo.lumen.lib :as lib]
             [akvo.lumen.util :refer [squuid]]
             [clojure.set :as set]
-            [akvo.lumen.auth :as auth]
             [clojure.tools.logging :as log]
             [clojure.walk :as w]
             [hugsql.core :as hugsql])
@@ -50,7 +49,7 @@
                      "status" "OK"
                      "created" (:created v)
                      "modified" (:modified v))))
-    auth/not-authorized))
+    (lib/not-authorized nil)))
 
 (defn public-fetch
   "no auth here"
@@ -69,7 +68,7 @@
                                   {:identifiers identity})]
     (if (auth-vis auth-datasets v)
       (lib/ok (dissoc v :author))
-      auth/not-authorized)
+      (lib/not-authorized nil))
     (lib/not-found {:error "Not found"})))
 
 (defn upsert [tenant-conn body jwt-claims auth-datasets]
@@ -82,11 +81,11 @@
                                    :spec (get body "spec")
                                    :author jwt-claims})]
       (lib/ok {:id (-> v first :id)}))
-    auth/not-authorized))
+    (lib/not-authorized nil)))
 
 (defn delete [tenant-conn id auth-datasets]
   (if (auth-vis auth-datasets (visualisation-by-id tenant-conn {:id id} {} {:identifiers identity}))
     (if (zero? (delete-visualisation-by-id tenant-conn {:id id}))
       (lib/not-found {:error "Not found"})
       (lib/ok {:id id}))
-    auth/not-authorized))
+    (lib/not-authorized nil)))

--- a/backend/src/akvo/lumen/lib/visualisation.clj
+++ b/backend/src/akvo/lumen/lib/visualisation.clj
@@ -1,17 +1,32 @@
 (ns akvo.lumen.lib.visualisation
   (:require [akvo.lumen.lib :as lib]
             [akvo.lumen.util :refer [squuid]]
+            [clojure.set :as set]
+            [clojure.tools.logging :as log]
             [hugsql.core :as hugsql])
   (:import [java.sql SQLException]))
 
-
 (hugsql/def-db-fns "akvo/lumen/lib/visualisation.sql")
 
-(defn all [tenant-conn]
-  (lib/ok (all-visualisations tenant-conn
-                              {}
-                              {}
-                              {:identifiers identity})))
+(defn all [tenant-conn auth-datasets]
+  (lib/ok
+   (if (seq auth-datasets)
+     (let [auth-vis-col (all-auth-visualisations tenant-conn
+                                                 {:ids auth-datasets}
+                                                 {}
+                                                 {:identifiers identity})
+           auth-datasets-set (set auth-datasets)
+           filtered (filter (fn [vis]
+                              (if (not= "map" (:visualisationType vis))
+                                true
+                                (set/superset? auth-datasets-set
+                                               (set (map #(get % "datasetId")
+                                                         (get-in vis [:spec "layers"]))))))
+                            auth-vis-col)]
+       (log/error (count auth-vis-col)
+                  (count filtered))
+       filtered)
+     [])))
 
 (defn create [tenant-conn body jwt-claims]
   (let [id (squuid)

--- a/backend/src/akvo/lumen/lib/visualisation.sql
+++ b/backend/src/akvo/lumen/lib/visualisation.sql
@@ -3,6 +3,12 @@
 SELECT id, dataset_id as "datasetId", "name", "type" as "visualisationType", spec, created, modified, author
 FROM visualisation;
 
+-- :name all-auth-visualisations :? :*
+-- :doc All visualisations.
+SELECT id, dataset_id as "datasetId", "name", "type" as "visualisationType", spec, created, modified, author
+FROM visualisation
+WHERE dataset_id IN (:v*:ids);
+
 -- :name visualisation-by-id :? :1
 -- :doc grab visualisation by id
 SELECT id, dataset_id as "datasetId", "name", "type" as "visualisationType", spec, created, modified

--- a/backend/src/akvo/lumen/lib/visualisation.sql
+++ b/backend/src/akvo/lumen/lib/visualisation.sql
@@ -15,6 +15,19 @@ SELECT id, dataset_id as "datasetId", "name", "type" as "visualisationType", spe
 FROM visualisation
 WHERE id = :id;
 
+-- :name visualisation-by-id-list :? :*
+-- :doc grab visualisation by id
+SELECT id, dataset_id as "datasetId", "name", "type" as "visualisationType", spec, created, modified
+FROM visualisation
+WHERE id IN (:v*:ids);
+
+-- :name visualisations-by-dashboard-visualisation-id-list :? :*
+SELECT visualisation.id, dataset_id as "datasetId", "name", "type" as "visualisationType", spec, visualisation.created, visualisation.modified, dashboard_id
+FROM visualisation
+LEFT JOIN dashboard_visualisation ON dashboard_visualisation.visualisation_id = visualisation.id
+WHERE dashboard_id IN (:v*:ids);
+
+
 -- :name delete-visualisation-by-id :! :n
 -- :doc delete visualisation by id
 DELETE FROM visualisation WHERE id = :id;

--- a/backend/test/akvo/lumen/endpoint/collection_test.clj
+++ b/backend/test/akvo/lumen/endpoint/collection_test.clj
@@ -97,7 +97,7 @@
         (is (= #{ds1 ds2 vs1 vs2 db2}
                (-> (collection/fetch *tenant-conn* id)
                    variant/value :entities set)))
-        (dataset/delete *tenant-conn* ds1)
+        (dataset/delete *tenant-conn* ds1 "")
         (is (= #{ds2 vs2 db2}
                (-> (collection/fetch *tenant-conn* id)
                    variant/value :entities set)))))))

--- a/backend/test/akvo/lumen/endpoint/collection_test.clj
+++ b/backend/test/akvo/lumen/endpoint/collection_test.clj
@@ -93,7 +93,7 @@
       (let [id (-> (collection/create *tenant-conn* {"title" "col6"
                                                      "entities" [ds1 ds2 vs1 vs2 db1 db2]})
                    variant/value :id)]
-        (dashboard/delete *tenant-conn* db1)
+        (dashboard/delete *tenant-conn* db1 [ds1 ds2])
         (is (= #{ds1 ds2 vs1 vs2 db2}
                (-> (collection/fetch *tenant-conn* id)
                    variant/value :entities set)))

--- a/backend/test/akvo/lumen/endpoint/collection_test.clj
+++ b/backend/test/akvo/lumen/endpoint/collection_test.clj
@@ -97,7 +97,7 @@
         (is (= #{ds1 ds2 vs1 vs2 db2}
                (-> (collection/fetch *tenant-conn* id)
                    variant/value :entities set)))
-        (dataset/delete *tenant-conn* ds1 [ds1])
+        (dataset/delete *tenant-conn* ds1)
         (is (= #{ds2 vs2 db2}
                (-> (collection/fetch *tenant-conn* id)
                    variant/value :entities set)))))))

--- a/backend/test/akvo/lumen/endpoint/collection_test.clj
+++ b/backend/test/akvo/lumen/endpoint/collection_test.clj
@@ -97,7 +97,7 @@
         (is (= #{ds1 ds2 vs1 vs2 db2}
                (-> (collection/fetch *tenant-conn* id)
                    variant/value :entities set)))
-        (dataset/delete *tenant-conn* ds1)
+        (dataset/delete *tenant-conn* ds1 [ds1])
         (is (= #{ds2 vs2 db2}
                (-> (collection/fetch *tenant-conn* id)
                    variant/value :entities set)))))))

--- a/backend/test/akvo/lumen/endpoint/collection_test.clj
+++ b/backend/test/akvo/lumen/endpoint/collection_test.clj
@@ -38,66 +38,67 @@
   (let [;; Import a few datasets
         ds1 (import-file *tenant-conn* *error-tracker* {:file "GDP.csv"})
         ds2 (import-file *tenant-conn* *error-tracker* {:file "dates.csv"})
-        vs1 (create-visualisation *tenant-conn* ds1 [ds1 ds2])
-        vs2 (create-visualisation *tenant-conn* ds2 [ds1 ds2])
-        db1 (create-dashboard *tenant-conn* [ds1 ds2])
-        db2 (create-dashboard *tenant-conn* [ds1 ds2])]
+        auth-datasets [ds1 ds2]
+        vs1 (create-visualisation *tenant-conn* ds1 auth-datasets)
+        vs2 (create-visualisation *tenant-conn* ds2 auth-datasets)
+        db1 (create-dashboard *tenant-conn* auth-datasets)
+        db2 (create-dashboard *tenant-conn* auth-datasets)]
     (testing "Create an empty collection"
       (let [[tag collection] (collection/create *tenant-conn*
-                                                {"title" "col1"})]
+                                                {"title" "col1"} auth-datasets)]
         (is (= ::lib/created tag))
         (is (= #{:id :title :modified :created :entities}
                (-> collection keys set)))
         (is (= ::lib/conflict
                (first (collection/create *tenant-conn*
-                                         {"title" "col1"} ))))
+                                         {"title" "col1"} auth-datasets))))
         (is (= ::lib/bad-request
                (first (collection/create *tenant-conn*
-                                         {"title" nil}))))
+                                         {"title" nil} auth-datasets))))
         (is (= ::lib/bad-request
                (first (collection/create *tenant-conn*
-                                         {"title" (apply str (repeat 129 "a"))}))))))
+                                         {"title" (apply str (repeat 129 "a"))} auth-datasets))))))
     (testing "Create a collection with entities"
       (let [[tag collection] (collection/create *tenant-conn* {"title" "col2"
-                                                               "entities" [ds1 vs1 db1]})]
+                                                               "entities" [ds1 vs1 db1]} auth-datasets)]
         (is (= ::lib/created tag))
         (is (= #{ds1 vs1 db1} (-> collection :entities set)))))
 
     (testing "Fetch collection"
       (let [id (-> (collection/create *tenant-conn*
-                                      {"title" "col3" "entities" [ds2 vs2 db2]})
+                                      {"title" "col3" "entities" [ds2 vs2 db2]} auth-datasets)
                    variant/value :id)
-            coll (variant/value (collection/fetch *tenant-conn* id))]
+            coll (variant/value (collection/fetch *tenant-conn* id auth-datasets))]
         (is (= #{ds2 vs2 db2} (-> coll :entities set)))))
 
     (testing "Update collection"
-      (let [id (-> (collection/create *tenant-conn* {"title" "col4" "entities" [ds2 vs2 db2]})
+      (let [id (-> (collection/create *tenant-conn* {"title" "col4" "entities" [ds2 vs2 db2]} auth-datasets)
                    variant/value :id)]
-        (let [coll (variant/value (collection/update *tenant-conn* id {"title" "col4 renamed"}))]
+        (let [coll (variant/value (collection/update *tenant-conn* id {"title" "col4 renamed"} auth-datasets))]
           (is (= (:title coll) "col4 renamed"))
           (is (= (-> coll :entities set)
                  #{ds2 vs2 db2}))
-          (collection/update *tenant-conn* id {"entities" []})
-          (is (= [] (-> (collection/fetch *tenant-conn* id) variant/value :entities)))
-          (collection/update *tenant-conn* id {"entities" [ds1 vs1]})
-          (is (= #{ds1 vs1} (-> (collection/fetch *tenant-conn* id) variant/value :entities set)))
-          (collection/update *tenant-conn* id {"entities" [vs1 vs2]})
-          (is (= #{vs1 vs2} (-> (collection/fetch *tenant-conn* id) variant/value :entities set))))))
+          (collection/update *tenant-conn* id {"entities" []} auth-datasets)
+          (is (= [] (-> (collection/fetch *tenant-conn* id auth-datasets) variant/value :entities)))
+          (collection/update *tenant-conn* id {"entities" [ds1 vs1]} auth-datasets)
+          (is (= #{ds1 vs1} (-> (collection/fetch *tenant-conn* id auth-datasets) variant/value :entities set)))
+          (collection/update *tenant-conn* id {"entities" [vs1 vs2]} auth-datasets)
+          (is (= #{vs1 vs2} (-> (collection/fetch *tenant-conn* id auth-datasets) variant/value :entities set))))))
 
     (testing "Delete collection"
-      (let [id (-> (collection/create *tenant-conn* {"title" "col5"}) variant/value :id)]
-        (collection/delete *tenant-conn* id)
-        (is (= ::lib/not-found (variant/tag (collection/fetch *tenant-conn* id))))))
+      (let [id (-> (collection/create *tenant-conn* {"title" "col5"} auth-datasets) variant/value :id)]
+        (collection/delete *tenant-conn* id auth-datasets)
+        (is (= ::lib/not-found (variant/tag (collection/fetch *tenant-conn* id auth-datasets))))))
 
     (testing "Delete collection entities"
       (let [id (-> (collection/create *tenant-conn* {"title" "col6"
-                                                     "entities" [ds1 ds2 vs1 vs2 db1 db2]})
+                                                     "entities" [ds1 ds2 vs1 vs2 db1 db2]} auth-datasets)
                    variant/value :id)]
-        (dashboard/delete *tenant-conn* db1 [ds1 ds2])
+        (dashboard/delete *tenant-conn* db1 auth-datasets)
         (is (= #{ds1 ds2 vs1 vs2 db2}
-               (-> (collection/fetch *tenant-conn* id)
+               (-> (collection/fetch *tenant-conn* id auth-datasets)
                    variant/value :entities set)))
         (dataset/delete *tenant-conn* ds1)
         (is (= #{ds2 vs2 db2}
-               (-> (collection/fetch *tenant-conn* id)
+               (-> (collection/fetch *tenant-conn* id auth-datasets)
                    variant/value :entities set)))))))

--- a/backend/test/akvo/lumen/endpoint/collection_test.clj
+++ b/backend/test/akvo/lumen/endpoint/collection_test.clj
@@ -29,8 +29,8 @@
       variant/value
       (get "id")))
 
-(defn create-dashboard [tenant-conn]
-  (-> (dashboard/create tenant-conn {"title" ""} {})
+(defn create-dashboard [tenant-conn auth-datasets]
+  (-> (dashboard/create tenant-conn {"title" ""} {} auth-datasets)
       variant/value
       (get :id)))
 
@@ -40,8 +40,8 @@
         ds2 (import-file *tenant-conn* *error-tracker* {:file "dates.csv"})
         vs1 (create-visualisation *tenant-conn* ds1 [ds1 ds2])
         vs2 (create-visualisation *tenant-conn* ds2 [ds1 ds2])
-        db1 (create-dashboard *tenant-conn*)
-        db2 (create-dashboard *tenant-conn*)]
+        db1 (create-dashboard *tenant-conn* [ds1 ds2])
+        db2 (create-dashboard *tenant-conn* [ds1 ds2])]
     (testing "Create an empty collection"
       (let [[tag collection] (collection/create *tenant-conn*
                                                 {"title" "col1"})]
@@ -50,7 +50,7 @@
                (-> collection keys set)))
         (is (= ::lib/conflict
                (first (collection/create *tenant-conn*
-                                         {"title" "col1"}))))
+                                         {"title" "col1"} ))))
         (is (= ::lib/bad-request
                (first (collection/create *tenant-conn*
                                          {"title" nil}))))

--- a/backend/test/akvo/lumen/endpoint/collection_test.clj
+++ b/backend/test/akvo/lumen/endpoint/collection_test.clj
@@ -97,7 +97,7 @@
         (is (= #{ds1 ds2 vs1 vs2 db2}
                (-> (collection/fetch *tenant-conn* id)
                    variant/value :entities set)))
-        (dataset/delete *tenant-conn* ds1 "")
+        (dataset/delete *tenant-conn* ds1)
         (is (= #{ds2 vs2 db2}
                (-> (collection/fetch *tenant-conn* id)
                    variant/value :entities set)))))))

--- a/backend/test/akvo/lumen/endpoint/collection_test.clj
+++ b/backend/test/akvo/lumen/endpoint/collection_test.clj
@@ -24,8 +24,8 @@
    "name" ""
    "spec" {}})
 
-(defn create-visualisation [tenant-conn dataset-id]
-  (-> (visualisation/create *tenant-conn* (visualisation-body dataset-id) {})
+(defn create-visualisation [tenant-conn dataset-id auth-datasets]
+  (-> (visualisation/create *tenant-conn* (visualisation-body dataset-id) {} auth-datasets)
       variant/value
       (get "id")))
 
@@ -38,8 +38,8 @@
   (let [;; Import a few datasets
         ds1 (import-file *tenant-conn* *error-tracker* {:file "GDP.csv"})
         ds2 (import-file *tenant-conn* *error-tracker* {:file "dates.csv"})
-        vs1 (create-visualisation *tenant-conn* ds1)
-        vs2 (create-visualisation *tenant-conn* ds2)
+        vs1 (create-visualisation *tenant-conn* ds1 [ds1 ds2])
+        vs2 (create-visualisation *tenant-conn* ds2 [ds1 ds2])
         db1 (create-dashboard *tenant-conn*)
         db2 (create-dashboard *tenant-conn*)]
     (testing "Create an empty collection"

--- a/backend/test/akvo/lumen/endpoint/dashboard_test.clj
+++ b/backend/test/akvo/lumen/endpoint/dashboard_test.clj
@@ -69,49 +69,48 @@
 
 
 (deftest ^:functional dashboard
-  (share-test/seed *tenant-conn* share-test/test-spec)
+  (let [auth-ds (share-test/seed *tenant-conn* share-test/test-spec)]
+    (testing "Dashboard"
+      (let [v-id               (-> (all-visualisations *tenant-conn*) first :id)
+            d-spec             (dashboard-spec v-id)
+            {dashboard-id :id} (variant/value (dashboard/create *tenant-conn* d-spec {} auth-ds))]
+        (is (not (nil? dashboard-id)))
 
-  (testing "Dashboard"
-    (let [v-id               (-> (all-visualisations *tenant-conn*) first :id)
-          d-spec             (dashboard-spec v-id)
-          {dashboard-id :id} (variant/value (dashboard/create *tenant-conn* d-spec {}))]
-      (is (not (nil? dashboard-id)))
+        (testing "Get dashboard"
+          (let [d (variant/value (dashboard/fetch *tenant-conn* dashboard-id))]
+            (is (not (nil? d)))
+            (is (every? #(contains? d %)
+                        [:id :title :entities :layout :type :status :created
+                         :modified]))
+            (is (= (get d-spec "title")
+                   (get d :title)))
 
-      (testing "Get dashboard"
-        (let [d (variant/value (dashboard/fetch *tenant-conn* dashboard-id))]
-          (is (not (nil? d)))
-          (is (every? #(contains? d %)
-                      [:id :title :entities :layout :type :status :created
-                       :modified]))
-          (is (= (get d-spec "title")
-                 (get d :title)))
+            (is (= (set (mapv name (keys (:entities d))))
+                   (set (mapv name (keys (get d-spec "entities"))))))
 
-          (is (= (set (mapv name (keys (:entities d))))
-                 (set (mapv name (keys (get d-spec "entities"))))))
+            (is (= (set (mapv name (keys (:layout d))))
+                   (set (mapv name (keys (get d-spec "layout"))))))))
 
-          (is (= (set (mapv name (keys (:layout d))))
-                 (set (mapv name (keys (get d-spec "layout"))))))))
+        (testing "Update dashboard"
+          (let [new-spec (-> d-spec
+                             (assoc "title" "My updated dashboard")
+                             (assoc-in ["entities" "text-1" "content"]
+                                       "Updated text entity")
+                             (assoc-in ["layout" "text-1" "h"] 1))]
 
-      (testing "Update dashboard"
-        (let [new-spec (-> d-spec
-                           (assoc "title" "My updated dashboard")
-                           (assoc-in ["entities" "text-1" "content"]
-                                     "Updated text entity")
-                           (assoc-in ["layout" "text-1" "h"] 1))]
+            (dashboard/upsert *tenant-conn* dashboard-id new-spec)
+            (let [updated-d (variant/value (dashboard/fetch *tenant-conn* dashboard-id))]
+              (is (= (:title updated-d)
+                     "My updated dashboard"))
+              (is (= (get-in updated-d [:entities "text-1" "content"])
+                     "Updated text entity"))
+              (is (= (get-in updated-d [:layout "text-1" "h"])
+                     1)))))
 
-          (dashboard/upsert *tenant-conn* dashboard-id new-spec)
-          (let [updated-d (variant/value (dashboard/fetch *tenant-conn* dashboard-id))]
-            (is (= (:title updated-d)
-                   "My updated dashboard"))
-            (is (= (get-in updated-d [:entities "text-1" "content"])
-                   "Updated text entity"))
-            (is (= (get-in updated-d [:layout "text-1" "h"])
-                   1)))))
-
-      (testing "Delete dashboard"
-        (dashboard/delete *tenant-conn* dashboard-id)
-        (is (nil? (dashboard-by-id *tenant-conn* {:id dashboard-id})))
-        (is (empty? (dashboard_visualisation-by-dashboard-id
-                     *tenant-conn* {:dashboard-id dashboard-id})))
-        (is (= (count (all-dashboards *tenant-conn*))
-               1))))))
+        (testing "Delete dashboard"
+          (dashboard/delete *tenant-conn* dashboard-id)
+          (is (nil? (dashboard-by-id *tenant-conn* {:id dashboard-id})))
+          (is (empty? (dashboard_visualisation-by-dashboard-id
+                       *tenant-conn* {:dashboard-id dashboard-id})))
+          (is (= (count (all-dashboards *tenant-conn*))
+                 1)))))))

--- a/backend/test/akvo/lumen/endpoint/dashboard_test.clj
+++ b/backend/test/akvo/lumen/endpoint/dashboard_test.clj
@@ -4,69 +4,17 @@
             [akvo.lumen.fixtures :refer [*tenant-conn*
                                          tenant-conn-fixture
                                          system-fixture]]
+            [akvo.lumen.lib.dashboard-test :refer [dashboard-spec]]
             [akvo.lumen.lib.dashboard :as dashboard]
             [akvo.lumen.endpoint.commons.variant :as variant]
             [akvo.lumen.test-utils :as tu]
             [clojure.test :refer :all]
             [hugsql.core :as hugsql]))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Test data
-;;;
-
-(defn dashboard-spec [v-id]
-  {"type"     "dashboard"
-   "title"    "My first Dashboard"
-   ;; "id"       dashboard-id ;; Not present on new
-   "entities" {v-id     {"id"   v-id
-                         "type" "visualisation"
-                         ;;"visualisation" v-id ;; data?
-                         }
-               "text-1" {"id"      "text-1"
-                         "type"    "text"
-                         "content" "I am a text entity."}
-               "text-2" {"id"      "text-2"
-                         "type"    "text"
-                         "content" "I am another text entity."}}
-   "layout"   {v-id     {"x" 1
-                         "y" 0
-                         "w" 0
-                         "h" 0
-                         "i" v-id}
-               "text-1" {"x" 2
-                         "y" 0
-                         "w" 0
-                         "h" 0
-                         "i" "text-1"}
-               "text-2" {"x" 3
-                         "y" 0
-                         "w" 0
-                         "h" 0
-                         "i" "text-2"}}})
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Tests
-;;;
-
 (use-fixtures :once system-fixture tenant-conn-fixture tu/spec-instrument)
-
 
 (hugsql/def-db-fns "akvo/lumen/lib/visualisation.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/dashboard.sql")
-
-(deftest dashboard-unit
-  (testing "filter-type"
-    (is (= (dashboard/filter-type (dashboard-spec "abc123") "text")
-           {:entities
-            '({"id" "text-1", "type" "text", "content" "I am a text entity."}
-             {"id" "text-2",
-              "type" "text",
-              "content" "I am another text entity."}),
-            :layout
-            '({"x" 2, "y" 0, "w" 0, "h" 0, "i" "text-1"}
-             {"x" 3, "y" 0, "w" 0, "h" 0, "i" "text-2"})}))))
-
 
 (deftest ^:functional dashboard
   (let [auth-ds (share-test/seed *tenant-conn* share-test/test-spec)]

--- a/backend/test/akvo/lumen/endpoint/dashboard_test.clj
+++ b/backend/test/akvo/lumen/endpoint/dashboard_test.clj
@@ -25,14 +25,13 @@
         (is (not (nil? dashboard-id)))
 
         (testing "Get dashboard"
-          (let [d (variant/value (dashboard/fetch *tenant-conn* dashboard-id))]
+          (let [d (variant/value (dashboard/auth-fetch *tenant-conn* dashboard-id auth-ds))]
             (is (not (nil? d)))
             (is (every? #(contains? d %)
                         [:id :title :entities :layout :type :status :created
                          :modified]))
             (is (= (get d-spec "title")
                    (get d :title)))
-
             (is (= (set (mapv name (keys (:entities d))))
                    (set (mapv name (keys (get d-spec "entities"))))))
 
@@ -46,8 +45,8 @@
                                        "Updated text entity")
                              (assoc-in ["layout" "text-1" "h"] 1))]
 
-            (dashboard/upsert *tenant-conn* dashboard-id new-spec)
-            (let [updated-d (variant/value (dashboard/fetch *tenant-conn* dashboard-id))]
+            (dashboard/upsert *tenant-conn* dashboard-id new-spec auth-ds)
+            (let [updated-d (variant/value (dashboard/auth-fetch *tenant-conn* dashboard-id auth-ds))]
               (is (= (:title updated-d)
                      "My updated dashboard"))
               (is (= (get-in updated-d [:entities "text-1" "content"])
@@ -56,7 +55,7 @@
                      1)))))
 
         (testing "Delete dashboard"
-          (dashboard/delete *tenant-conn* dashboard-id)
+          (dashboard/delete *tenant-conn* dashboard-id auth-ds)
           (is (nil? (dashboard-by-id *tenant-conn* {:id dashboard-id})))
           (is (empty? (dashboard_visualisation-by-dashboard-id
                        *tenant-conn* {:dashboard-id dashboard-id})))

--- a/backend/test/akvo/lumen/endpoint/share_test.clj
+++ b/backend/test/akvo/lumen/endpoint/share_test.clj
@@ -79,10 +79,13 @@
 
 (defn seed
   [conn spec]
-  (seed* conn (:vis-1 spec))
-  (seed* conn (:vis-2 spec))
-  (dashboard/create conn (dashboard-spec (:id (:vis-1 spec))
-                                         (:id (:vis-2 spec))) {}))
+  (let [{:keys [visualisation-id dataset-id]} (seed* conn (:vis-1 spec))
+        [v1 d1] [visualisation-id dataset-id]
+        {:keys [visualisation-id dataset-id]} (seed* conn (:vis-2 spec))
+        [v2 d2] [visualisation-id dataset-id]
+        ]
+    (dashboard/create conn (dashboard-spec v1 v2) {} [d1 d2])
+    [d1 d2]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Test data

--- a/backend/test/akvo/lumen/lib/dashboard_test.clj
+++ b/backend/test/akvo/lumen/lib/dashboard_test.clj
@@ -3,6 +3,7 @@
   (:require [akvo.lumen.fixtures :refer [*tenant-conn*
                                          tenant-conn-fixture
                                          system-fixture]]
+            [clojure.walk :refer [keywordize-keys]]
             [akvo.lumen.lib.dashboard :as dashboard]
             [clojure.test :refer :all]))
 
@@ -38,7 +39,7 @@
 
 (deftest dashboard-unit
   (testing "filter-type"
-    (is (= (dashboard/filter-type (dashboard-spec "abc123") "text")
+    (is (= (dashboard/filter-type (keywordize-keys (dashboard-spec "abc123")) "text")
            {:entities
 	   '({:id "text-1", :type "text", :content "I am a text entity."}
 	    {:id "text-2", :type "text", :content "I am another text entity."}),

--- a/backend/test/akvo/lumen/lib/dashboard_test.clj
+++ b/backend/test/akvo/lumen/lib/dashboard_test.clj
@@ -1,0 +1,47 @@
+(ns akvo.lumen.lib.dashboard-test
+  {:functional true}
+  (:require [akvo.lumen.fixtures :refer [*tenant-conn*
+                                         tenant-conn-fixture
+                                         system-fixture]]
+            [akvo.lumen.lib.dashboard :as dashboard]
+            [clojure.test :refer :all]))
+
+(defn dashboard-spec [v-id]
+  {"type"     "dashboard"
+   "title"    "My first Dashboard"
+   ;; "id"       dashboard-id ;; Not present on new
+   "entities" {v-id     {"id"   v-id
+                         "type" "visualisation"
+                         ;;"visualisation" v-id ;; data?
+                         }
+               "text-1" {"id"      "text-1"
+                         "type"    "text"
+                         "content" "I am a text entity."}
+               "text-2" {"id"      "text-2"
+                         "type"    "text"
+                         "content" "I am another text entity."}}
+   "layout"   {v-id     {"x" 1
+                         "y" 0
+                         "w" 0
+                         "h" 0
+                         "i" v-id}
+               "text-1" {"x" 2
+                         "y" 0
+                         "w" 0
+                         "h" 0
+                         "i" "text-1"}
+               "text-2" {"x" 3
+                         "y" 0
+                         "w" 0
+                         "h" 0
+                         "i" "text-2"}}})
+
+(deftest dashboard-unit
+  (testing "filter-type"
+    (is (= (dashboard/filter-type (dashboard-spec "abc123") "text")
+           {:entities
+	   '({:id "text-1", :type "text", :content "I am a text entity."}
+	    {:id "text-2", :type "text", :content "I am another text entity."}),
+	   :layout
+	   '({:x 2, :y 0, :w 0, :h 0, :i "text-1"}
+	    {:x 3, :y 0, :w 0, :h 0, :i "text-2"})}))))

--- a/backend/test/akvo/lumen/test_utils.clj
+++ b/backend/test/akvo/lumen/test_utils.clj
@@ -184,7 +184,5 @@
           :as req}]
       (let [dss (->> (all-datasets (p/connection tenant-manager tenant))
                      (mapv :id))]
-        (handler (assoc req :auth-datasets (if (empty? dss)
-                                             [""]
-                                             dss)))))))
+        (handler (assoc req :auth-datasets dss))))))
 

--- a/backend/test/akvo/lumen/test_utils.clj
+++ b/backend/test/akvo/lumen/test_utils.clj
@@ -178,7 +178,7 @@
 
 (hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")
 
-(defmethod ig/init-key :akvo.lumen.test-utils/wrap-ds-auth  [_ {:keys [tenant-manager] :as opts}]
+(defmethod ig/init-key :akvo.lumen.test-utils/wrap-auth-datasets  [_ {:keys [tenant-manager] :as opts}]
   (fn [handler]
     (fn [{tenant :tenant
           :as req}]

--- a/backend/test/resources/endpoints-test.edn
+++ b/backend/test/resources/endpoints-test.edn
@@ -1,10 +1,10 @@
 {:akvo.lumen.component.handler/handler-verify {:middleware ^:replace [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant
                                                                       #ig/ref :akvo.lumen.component.handler/common-middleware]}
  :akvo.lumen.test-utils/wrap-jwt-mock {:keycloak #ig/ref :akvo.lumen.component.keycloak/data}
-  :akvo.lumen.test-utils/wrap-ds-auth {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
+  :akvo.lumen.test-utils/wrap-auth-datasets {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
  :akvo.lumen.component.handler/handler-api {:middleware ^:replace [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant
                                                                    #ig/ref :akvo.lumen.test-utils/wrap-jwt-mock
-                                                                   #ig/ref :akvo.lumen.test-utils/wrap-ds-auth
+                                                                   #ig/ref :akvo.lumen.test-utils/wrap-auth-datasets
                                                                    #ig/ref :akvo.lumen.component.handler/common-middleware
                                                                    #ig/ref :akvo.lumen.monitoring/middleware]}}
 

--- a/backend/test/resources/endpoints-test.edn
+++ b/backend/test/resources/endpoints-test.edn
@@ -1,8 +1,10 @@
 {:akvo.lumen.component.handler/handler-verify {:middleware ^:replace [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant
                                                                       #ig/ref :akvo.lumen.component.handler/common-middleware]}
  :akvo.lumen.test-utils/wrap-jwt-mock {:keycloak #ig/ref :akvo.lumen.component.keycloak/data}
+  :akvo.lumen.test-utils/wrap-ds-auth {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
  :akvo.lumen.component.handler/handler-api {:middleware ^:replace [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant
                                                                    #ig/ref :akvo.lumen.test-utils/wrap-jwt-mock
+                                                                   #ig/ref :akvo.lumen.test-utils/wrap-ds-auth
                                                                    #ig/ref :akvo.lumen.component.handler/common-middleware
                                                                    #ig/ref :akvo.lumen.monitoring/middleware]}}
 

--- a/backend/test/resources/test.edn
+++ b/backend/test/resources/test.edn
@@ -40,11 +40,10 @@
 
  :akvo.lumen.upload/data {:file-upload-path "/tmp/akvo/lumen"}
 
- :akvo.lumen.endpoint.dataset/dataset {:import-config {:flow-api-url "https://api.akvotest.org/flow"}}
+ :akvo.lumen.component.flow/api {:url "https://api.akvotest.org/flow"}
 
  :akvo.lumen.endpoint.env/env {:keycloak-public-client-id "akvo-lumen"
                                :keycloak-url "http://auth.lumen.local:8080/auth"
-                               :flow-api-url "https://api.akvotest.org/flow"
                                :sentry-client-dsn "dev-sentry-client-dsn"
                                :piwik-site-id "165"}
  

--- a/client/e2e-test/cypress/integration/index.spec.js
+++ b/client/e2e-test/cypress/integration/index.spec.js
@@ -67,16 +67,14 @@ context('Akvo Lumen', () => {
     // Import
     cy.get('button[data-test-id="next"]').click();
     cy.get(`[data-test-name="${datasetName}"]:not(.PENDING)`).should('exist');
-    setTimeout(5000, () => {
-      cy.get(`[data-test-name="${datasetName}"] > a`).click({ force: true });
-      // see if metadata is correct
-      cy.get('.columnCount').contains('6 Columns').should('exist');
-      cy.get('.rowCount').contains('4 Rows').should('exist');
-    // see if table cells exist
-      cy.get('.fixedDataTableCellLayout_main').should('have.length.of.at.least', 4);
-    // back to library
-      cy.get('[data-test-id="back-button"]').click();
-    });
+    cy.get(`[data-test-name="${datasetName}"] > a`).click({ force: true });
+    // see if metadata is correct
+    cy.get('.columnCount').contains('6 Columns').should('exist');
+    cy.get('.rowCount').contains('4 Rows').should('exist');
+  // see if table cells exist
+    cy.get('.fixedDataTableCellLayout_main').should('have.length.of.at.least', 4);
+  // back to library
+    cy.get('[data-test-id="back-button"]').click();
   });
 
   it('create visualisation (pivot table)', () => {

--- a/client/e2e-test/cypress/integration/index.spec.js
+++ b/client/e2e-test/cypress/integration/index.spec.js
@@ -23,7 +23,7 @@ Cypress.on('fail', (error) => {
   throw error; // throw error to have test still fail
 });
 
-context('Akvo Lumen', ()  => {
+context('Akvo Lumen', () => {
   // login
   before(() => {
     cy.visit(baseUrl);
@@ -67,14 +67,16 @@ context('Akvo Lumen', ()  => {
     // Import
     cy.get('button[data-test-id="next"]').click();
     cy.get(`[data-test-name="${datasetName}"]:not(.PENDING)`).should('exist');
-    cy.get(`[data-test-name="${datasetName}"] > a`).click({ force: true });
-    // see if metadata is correct
-    cy.get('.columnCount').contains('6 Columns').should('exist');
-    cy.get('.rowCount').contains('4 Rows').should('exist');
+    setTimeout(5000, () => {
+      cy.get(`[data-test-name="${datasetName}"] > a`).click({ force: true });
+      // see if metadata is correct
+      cy.get('.columnCount').contains('6 Columns').should('exist');
+      cy.get('.rowCount').contains('4 Rows').should('exist');
     // see if table cells exist
-    cy.get('.fixedDataTableCellLayout_main').should('have.length.of.at.least', 4);
+      cy.get('.fixedDataTableCellLayout_main').should('have.length.of.at.least', 4);
     // back to library
-    cy.get('[data-test-id="back-button"]').click();
+      cy.get('[data-test-id="back-button"]').click();
+    });
   });
 
   it('create visualisation (pivot table)', () => {


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

## Thoughts to share & to agree:
we need to ensure that the user has rights to *operate* in/with a dataset and the user has rights to *view* data with dataset

### 1. where should we place dataset authentication logic?
Datasets are spread out different entities like aggregations, transformations, visualizations, collections or dashboards. 
At first glance, it seems that we should place dataset authentication logic on the endpoints in a declarative way (using `edn` and middleware). But due to the interrelations between dataset entities and the rest of the other domain entities, makes very difficult to ensure that some response carries dataset with no privileges for the current user. As a possible solution in the view, we could define some kind of entity-response-protocol that always is called in the response (and maybe the same solution could be applied to the request  🤔 )
- Putting the logic in the endpoint layer leaves to the developer the duty to take care of using lib.dataset ns without enough rights from other endpoints or layers ... (e.g: endpoint.public=> lib.public => lib.dataset)
- there is some ambiguity with the authentication behavior with `/share` endpoint, thus the authentication logic, in this case, is ignored, or displaced by a password-based protected view
- 2 different users with different rights could work in the same dataset/vis. The user with more rights could invalidate the other user access data, combining the "allowed" data with "unallowed" data.  

### 2. maybe it is worthing to grab the allowed visualizations together with allowed datasets in the middleware?
to discuss


### 3. views/ops that we need to take into account
- [x] library => dataset/all
- [x] dataset detail
- [x] visualization detail
- [x] aggregation detail
- [x] dashboard
- [ ] collection
- [x] lib.public => dataset/fetch-metadata ... allowing access thus user should have rights at the time they create the share link ... check with Daniel & Jana about this asumption
- [ ] Combined datasets: through transformations

### 4. questions: 
- auth-dataset-opt-middleware ?
- cache dataset permissions having a short expired time ?

### middleware approach using reitit to get routes (... and then matching with desired endpoints)

below routes in `dev` env

```clojure
(map (juxt first (comp #(disj % :middleware) set keys second))
                                        (rc/routes router))
```

```clojure
(["/env" #{:get}]
 ["/healthz" #{:get}]
 ["/metrics" #{:get}]
 ["/api/aggregation/:dataset-id/:visualisation-type" #{:get}]
 ["/api/collections" #{:get :post}]
 ["/api/collections/:id" #{:get :delete :put}]
 ["/api/dashboards" #{:get :post}]
 ["/api/dashboards/:id" #{:get :delete :put}]
 ["/api/datasets" #{:get :post}]
 ["/api/datasets/:id" #{:get :delete :put}]
 ["/api/datasets/:id/meta" #{:get}]
 ["/api/datasets/:id/update" #{:post}]
 ["/api/library" #{:get}]
 ["/api/transformations/:dataset-id/transform" #{:post}]
 ["/api/transformations/:dataset-id/undo" #{:post}]
 ["/api/visualisations" #{:get :post}]
 ["/api/visualisations/maps" #{:post}]
 ["/api/visualisations/rasters" #{:post}]
 ["/api/visualisations/:id" #{:get :delete :put}]
 ["/api/files" #{:post}]
 ["/api/files/:id" #{:patch :head}]
 ["/api/rasters" #{:get :post}]
 ["/api/rasters/:id" #{:get :delete}]
 ["/api/exports" #{:post}]
 ["/api/data-source/job-execution/:id/status/:status" #{:delete}]
 ["/api/job_executions/:id" #{:get}]
 ["/api/multiple-column" #{:get}]
 ["/api/split-column/:dataset-id/pattern-analysis" #{:get}]
 ["/api/resources" #{:get}]
 ["/api/shares" #{:post}]
 ["/api/shares/:id" #{:put}]
 ["/api/tiers" #{:get}]
 ["/api/admin/users" #{:get}]
 ["/api/admin/users/:id" #{:patch :delete}]
 ["/api/admin/invites" #{:get :post}]
 ["/api/admin/invites/:id" #{:delete}]
 ["/verify/:id" #{:get}]
 ["/share/:id" #{:get}]
 ["/local-development/local-server/:file" #{:get}]
 ["/spec/sample/:spec-ns/:spec-id" #{:get}]
 ["/spec/describe/:spec-ns/:spec-id" #{:get}]
 ["/spec/conform/:spec-ns/:spec-id" #{:post}])
```
