### PR TITLE
[#1949] Auth "PUT /collections/:id" & "POST /collections" payloads 

### DIFF
--- a/backend/specs/akvo/lumen/specs/collection.clj
+++ b/backend/specs/akvo/lumen/specs/collection.clj
@@ -25,8 +25,8 @@
 (s/def ::entities (s/coll-of ::entity :distinct true))
 
 (s/def ::collection (s/keys :req-un [::id ::created ::modified ::entities]))
-(s/def ::collection-post-payload (s/keys :req-un [::title]))
+
+(s/def ::collection-post-payload (s/keys :req-un [::title]
+                                         :opt-un [::entities]))
 
 (s/def ::collection-payload (s/merge ::collection ::collection-post-payload))
-
-#_(s/valid? ::collection-payload {:id "3fceb475-fe78-4764-8302-3467ae990fd5", :title "pickachu", :created 1555079216460, :modified 1555079216460, :entities ["5cb0887f-2843-4a3f-9991-a50a0e5da987"]})

--- a/backend/specs/akvo/lumen/specs/collection.clj
+++ b/backend/specs/akvo/lumen/specs/collection.clj
@@ -2,6 +2,8 @@
   (:require [clojure.tools.logging :as log]
             [akvo.lumen.specs.db :as db.s]
             [akvo.lumen.specs.visualisation :as visualisation.s]
+            [akvo.lumen.specs.dashboard :as dashboard.s]
+            [akvo.lumen.specs.dataset :as dataset.s]
             [akvo.lumen.specs :as lumen.s]
             [akvo.lumen.lib.visualisation :as visualisation]
             [clojure.spec.alpha :as s]))
@@ -12,6 +14,19 @@
               #'*id?*
               lumen.s/str-uuid-gen))
 
-(s/def ::collection (s/keys :req-un [::id]))
+(s/def ::created ::lumen.s/date-number)
 
-(s/def ::datasets (s/coll-of ::collection :distinct true))
+(s/def ::modified ::lumen.s/date-number)
+
+(s/def ::title string?)
+
+(s/def ::entity (s/or :dash ::dashboard.s/id :vis ::visualisation.s/id :ds ::dataset.s/id))
+
+(s/def ::entities (s/coll-of ::entity :distinct true))
+
+(s/def ::collection (s/keys :req-un [::id ::created ::modified ::entities]))
+(s/def ::collection-post-payload (s/keys :req-un [::title]))
+
+(s/def ::collection-payload (s/merge ::collection ::collection-post-payload))
+
+#_(s/valid? ::collection-payload {:id "3fceb475-fe78-4764-8302-3467ae990fd5", :title "pickachu", :created 1555079216460, :modified 1555079216460, :entities ["5cb0887f-2843-4a3f-9991-a50a0e5da987"]})

--- a/backend/src/akvo/lumen/endpoint/collection.clj
+++ b/backend/src/akvo/lumen/endpoint/collection.clj
@@ -25,8 +25,7 @@
              :parameters {:body map?}
              :handler (fn [{tenant :tenant
                             body :body}]
-                        (log/error :POST-body body)
-                        (collection/create (p/connection tenant-manager tenant) (stringify-keys body)))}}]
+                        (collection/create (p/connection tenant-manager tenant) (w/keywordize-keys body)))}}]
    ["/:id"
     {:middleware [(fn [handler]
                     (fn [{{:keys [id]} :path-params
@@ -51,7 +50,7 @@
                               ids (l.auth/ids ::collection.s/collection-payload vis-payload)
                               all-ids (apply set/union (vals (dissoc ids :spec-valid?)))]
                           (if (p/optimistic-allow? auth-service all-ids)
-                            (collection/update (p/connection tenant-manager tenant) id body)
+                            (collection/update (p/connection tenant-manager tenant) id vis-payload)
                             (lib/not-authorized {:ids all-ids}))))}
          :delete {:parameters {:path-params {:id string?}}
                   :handler (fn [{tenant :tenant

--- a/backend/src/akvo/lumen/lib/auth.clj
+++ b/backend/src/akvo/lumen/lib/auth.clj
@@ -158,7 +158,11 @@
   (s/keys :req-un [::tenant-manager/tenant-manager
                    ::flow-api]))
 
-(defn ids [spec data]
+(defn ids
+  "returns `{:dataset-ids #{id...} :dashboard-ids #{id...} :visualisation-ids #{id...} :collection-ids #{id...}}` found in `data` arg. Logic based on clojure.spec/def `spec` 
+  
+   Based on dynamic thread binding."
+  [spec data]
   (let [ids               (atom {:dataset-ids       #{}
                                  :dashboard-ids     #{}
                                  :visualisation-ids #{}

--- a/backend/src/akvo/lumen/lib/auth.clj
+++ b/backend/src/akvo/lumen/lib/auth.clj
@@ -25,10 +25,11 @@
 (declare ids)
 
 (defrecord AuthServiceImpl [auth-datasets-set auth-visualisations-set auth-dashboards-set auth-collections-set]
-  p/AuthService
+  p/AuthService2080
   (optimistic-allow? [this ids]
     (set/subset? (set ids)
                  (set/union auth-datasets-set auth-visualisations-set auth-dashboards-set auth-collections-set)))
+  p/AuthService
   (allow? [this ids]
     (and (set/subset? (:visualisation-ids ids) auth-visualisations-set)
          (set/subset? (:dataset-ids ids) auth-datasets-set)

--- a/backend/src/akvo/lumen/lib/auth.clj
+++ b/backend/src/akvo/lumen/lib/auth.clj
@@ -207,6 +207,5 @@
               dataset.s/*id?*       ds-fun
               dashboard.s/*id?*     dash-fun
               collection.s/*id?*    col-fun]
-      (let [explain (s/explain-str spec data)]
-        (swap! ids assoc :spec-valid? (s/valid? spec data))
-        (deref ids)))))
+      (s/explain spec data)
+      (deref ids))))

--- a/backend/src/akvo/lumen/lib/auth.clj
+++ b/backend/src/akvo/lumen/lib/auth.clj
@@ -26,6 +26,9 @@
 
 (defrecord AuthServiceImpl [auth-datasets-set auth-visualisations-set auth-dashboards-set auth-collections-set]
   p/AuthService
+  (optimistic-allow? [this ids]
+    (set/subset? (set ids)
+                 (set/union auth-datasets-set auth-visualisations-set auth-dashboards-set auth-collections-set)))
   (allow? [this ids]
     (and (set/subset? (:visualisation-ids ids) auth-visualisations-set)
          (set/subset? (:dataset-ids ids) auth-datasets-set)

--- a/backend/src/akvo/lumen/lib/auth.clj
+++ b/backend/src/akvo/lumen/lib/auth.clj
@@ -27,7 +27,7 @@
 (defrecord AuthServiceImpl [auth-datasets-set auth-visualisations-set auth-dashboards-set auth-collections-set]
   p/AuthService2080
   (optimistic-allow? [this ids]
-    (set/subset? (set ids)
+    (set/subset? (set/union (:dataset-ids ids) (:visualisation-ids ids) (:dashboard-ids ids) (:collection-ids ids))
                  (set/union auth-datasets-set auth-visualisations-set auth-dashboards-set auth-collections-set)))
   p/AuthService
   (allow? [this ids]

--- a/backend/src/akvo/lumen/lib/auth.clj
+++ b/backend/src/akvo/lumen/lib/auth.clj
@@ -14,8 +14,7 @@
    [clojure.tools.logging :as log]
    [clojure.set :as set]
    [hugsql.core :as hugsql]
-   [integrant.core :as ig]
-   [reitit.core :as rc]))
+   [integrant.core :as ig]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/visualisation.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")

--- a/backend/src/akvo/lumen/lib/collection.clj
+++ b/backend/src/akvo/lumen/lib/collection.clj
@@ -51,7 +51,7 @@
 (defn unique-violation? [^SQLException e]
   (= (.getSQLState e) "23505"))
 
-(defn create [tenant-conn {:strs [title entities]}]
+(defn create [tenant-conn {:keys [title entities]}]
   (cond
     (empty? title) (lib/bad-request {:error "Title is missing"})
     (> (count title) 128) (lib/bad-request {:error "Title is too long"
@@ -73,7 +73,7 @@
 (defn update
   "Update a collection. Updates the title and all the entities"
   [tenant-conn id collection]
-  (let [{:strs [entities title]} collection]
+  (let [{:keys [entities title]} collection]
     (jdbc/with-db-transaction [tx-conn tenant-conn]
       (when title
         (update-collection-title tx-conn {:id id :title title}))

--- a/backend/src/akvo/lumen/protocols.clj
+++ b/backend/src/akvo/lumen/protocols.clj
@@ -102,5 +102,6 @@
   (auth
     [_ uuid-tree]
     [_ type* uuid])
-  (allow? [_ d]))
+  (allow? [_ d])
+  (optimistic-allow? [_ d]))
 

--- a/backend/src/akvo/lumen/protocols.clj
+++ b/backend/src/akvo/lumen/protocols.clj
@@ -102,6 +102,11 @@
   (auth
     [_ uuid-tree]
     [_ type* uuid])
-  (allow? [_ d])
-  (optimistic-allow? [_ d]))
+  (allow? [_ d]))
+
+(defprotocol AuthService2080
+  (optimistic-allow? [_ d]
+    "Provisional workaround for
+     https://github.com/akvo/akvo-lumen/issues/2080
+    'Refactor api/collections payload'"))
 

--- a/backend/test/akvo/lumen/endpoint/collection_test.clj
+++ b/backend/test/akvo/lumen/endpoint/collection_test.clj
@@ -44,54 +44,54 @@
         db2 (create-dashboard *tenant-conn*)]
     (testing "Create an empty collection"
       (let [[tag collection] (collection/create *tenant-conn*
-                                                {"title" "col1"})]
+                                                {:title "col1"})]
         (is (= ::lib/created tag))
         (is (= #{:id :title :modified :created :entities}
                (-> collection keys set)))
         (is (= ::lib/conflict
                (first (collection/create *tenant-conn*
-                                         {"title" "col1"}))))
+                                         {:title "col1"}))))
         (is (= ::lib/bad-request
                (first (collection/create *tenant-conn*
-                                         {"title" nil}))))
+                                         {:title nil}))))
         (is (= ::lib/bad-request
                (first (collection/create *tenant-conn*
-                                         {"title" (apply str (repeat 129 "a"))}))))))
+                                         {:title (apply str (repeat 129 "a"))}))))))
     (testing "Create a collection with entities"
-      (let [[tag collection] (collection/create *tenant-conn* {"title" "col2"
-                                                               "entities" [ds1 vs1 db1]})]
+      (let [[tag collection] (collection/create *tenant-conn* {:title "col2"
+                                                               :entities [ds1 vs1 db1]})]
         (is (= ::lib/created tag))
         (is (= #{ds1 vs1 db1} (-> collection :entities set)))))
 
     (testing "Fetch collection"
       (let [id (-> (collection/create *tenant-conn*
-                                      {"title" "col3" "entities" [ds2 vs2 db2]})
+                                      {:title "col3" :entities [ds2 vs2 db2]})
                    variant/value :id)
             coll (variant/value (collection/fetch *tenant-conn* id))]
         (is (= #{ds2 vs2 db2} (-> coll :entities set)))))
 
     (testing "Update collection"
-      (let [id (-> (collection/create *tenant-conn* {"title" "col4" "entities" [ds2 vs2 db2]})
+      (let [id (-> (collection/create *tenant-conn* {:title "col4" :entities [ds2 vs2 db2]})
                    variant/value :id)]
-        (let [coll (variant/value (collection/update *tenant-conn* id {"title" "col4 renamed"}))]
+        (let [coll (variant/value (collection/update *tenant-conn* id {:title "col4 renamed"}))]
           (is (= (:title coll) "col4 renamed"))
           (is (= (-> coll :entities set)
                  #{ds2 vs2 db2}))
-          (collection/update *tenant-conn* id {"entities" []})
+          (collection/update *tenant-conn* id {:entities []})
           (is (= [] (-> (collection/fetch *tenant-conn* id) variant/value :entities)))
-          (collection/update *tenant-conn* id {"entities" [ds1 vs1]})
+          (collection/update *tenant-conn* id {:entities [ds1 vs1]})
           (is (= #{ds1 vs1} (-> (collection/fetch *tenant-conn* id) variant/value :entities set)))
-          (collection/update *tenant-conn* id {"entities" [vs1 vs2]})
+          (collection/update *tenant-conn* id {:entities [vs1 vs2]})
           (is (= #{vs1 vs2} (-> (collection/fetch *tenant-conn* id) variant/value :entities set))))))
 
     (testing "Delete collection"
-      (let [id (-> (collection/create *tenant-conn* {"title" "col5"}) variant/value :id)]
+      (let [id (-> (collection/create *tenant-conn* {:title "col5"}) variant/value :id)]
         (collection/delete *tenant-conn* id)
         (is (= ::lib/not-found (variant/tag (collection/fetch *tenant-conn* id))))))
 
     (testing "Delete collection entities"
-      (let [id (-> (collection/create *tenant-conn* {"title" "col6"
-                                                     "entities" [ds1 ds2 vs1 vs2 db1 db2]})
+      (let [id (-> (collection/create *tenant-conn* {:title "col6"
+                                                     :entities [ds1 ds2 vs1 vs2 db1 db2]})
                    variant/value :id)]
         (dashboard/delete *tenant-conn* db1)
         (is (= #{ds1 ds2 vs1 vs2 db2}

--- a/backend/test/akvo/lumen/lib/auth_test.clj
+++ b/backend/test/akvo/lumen/lib/auth_test.clj
@@ -1,8 +1,9 @@
 (ns akvo.lumen.lib.auth-test
   (:require [akvo.lumen.lib.auth :as auth]
-            [akvo.lumen.specs.visualisation.maps]
-            [akvo.lumen.specs.visualisation]
+            [akvo.lumen.specs.visualisation.maps :as visualisation.maps.s]
+            [akvo.lumen.specs.visualisation :as visualisation.s]
             [clojure.set :as set]
+            [clojure.spec.alpha :as s]
             [clojure.test :refer :all]))
 
 (declare author)
@@ -10,87 +11,86 @@
 (deftest ids-test
   (let [ds-id "5ca70f7a-3c66-45ac-a546-820dd55e3916"
         v-id "5caaf957-e5eb-47be-a807-65697536fa7e"
-        spec-valid? true]
+        data {:name "jolin asdasd",
+              :visualisationType "pie",
+              :type "visualisation",
+              :created 1554708823102,
+              :modified 1554796491579,
+              :datasetId ds-id,
+              :author author,
+              :spec
+              {:sort nil,
+               :filters [],
+               :version 1,
+               :showLegend nil,
+               :legendTitle "Temperature",
+               :bucketColumn "c4"},
+              :status "OK",
+              :id v-id}]
     (is (= (auth/ids
-            :akvo.lumen.specs.visualisation/visualisation
-            {:name "jolin asdasd",
-             :visualisationType "pie",
-             :type "visualisation",
-             :created 1554708823102,
-             :modified 1554796491579,
-             :datasetId ds-id,
-             :author author, 
-             :spec
-             {:sort nil,
-              :filters [],
-              :version 1,
-              :showLegend nil,
-              :legendTitle "Temperature",
-              :bucketColumn "c4"},
-             :status "OK",
-             :id v-id})
-           {:dashboard-ids #{}, :collection-ids #{}, :dataset-ids #{ds-id}, :visualisation-ids #{v-id}, :spec-valid? spec-valid?})))
+            ::visualisation.s/visualisation
+            data)
+           {:dashboard-ids #{}, :collection-ids #{}, :dataset-ids #{ds-id}, :visualisation-ids #{v-id}}))
+    (is (s/valid? ::visualisation.s/visualisation data)))
   (let [ds-id "1"
-        spec-valid? false]
+        data [{:aggregationMethod "avg", :popup [], :filters [], :layerType "geo-location", :legend {:title "latitude", :visible true}, :rasterId nil, :pointSize 3, :pointColorMapping [], :longitude nil, :datasetId ds-id, :title "Untitled layer 1", :geom "d1", :pointColorColumn "c2", :latitude nil, :visible true}]]
     (is (= (auth/ids
-            :akvo.lumen.specs.visualisation.maps/layers
-            [{:aggregationMethod "avg", :popup [], :filters [], :layerType "geo-location", :legend {:title "latitude", :visible true}, :rasterId nil, :pointSize 3, :pointColorMapping [], :longitude nil, :datasetId ds-id, :title "Untitled layer 1", :geom "d1", :pointColorColumn "c2", :latitude nil, :visible true}])
-           {:collection-ids #{}, :dashboard-ids #{}, :dataset-ids #{ds-id}, :visualisation-ids #{}, :spec-valid? spec-valid?})))
+            ::visualisation.maps.s/layers
+            data)
+           {:collection-ids #{}, :dashboard-ids #{}, :dataset-ids #{ds-id}, :visualisation-ids #{}}))
+    (is (not (s/valid? ::visualisation.maps.s/layers data))))
   (let [ds-id "5cac541e-ba6c-4c78-969a-c55d624fc5ba"
-        spec-valid? true]
-    (is (= (auth/ids
-            :akvo.lumen.specs.visualisation.maps/layers 
-            [{:aggregationMethod "avg",
-              :popup [],
-              :filters [],
-              :layerType "geo-location",
-              :legend {:title "latitude", :visible true},
-              :rasterId nil,
-              :pointSize 3,
-              :pointColorMapping [],
-              :longitude nil,
-              :datasetId ds-id,
-              :title "go1",
-              :geom "d1",
-              :pointColorColumn "c2",
-              :latitude nil,
-              :visible true}
-             {:aggregationMethod "avg",
-              :popup [],
-              :filters [],
-              :layerType "raster",
-              :legend {:title nil, :visible true},
-              :rasterId "5cac54fa-d93a-45d3-be6c-356f85559a9d",
-              :pointSize 3,
-              :pointColorMapping [],
-              :longitude nil,
-              :datasetId nil,
-              :title "Untitled layer 2",
-              :geom nil,
-              :pointColorColumn nil,
-              :latitude nil,
-              :visible true}
-             {:aggregationMethod "avg",
-              :popup [{:column "c2"}],
-              :filters [],
-              :layerType "geo-location",
-              :legend {:title "latitude", :visible true},
-              :rasterId nil,
-              :pointSize 3,
-              :pointColorMapping [],
-              :longitude nil,
-              :datasetId ds-id,
-              :title "Untitled layer 3",
-              :geom "d1",
-              :pointColorColumn "c2",
-              :latitude nil,
-              :visible true}])
+        data [{:aggregationMethod "avg",
+               :popup [],
+               :filters [],
+               :layerType "geo-location",
+               :legend {:title "latitude", :visible true},
+               :rasterId nil,
+               :pointSize 3,
+               :pointColorMapping [],
+               :longitude nil,
+               :datasetId ds-id,
+               :title "go1",
+               :geom "d1",
+               :pointColorColumn "c2",
+               :latitude nil,
+               :visible true}
+              {:aggregationMethod "avg",
+               :popup [],
+               :filters [],
+               :layerType "raster",
+               :legend {:title nil, :visible true},
+               :rasterId "5cac54fa-d93a-45d3-be6c-356f85559a9d",
+               :pointSize 3,
+               :pointColorMapping [],
+               :longitude nil,
+               :datasetId nil,
+               :title "Untitled layer 2",
+               :geom nil,
+               :pointColorColumn nil,
+               :latitude nil,
+               :visible true}
+              {:aggregationMethod "avg",
+               :popup [{:column "c2"}],
+               :filters [],
+               :layerType "geo-location",
+               :legend {:title "latitude", :visible true},
+               :rasterId nil,
+               :pointSize 3,
+               :pointColorMapping [],
+               :longitude nil,
+               :datasetId ds-id,
+               :title "Untitled layer 3",
+               :geom "d1",
+               :pointColorColumn "c2",
+               :latitude nil,
+               :visible true}]]
+    (is (= (auth/ids ::visualisation.maps.s/layers data)
            {:dataset-ids #{ds-id},
             :dashboard-ids #{}
             :visualisation-ids #{},
-            :collection-ids #{},
-            :spec-valid? spec-valid?}))))
-
+            :collection-ids #{}}))
+    (is (s/valid? ::visualisation.maps.s/layers data))))
 
 (def author {:given_name "Jerome$auth$",
              :email "jerome@t1.lumen.localhost",


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Add protocol provisional workaround that only ensure uuid but not [uuid collection-type] relation. 
Depends on #2080 

```clojure
(defprotocol AuthService2080
  (optimistic-allow? [_ d]
    "Provisional workaround for
     https://github.com/akvo/akvo-lumen/issues/2080
    'Refactor api/collections payload'"))
```