### PR TITLE
[#1949] Auth visualisation map type payloads 

### DIFF
--- a/backend/specs/akvo/lumen/specs/visualisation.clj
+++ b/backend/specs/akvo/lumen/specs/visualisation.clj
@@ -103,8 +103,15 @@
 (defmethod vis "bubble"  [_]
   (s/merge ::base-viz #_(s/keys :req-un [::area.s/spec])))
 
+(create-ns  'akvo.lumen.specs.visualisation.map)
+(alias 'map.s 'akvo.lumen.specs.visualisation.map)
+
+(s/def ::map.s/baseLayer #{"street" "satellite" "terrain"})
+
+(s/def ::map.s/spec (s/keys :req-un [::version ::map.s/baseLayer ::visualisation.maps.s/layers]))
+
 (defmethod vis "map"  [_]
-  (s/merge ::base-viz #_(s/keys :req-un [::area.s/spec])))
+  (s/merge ::base-viz (s/keys :req-un [::map.s/spec])) )
 
 (s/fdef visualisation/create
   :args (s/cat

--- a/backend/specs/akvo/lumen/specs/visualisation.clj
+++ b/backend/specs/akvo/lumen/specs/visualisation.clj
@@ -113,14 +113,14 @@
 (defmethod vis "map"  [_]
   (s/merge ::base-viz (s/keys :req-un [::map.s/spec])) )
 
-(s/fdef visualisation/create
+#_(s/fdef visualisation/create
   :args (s/cat
          :db-conn ::db.s/tenant-connection
 	 :body ::visualisation
 	 :jwt-claims map?)
   :ret any?)
 
-(s/fdef visualisation/upsert
+#_(s/fdef visualisation/upsert
   :args (s/cat
          :db-conn ::db.s/tenant-connection
 	 :body ::visualisation

--- a/backend/specs/akvo/lumen/specs/visualisation.clj
+++ b/backend/specs/akvo/lumen/specs/visualisation.clj
@@ -2,20 +2,21 @@
   (:require [akvo.lumen.lib.aggregation :as aggregation]
             [akvo.lumen.lib.aggregation.bar :as aggregation.bar]
             [akvo.lumen.lib.aggregation.bubble :as aggregation.bubble]
-            [akvo.lumen.specs.protocols :as protocols.s]
-            [clojure.tools.logging :as log]
             [akvo.lumen.lib.aggregation.line :as aggregation.line]
             [akvo.lumen.lib.aggregation.pie :as aggregation.pie]
             [akvo.lumen.lib.aggregation.pivot :as aggregation.pivot]
             [akvo.lumen.lib.aggregation.scatter :as aggregation.scatter]
+            [akvo.lumen.lib.visualisation :as visualisation]
             [akvo.lumen.postgres.filter :as postgres.filter]
-            [akvo.lumen.specs.db :as db.s]
             [akvo.lumen.specs :as lumen.s]
             [akvo.lumen.specs.aggregation :as aggregation.s]
+            [akvo.lumen.specs.db :as db.s]
             [akvo.lumen.specs.db.dataset-version :as db.dsv.s]
             [akvo.lumen.specs.db.dataset-version.column :as db.dsv.column.s]
-            [akvo.lumen.lib.visualisation :as visualisation]
-            [clojure.spec.alpha :as s]))
+            [akvo.lumen.specs.protocols :as protocols.s]
+            [akvo.lumen.specs.visualisation.maps :as visualisation.maps.s]
+            [clojure.spec.alpha :as s]
+            [clojure.tools.logging :as log]))
 
 (s/def ::name string?)
 (s/def ::visualisationType #{"pie" "area" "bar" "line" "polararea" "donut" "pivot table" "scatter" "bubble" "map"})

--- a/backend/specs/akvo/lumen/specs/visualisation/maps.clj
+++ b/backend/specs/akvo/lumen/specs/visualisation/maps.clj
@@ -46,7 +46,7 @@
 (s/def ::layer (s/multi-spec layer-type :layerType))
 (s/def ::layers (s/coll-of ::layer :kind vector? :distinct true))
 
-(s/fdef lib.vis.maps/create
+#_(s/fdef lib.vis.maps/create
   :args (s/cat
          :db-conn ::db.s/tenant-connection
 	 :windshaft-url string?

--- a/backend/specs/akvo/lumen/specs/visualisation/maps/layer.clj
+++ b/backend/specs/akvo/lumen/specs/visualisation/maps/layer.clj
@@ -2,6 +2,7 @@
   (:require [akvo.lumen.specs :as lumen.s]
             [akvo.lumen.specs.db.dataset-version :as db.dataset-version.s]
             [akvo.lumen.specs.db.dataset-version.column :as db.dsv.column.s]
+            [akvo.lumen.specs.dataset :as dataset.s]
             [clojure.spec.alpha :as s]
             [clojure.string :as str])
   (:import [java.awt Color]))
@@ -59,7 +60,7 @@
 
 (s/def ::pointColorColumn (s/nilable ::db.dsv.column.s/columnName))
 
-(s/def ::datasetId ::db.dataset-version.s/dataset-id)
+(s/def ::datasetId ::dataset.s/id)
 
 (s/def ::rasterId  (s/with-gen
                      lumen.s/str-uuid?

--- a/backend/specs/akvo/lumen/specs/visualisation/maps/layer.clj
+++ b/backend/specs/akvo/lumen/specs/visualisation/maps/layer.clj
@@ -31,7 +31,10 @@
 (defn string-pos-int? [s] (try (pos-int? (Integer/parseInt s))
                           (catch Exception e false)))
 
-(s/def ::pointSize  (s/or :s string-pos-int? :i pos-int?)) ;; only in geo-location we receive a string :!
+(s/def ::pointSize  (s/with-gen
+                      (s/or :s string-pos-int? :i pos-int?)
+                      #(s/gen #{"1" 1 "2" 2})
+                      )) ;; only in geo-location we receive a string :!
 
 (create-ns  'akvo.lumen.specs.visualisation.maps.layer.point-color-mapping)
 (alias 'layer.point-color-mapping.s 'akvo.lumen.specs.visualisation.maps.layer.point-color-mapping)
@@ -44,7 +47,9 @@
                        (Color/decode s)
                        (catch Exception e false)))
 
-(s/def ::layer.point-color-mapping.s/color valid-hex?)
+(s/def ::layer.point-color-mapping.s/color (s/with-gen
+                                             valid-hex?
+                                             #(s/gen #{"000" "256256256" "101010"})))
 
 (s/def ::point-color-mapping-item (s/keys :req-un [::layer.point-color-mapping.s/op
                                                    ::layer.point-color-mapping.s/value

--- a/backend/src/akvo/lumen/lib/auth.clj
+++ b/backend/src/akvo/lumen/lib/auth.clj
@@ -212,5 +212,5 @@
               dataset.s/*id?*       ds-fun
               dashboard.s/*id?*     dash-fun
               collection.s/*id?*    col-fun]
-      (s/explain spec data)
+      (s/explain-data spec data)
       (deref ids))))


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

`PUT /api/visualisations/:id` and `POST /api/visualisations` can have more than one dataset-id attached if visualisation type is `map` type.

So, with these changes we ensure that user is allowed to use those dataset-ids 

payload example:
```clojure
{:name "my vis name",
        :visualisationType "map",
        :type "visualisation",
        :created 1555933154021,
        :modified 1555933154021,
        :datasetId nil,
        :spec
        {:version 1,
         :baseLayer "street",
         :layers [{:aggregationMethod "avg",
                   :popup [],
                   :filters [],
                   :layerType "geo-location",
                   :legend {:title "latitude", :visible true},
                   :rasterId nil,
                   :pointSize 3,
                   :pointColorMapping [],
                   :longitude nil,
                   :datasetId "5cbd79a7-ba3b-4443-8433-2d14639dd269",
                   :title "Untitled layer 1",
                   :geom "d1",
                   :pointColorColumn "c2",
                   :latitude nil,
                   :visible true}]},
        :status "OK",
        :id "5cbda7e2-ff60-4ab8-87b3-34d60b6f4687"}
```

