### PR TITLE
[#1949] Auth "api/datasets" continuation

### DIFF
--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -43,7 +43,9 @@
     [["" {:get {:parameters {:path-params {:id string?}}
                 :handler (fn [{tenant :tenant
                                {:keys [id]} :path-params}]
-                           (dataset/fetch (p/connection tenant-manager tenant) id))}
+                           (if-let [res (dataset/fetch (p/connection tenant-manager tenant) id)]
+                             (lib/ok res)
+                             (lib/not-found {:error "Not found"})))}
           :put {:parameters {:body map?
                              :path-params {:id string?}}
                 :handler (fn [{tenant :tenant

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -42,9 +42,13 @@
                         (lib/not-authorized {:id id}))))]}
     [["" {:get {:parameters {:path-params {:id string?}}
                 :handler (fn [{tenant :tenant
+                               auth-service :auth-service
                                {:keys [id]} :path-params}]
                            (if-let [res (dataset/fetch (p/connection tenant-manager tenant) id)]
-                             (lib/ok res)
+                             (let [ids (l.auth/ids ::dataset.s/dataset res)]
+                               (if (p/allow? auth-service ids)
+                                 (lib/ok res)
+                                 (lib/not-authorized ids)))
                              (lib/not-found {:error "Not found"})))}
           :put {:parameters {:body map?
                              :path-params {:id string?}}

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -67,17 +67,15 @@
 
 (defn fetch
   [tenant-conn id]
-  (if-let [dataset (dataset-by-id tenant-conn {:id id})]
+  (when-let [dataset (dataset-by-id tenant-conn {:id id})]
     (let [columns (remove #(get % "hidden") (:columns dataset))
           data (rest (jdbc/query tenant-conn
                                  [(select-data-sql (:table-name dataset) columns)]
                                  {:as-arrays? true}))]
-      (lib/ok
-       (-> dataset
-           (select-keys [:created :id :modified :status :title :transformations :updated :author :source])
-           (rename-keys {:title :name})
-           (assoc :rows data :columns columns :status "OK"))))
-    (lib/not-found {:error "Not found"})))
+      (-> dataset
+          (select-keys [:created :id :modified :status :title :transformations :updated :author :source])
+          (rename-keys {:title :name})
+          (assoc :rows data :columns columns :status "OK")))))
 
 (defn delete
   [tenant-conn id]


### PR DESCRIPTION
- [ ] **Update release notes if necessary**


**To be reviewed&merged after https://github.com/akvo/akvo-lumen/pull/2070**

- Auth id in "/datasets/:id*" with middleware
- Move lib http details from lib.dataset to endpoint.dataset
- Auth outcome data for "GET /datasets/id"