### PR TITLE
Visualisation get split for dashboard pdf exports #1740

### DIFF
--- a/client/src/actions/dashboard.js
+++ b/client/src/actions/dashboard.js
@@ -174,7 +174,7 @@ export function exportDashboard(dashboard, options) {
 
     if (dashboard.id === null) throw new Error('dashboard.id not set');
 
-    const target = `${window.location.origin}/dashboard/${dashboard.id}/export`;
+    const target = `${window.location.origin}/dashboard/${dashboard.id}/export${format === 'pdf' ? '_pages' : ''}`;
 
     return api
       .post('/api/exports', {

--- a/client/src/components/dashboard/DashboardCanvasItem.jsx
+++ b/client/src/components/dashboard/DashboardCanvasItem.jsx
@@ -7,6 +7,7 @@ import DashboardCanvasItemEditable from './DashboardCanvasItemEditable';
 import { checkUndefined } from '../../utilities/utils';
 import LoadingSpinner from '../../components/common/LoadingSpinner';
 import { getTitle, getDataLastUpdated } from '../../utilities/chart';
+import { ROW_COUNT } from './DashboardEditor';
 
 require('./DashboardCanvasItem.scss');
 
@@ -88,7 +89,7 @@ export default class DashboardCanvasItem extends Component {
     if (layout !== null) {
       return ({
         width: (layout.w * unit) - 60,
-        height: (layout.h * unit) - 60,
+        height: (layout.h * this.props.rowHeight) - 60,
       });
     }
 
@@ -118,13 +119,20 @@ export default class DashboardCanvasItem extends Component {
       this.titleEl.getBoundingClientRect().height :
       TITLE_HEIGHT;
 
-    const { item, exporting } = this.props;
+    const { item, exporting, canvasLayout } = this.props;
+    let marginTop = 0;
+
+    if (exporting) {
+      const layoutItem = canvasLayout.filter(({ i }) => i === item.id)[0];
+      marginTop = layoutItem.y >= ROW_COUNT ? -40 : 10;
+    }
 
     return (
       <div
         data-test-id="dashboard-canvas-item"
         className="DashboardCanvasItem"
         ref={(c) => { this.el = c; }}
+        style={{ marginTop }}
       >
         {item.type === 'visualisation' && (
           <div className="itemContainerWrap">
@@ -186,6 +194,7 @@ DashboardCanvasItem.propTypes = {
   canvasLayout: PropTypes.array.isRequired,
   item: PropTypes.object.isRequired,
   canvasWidth: PropTypes.number.isRequired,
+  rowHeight: PropTypes.number.isRequired,
   datasets: PropTypes.object.isRequired,
   metadata: PropTypes.object,
   onEntityUpdate: PropTypes.func.isRequired,

--- a/client/src/components/dashboard/DashboardEditor.jsx
+++ b/client/src/components/dashboard/DashboardEditor.jsx
@@ -148,9 +148,9 @@ export default class DashboardEditor extends Component {
   }
 
   getLayout() {
-    const { exporting } = this.props;
+    const { exporting, preventPageOverlaps } = this.props;
     const { propLayout } = this.state;
-    return exporting ?
+    return (exporting && preventPageOverlaps) ?
       groupIntoPages()(propLayout) :
       propLayout;
   }
@@ -385,4 +385,10 @@ DashboardEditor.propTypes = {
   onUpdateName: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
   exporting: PropTypes.bool,
+  preventPageOverlaps: PropTypes.bool,
+};
+
+DashboardEditor.defaultProps = {
+  exporting: false,
+  preventPageOverlaps: false,
 };

--- a/client/src/components/dashboard/DashboardEditor.jsx
+++ b/client/src/components/dashboard/DashboardEditor.jsx
@@ -6,10 +6,15 @@ import { Element, scroller } from 'react-scroll';
 
 import DashboardVisualisationList from './DashboardVisualisationList';
 import DashboardCanvasItem from './DashboardCanvasItem';
+import { groupIntoPages } from '../../utilities/dashboard';
+import { A4 } from '../../constants/print';
 
 require('./DashboardEditor.scss');
 require('../../../node_modules/react-grid-layout/css/styles.css');
 require('../../../node_modules/react-resizable/css/styles.css');
+
+export const ROW_COUNT = 16;
+const COL_COUNT = 12;
 
 const getArrayFromObject = object => Object.keys(object).map(key => object[key]);
 
@@ -142,6 +147,33 @@ export default class DashboardEditor extends Component {
     }
   }
 
+  getLayout() {
+    const { exporting } = this.props;
+    const { propLayout } = this.state;
+    return exporting ?
+      groupIntoPages()(propLayout) :
+      propLayout;
+  }
+
+  getRowHeight() {
+    const canvasWidth = this.state.gridWidth;
+    const canvasHeight = (canvasWidth * (A4.height / A4.width)) + 46;
+    const rowHeight = canvasHeight / ROW_COUNT;
+    return rowHeight;
+  }
+
+  focusTextItem(id) {
+    setTimeout(() => {
+      const canvasItem = this.canvasElements[id];
+      if (!canvasItem) return;
+      const el = canvasItem.getElement();
+      if (!el) return;
+      const textarea = el.querySelector('textarea');
+      if (!textarea) return;
+      textarea.focus();
+    }, 1000);
+  }
+
   handleLayoutChange(layout) {
     this.props.onUpdateLayout(layout);
   }
@@ -206,18 +238,6 @@ export default class DashboardEditor extends Component {
     this.props.onUpdateEntities(newEntities);
   }
 
-  focusTextItem(id) {
-    setTimeout(() => {
-      const canvasItem = this.canvasElements[id];
-      if (!canvasItem) return;
-      const el = canvasItem.getElement();
-      if (!el) return;
-      const textarea = el.querySelector('textarea');
-      if (!textarea) return;
-      textarea.focus();
-    }, 1000);
-  }
-
   handleResize() {
     // Offset the padding width (16px on each side)
     const newWidth = this.DashboardEditorCanvasContainer.clientWidth - 32;
@@ -251,7 +271,8 @@ export default class DashboardEditor extends Component {
   render() {
     const { dashboard, datasets, exporting } = this.props;
     const canvasWidth = this.state.gridWidth;
-    const rowHeight = canvasWidth / 12;
+    const rowHeight = this.getRowHeight();
+    const layout = this.getLayout();
 
     return (
       <div
@@ -288,11 +309,11 @@ export default class DashboardEditor extends Component {
           <div className="DashboardEditorCanvas">
             <ReactGridLayout
               className="layout"
-              cols={12}
+              cols={COL_COUNT}
               rowHeight={rowHeight}
               width={canvasWidth}
-              verticalCompact
-              layout={this.state.propLayout}
+              verticalCompact={!exporting}
+              layout={layout}
               onLayoutChange={this.handleLayoutChange}
               isDraggable={!this.state.focusedItem}
               isResizable={!this.state.focusedItem}
@@ -324,6 +345,7 @@ export default class DashboardEditor extends Component {
                     metadata={this.props.metadata}
                     canvasLayout={dashboard.layout}
                     canvasWidth={canvasWidth}
+                    rowHeight={rowHeight}
                     onDeleteClick={this.handleEntityToggle}
                     onSave={this.props.onSave}
                     onEntityUpdate={this.handleEntityUpdate}

--- a/client/src/components/dashboard/DashboardEditor.scss
+++ b/client/src/components/dashboard/DashboardEditor.scss
@@ -109,6 +109,22 @@
         .DashboardEditorCanvasContainer {
             height: auto;
         }
+
+        .DashboardEditorCanvas {
+            background-color: white;
+        }
+
+        .DashboardCanvasItem {
+            border: 1px solid $midLightGrey;
+
+            .deleteButton {
+                display: none;
+            }
+        }
+
+        .react-resizable-handle {
+            display: none;
+        }
     }
 }
 

--- a/client/src/containers/App.jsx
+++ b/client/src/containers/App.jsx
@@ -13,7 +13,7 @@ import Resources from '../components/Resources';
 import Main from './Main';
 import WorkspaceNav from '../components/WorkspaceNav';
 import AdminNav from '../components/AdminNav';
-import withExport from '../utilities/withExport';
+import withProps from '../utilities/withProps';
 
 export default function App({ history, location }) {
   return (
@@ -53,7 +53,7 @@ export default function App({ history, location }) {
           />
           <Route
             path="visualisation/:visualisationId/export"
-            components={{ sidebar: WorkspaceNav, content: withExport(Visualisation) }}
+            components={{ sidebar: WorkspaceNav, content: withProps(Visualisation, { exporting: true }) }}
             location={location}
           />
           <Route
@@ -67,8 +67,16 @@ export default function App({ history, location }) {
             location={location}
           />
           <Route
+            path="dashboard/:dashboardId/export_pages"
+            components={{
+              sidebar: WorkspaceNav,
+              content: withProps(Dashboard, { exporting: true, preventPageOverlaps: true }),
+            }}
+            location={location}
+          />
+          <Route
             path="dashboard/:dashboardId/export"
-            components={{ sidebar: WorkspaceNav, content: withExport(Dashboard) }}
+            components={{ sidebar: WorkspaceNav, content: withProps(Dashboard, { exporting: true }) }}
             location={location}
           />
           <Route

--- a/client/src/containers/App.jsx
+++ b/client/src/containers/App.jsx
@@ -53,7 +53,10 @@ export default function App({ history, location }) {
           />
           <Route
             path="visualisation/:visualisationId/export"
-            components={{ sidebar: WorkspaceNav, content: withProps(Visualisation, { exporting: true }) }}
+            components={{
+              sidebar: WorkspaceNav,
+              content: withProps(Visualisation, { exporting: true }),
+            }}
             location={location}
           />
           <Route
@@ -76,7 +79,10 @@ export default function App({ history, location }) {
           />
           <Route
             path="dashboard/:dashboardId/export"
-            components={{ sidebar: WorkspaceNav, content: withProps(Dashboard, { exporting: true }) }}
+            components={{
+              sidebar: WorkspaceNav,
+              content: withProps(Dashboard, { exporting: true }),
+            }}
             location={location}
           />
           <Route

--- a/client/src/containers/Dashboard.jsx
+++ b/client/src/containers/Dashboard.jsx
@@ -573,6 +573,7 @@ class Dashboard extends Component {
               onUpdateName={this.onUpdateName}
               print={this.props.print}
               exporting={exporting}
+              preventPageOverlaps={this.props.preventPageOverlaps}
             />
             {!exporting && (
               <ShareEntity
@@ -603,6 +604,7 @@ Dashboard.propTypes = {
   location: PropTypes.object.isRequired,
   params: PropTypes.object,
   exporting: PropTypes.bool,
+  preventPageOverlaps: PropTypes.bool,
   print: printShape,
 };
 

--- a/client/src/containers/Dashboard.scss
+++ b/client/src/containers/Dashboard.scss
@@ -1,4 +1,7 @@
+@import "../styles/modules/importAll";
+
 .export-header {
     padding: 10px 30px;
     font-size: 2em;
+    border-bottom: 1px solid $midLightGrey;
   }

--- a/client/src/utilities/dashboard.js
+++ b/client/src/utilities/dashboard.js
@@ -1,0 +1,91 @@
+import { sortBy } from 'lodash';
+
+export const ROWS_PER_PAGE = 16;
+const LENGTH_DIMENSION = {
+  x: 'w',
+  y: 'h',
+};
+
+const sort = items => sortBy(items, [
+  ({ y, h }) => y + h,
+  'x',
+]);
+
+export const isOverlappingInAxis = (axisKey, unsortedA, unsortedB) => {
+  const [a, b] = sortBy([unsortedA, unsortedB], axisKey);
+  const a2 = a[axisKey] + a[LENGTH_DIMENSION[axisKey]];
+  const b2 = b[axisKey] + b[LENGTH_DIMENSION[axisKey]];
+  if (a[axisKey] <= b2 && a2 > b[axisKey]) {
+    return true;
+  }
+  return false;
+};
+
+export const isColliding = (a, b) =>
+  isOverlappingInAxis('x', a, b) &&
+  isOverlappingInAxis('y', a, b);
+
+export const getCollidedItems = items =>
+  items.filter((item, i) =>
+    isColliding(item, items[i - 1] || {})
+  );
+
+export const getDiffYToAvoidCollision = (items, item) =>
+  items.reduce((maxOverlap, { index, h, y }) => (
+    (item.index === index || y > item.y) ?
+      maxOverlap :
+      Math.max(maxOverlap, (y + h) - item.y)
+  ), 0);
+
+export const moveCollidedItems = (items) => {
+  let sortedItems = sort(items).slice().map((item, index) => ({ ...item, index }));
+  const collidedItems = getCollidedItems(sortedItems);
+  if (collidedItems.length) {
+    collidedItems.forEach((collidedItem) => {
+      const diffY = getDiffYToAvoidCollision(sortedItems, collidedItem);
+      sortedItems[collidedItem.index].y += diffY; // eslint-disable-line no-param-reassign
+    });
+    sortedItems = moveCollidedItems(sortedItems);
+  }
+  return sortedItems
+    .map(({ index, ...rest }) => ({ ...rest })); // eslint-disable-line no-unused-vars
+};
+
+export const tryFitToPage = (item, pageIndex) => {
+  const pageStart = pageIndex * ROWS_PER_PAGE;
+  const pageEnd = (pageStart + ROWS_PER_PAGE) - 1;
+  return item.y <= pageEnd && (item.y + item.h <= pageEnd || item.h > ROWS_PER_PAGE);
+};
+
+export const groupIntoPages = (pages = []) => (items, pageIndex = 0) => {
+  const rowsOffset = (pageIndex ? ROWS_PER_PAGE : ROWS_PER_PAGE - 1) * pageIndex;
+  let sortedItems = moveCollidedItems(sort(items));
+  const itemsFromPreviousPage = sortedItems.filter(({ y }) => y < rowsOffset);
+
+  itemsFromPreviousPage.forEach((itemFromPreviousPage) => {
+    itemFromPreviousPage.y = rowsOffset; // eslint-disable-line no-param-reassign
+  });
+
+  const tryAddNextItemToPage = () => {
+    sortedItems = moveCollidedItems(sort(sortedItems));
+    return sortedItems.length && tryFitToPage(sortedItems[0], pageIndex);
+  };
+
+  const page = [];
+  while (tryAddNextItemToPage()) {
+    page.push(sortedItems.shift());
+  }
+
+  const result = pages.slice();
+
+  result.push(page);
+
+  return sortBy(
+      (
+      sortedItems.length ?
+        groupIntoPages(result)(sortedItems, pageIndex + 1) :
+        result
+    ).reduce((acc, resultPage) => acc.concat(resultPage), []),
+    ['y', 'x']
+  );
+};

--- a/client/src/utilities/withExport.jsx
+++ b/client/src/utilities/withExport.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default WrappedComponent => props => (
-  <WrappedComponent exporting {...props} />
-);

--- a/client/src/utilities/withProps.jsx
+++ b/client/src/utilities/withProps.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default (WrappedComponent, withProps) => props => (
+  <WrappedComponent {...withProps} {...props} />
+);

--- a/client/test/utilities/dashboard.js
+++ b/client/test/utilities/dashboard.js
@@ -8,9 +8,21 @@ import {
   tryFitToPage,
   groupIntoPages,
   ROWS_PER_PAGE,
+  isOverlappingInAxis,
 } from '../../src/utilities/dashboard';
 
 describe('Utility: Dashboard', () => {
+  describe('isOverlappingInAxis()', () => {
+    it('from top', () => {
+      const result = isOverlappingInAxis(
+        'y',
+        { y: 1, h: 2, index: 0 },
+        { y: 2, h: 2, index: 1 }
+      );
+      assert(result);
+    });
+  });
+
   describe('isColliding()', () => {
 
     it('from left', () => {
@@ -45,6 +57,13 @@ describe('Utility: Dashboard', () => {
       assert.equal(result, false);
     });
 
+    it('from top', () => {
+      const result = isColliding(
+        { y: 1, h: 2, x: 0, w: 2, index: 0 },
+        { y: 2, h: 2, x: 0, w: 2, index: 1 }
+      );
+      assert(result);
+    });
   });
 
   it('getCollidedItems()', () => {
@@ -68,24 +87,24 @@ describe('Utility: Dashboard', () => {
   describe('getDiffYToAvoidCollision()', () => {
     it('below', () => {
       const result = getDiffYToAvoidCollision(
-        [{ y: 1, h: 2, index: 0 }],
-        { y: 2, h: 2, index: 1 }
+        [{ y: 1, h: 2, x: 0, w: 2, index: 0 }],
+        { y: 2, h: 2, x: 0, w: 2, index: 1 }
       );
       assert.equal(result, 1);
     });
 
     it('inside', () => {
       const result = getDiffYToAvoidCollision(
-        [{ y: 1, h: 4, index: 0 }],
-        { y: 2, h: 2, index: 1 }
+        [{ y: 1, h: 4, x: 0, w: 2, index: 0 }],
+        { y: 2, h: 2, x: 0, w: 2, index: 1 }
       );
       assert.equal(result, 3);
     });
 
     it('above', () => {
       const result = getDiffYToAvoidCollision(
-        [{ y: 4, h: 4, index: 0 }],
-        { y: 2, h: 3, index: 1 }
+        [{ y: 4, h: 4, x: 0, w: 2, index: 0 }],
+        { y: 2, h: 3, x: 0, w: 2, index: 1 }
       );
       assert.equal(result, 6);
     });
@@ -103,12 +122,26 @@ describe('Utility: Dashboard', () => {
         [
           { x: 0, y: 1, h: 4, w: 2, index: 0 },
           { x: 0, y: 2, h: 4, w: 2, index: 1 },
-          { x: 0, y: 4, h: 4, w: 2 },
+          { x: 0, y: 7, h: 4, w: 2, index: 2 },
         ],
         { x: 0, y: 2, h: 4, w: 2, index: 1 }
       );
       assert.equal(result, 3);
     });
+
+    it('special 1', () => {
+      const result = getDiffYToAvoidCollision(
+        [
+          { x: 0, y: 1, h: 4, w: 2, index: 0 },
+          { x: 0, y: 2, h: 4, w: 2, index: 1 },
+          { x: 0, y: 4, h: 4, w: 2, index: 2 },
+          { x: 0, y: 4, h: 4, w: 2, index: 3 },
+        ],
+        { x: 0, y: 2, h: 4, w: 2, index: 1 }
+      );
+      assert.equal(result, 3);
+    });
+
   });
 
   describe('moveCollidedItems()', () => {
@@ -137,7 +170,7 @@ describe('Utility: Dashboard', () => {
     });
 
     it('fits 2', () => {
-      const result = tryFitToPage({ x: 0, y: ROWS_PER_PAGE - 2, h: 2, w: 2 }, 0);
+      const result = tryFitToPage({ x: 0, y: ROWS_PER_PAGE - 3, h: 2, w: 2 }, 0);
       assert(result);
     });
 
@@ -167,7 +200,7 @@ describe('Utility: Dashboard', () => {
     });
 
     it('fits 8', () => {
-      const result = tryFitToPage({ x: 4, y: 11, h: 5, w: 4 }, 0);
+      const result = tryFitToPage({ x: 4, y: 10, h: 5, w: 4 }, 0);
       assert(result);
     });
 

--- a/client/test/utilities/dashboard.js
+++ b/client/test/utilities/dashboard.js
@@ -1,0 +1,221 @@
+/* eslint-disable padded-blocks */
+import assert from 'assert';
+import {
+  isColliding,
+  getCollidedItems,
+  getDiffYToAvoidCollision,
+  moveCollidedItems,
+  tryFitToPage,
+  groupIntoPages,
+  ROWS_PER_PAGE,
+} from '../../src/utilities/dashboard';
+
+describe('Utility: Dashboard', () => {
+  describe('isColliding()', () => {
+
+    it('from left', () => {
+      const result = isColliding(
+        { x: 0, y: 0, h: 2, w: 2 },
+        { x: 1, y: 0, h: 2, w: 2 }
+      );
+      assert(result);
+    });
+
+    it('from right', () => {
+      const result = isColliding(
+        { x: 10, y: 0, h: 2, w: 2 },
+        { x: 9, y: 0, h: 2, w: 2 }
+      );
+      assert(result);
+    });
+
+    it('no collision', () => {
+      const result = isColliding(
+        { x: 10, y: 0, h: 2, w: 2 },
+        { x: 5, y: 0, h: 2, w: 2 }
+      );
+      assert.equal(result, false);
+    });
+
+    it('no collision', () => {
+      const result = isColliding(
+        { x: 0, y: 1, h: 2, w: 2 },
+        { x: 0, y: 3, h: 2, w: 2 }
+      );
+      assert.equal(result, false);
+    });
+
+  });
+
+  it('getCollidedItems()', () => {
+    const result = getCollidedItems([
+      { x: 0, y: 1, h: 2, w: 2 },
+      { x: 0, y: 2, h: 2, w: 2 },
+      { x: 0, y: 3, h: 2, w: 2 },
+      { x: 0, y: 4, h: 2, w: 2 },
+      { x: 0, y: 5, h: 2, w: 2 },
+      { x: 0, y: 6, h: 2, w: 2 },
+    ]);
+    assert.deepEqual(result, [
+      { x: 0, y: 2, h: 2, w: 2 },
+      { x: 0, y: 3, h: 2, w: 2 },
+      { x: 0, y: 4, h: 2, w: 2 },
+      { x: 0, y: 5, h: 2, w: 2 },
+      { x: 0, y: 6, h: 2, w: 2 },
+    ]);
+  });
+
+  describe('getDiffYToAvoidCollision()', () => {
+    it('below', () => {
+      const result = getDiffYToAvoidCollision(
+        [{ y: 1, h: 2, index: 0 }],
+        { y: 2, h: 2, index: 1 }
+      );
+      assert.equal(result, 1);
+    });
+
+    it('inside', () => {
+      const result = getDiffYToAvoidCollision(
+        [{ y: 1, h: 4, index: 0 }],
+        { y: 2, h: 2, index: 1 }
+      );
+      assert.equal(result, 3);
+    });
+
+    it('above', () => {
+      const result = getDiffYToAvoidCollision(
+        [{ y: 4, h: 4, index: 0 }],
+        { y: 2, h: 3, index: 1 }
+      );
+      assert.equal(result, 6);
+    });
+
+    it('below 2', () => {
+      const result = getDiffYToAvoidCollision(
+        [{ x: 0, y: 1, h: 2, w: 2, index: 0 }],
+        { x: 0, y: 2, h: 2, w: 2, index: 1 }
+      );
+      assert.equal(result, 1);
+    });
+
+    it('below 3', () => {
+      const result = getDiffYToAvoidCollision(
+        [
+          { x: 0, y: 1, h: 4, w: 2, index: 0 },
+          { x: 0, y: 2, h: 4, w: 2, index: 1 },
+          { x: 0, y: 4, h: 4, w: 2 },
+        ],
+        { x: 0, y: 2, h: 4, w: 2, index: 1 }
+      );
+      assert.equal(result, 3);
+    });
+  });
+
+  describe('moveCollidedItems()', () => {
+    const result = moveCollidedItems([
+      { x: 0, y: 1, h: 2, w: 2 },
+      { x: 0, y: 2, h: 2, w: 2 },
+      { x: 0, y: 4, h: 2, w: 2 },
+      { x: 0, y: 4, h: 2, w: 2 },
+      { x: 0, y: 5, h: 2, w: 2 },
+      { x: 0, y: 6, h: 2, w: 2 },
+    ]);
+    assert.deepStrictEqual(result, [
+      { x: 0, y: 1, h: 2, w: 2 },
+      { x: 0, y: 3, h: 2, w: 2 },
+      { x: 0, y: 5, h: 2, w: 2 },
+      { x: 0, y: 7, h: 2, w: 2 },
+      { x: 0, y: 9, h: 2, w: 2 },
+      { x: 0, y: 11, h: 2, w: 2 },
+    ]);
+  });
+
+  describe('tryFitToPage()', () => {
+    it('fits 1', () => {
+      const result = tryFitToPage({ x: 0, y: 0, h: 2, w: 2 }, 0);
+      assert(result);
+    });
+
+    it('fits 2', () => {
+      const result = tryFitToPage({ x: 0, y: ROWS_PER_PAGE - 2, h: 2, w: 2 }, 0);
+      assert(result);
+    });
+
+    it('fits 3', () => {
+      const result = tryFitToPage({ x: 0, y: 0, h: ROWS_PER_PAGE, w: 2 }, 0);
+      assert(result);
+    });
+
+    it('fits 4', () => {
+      const result = tryFitToPage({ x: 0, y: ROWS_PER_PAGE, h: 2, w: 2 }, 1);
+      assert(result);
+    });
+
+    it('fits 5', () => {
+      const result = tryFitToPage({ x: 0, y: ROWS_PER_PAGE, h: ROWS_PER_PAGE, w: 2 }, 1);
+      assert(result);
+    });
+
+    it('fits 6', () => {
+      const result = tryFitToPage({ x: 0, y: ROWS_PER_PAGE * 2, h: 2, w: 2 }, 2);
+      assert(result);
+    });
+
+    it('fits 7', () => {
+      const result = tryFitToPage({ x: 0, y: 57, h: 4, w: 2 }, 5);
+      assert(result);
+    });
+
+    it('fits 8', () => {
+      const result = tryFitToPage({ x: 4, y: 11, h: 5, w: 4 }, 0);
+      assert(result);
+    });
+
+    it('fits 9', () => {
+      const result = tryFitToPage({ x: 0, y: 13, h: 4, w: 2 }, 0);
+      assert.equal(result, false);
+    });
+
+    it('fits 10', () => {
+      const result = tryFitToPage({ x: 4, y: 11, h: 3, w: 4 }, 0);
+      assert(result);
+    });
+  });
+
+  describe('groupIntoPages()', () => {
+    it('1 column', () => {
+      const result = groupIntoPages()([
+        { x: 0, y: 1, h: 4, w: 2 },
+        { x: 0, y: 2, h: 4, w: 2 },
+        { x: 0, y: 4, h: 4, w: 2 },
+        { x: 0, y: 4, h: 4, w: 2 },
+        { x: 0, y: 5, h: 4, w: 2 },
+        { x: 0, y: 6, h: 4, w: 2 },
+      ]);
+      assert.deepStrictEqual(result, [
+        { x: 0, y: 1, h: 4, w: 2 },
+        { x: 0, y: 5, h: 4, w: 2 },
+        { x: 0, y: 9, h: 4, w: 2 },
+        { x: 0, y: 16, h: 4, w: 2 },
+        { x: 0, y: 20, h: 4, w: 2 },
+        { x: 0, y: 24, h: 4, w: 2 },
+      ]);
+    });
+
+    it('multi column', () => {
+      const result = groupIntoPages()([
+        { x: 0, y: 0, h: 11, w: 6 }, { x: 6, y: 0, h: 7, w: 6 },
+        { x: 0, y: 11, h: 7, w: 4 }, { x: 4, y: 11, h: 3, w: 4 }, { x: 8, y: 7, h: 6, w: 4 },
+                                     { x: 4, y: 16, h: 6, w: 4 }, { x: 8, y: 13, h: 6, w: 4 },
+      ]);
+      assert.deepStrictEqual(result, [
+        { x: 0, y: 0, h: 11, w: 6 }, { x: 6, y: 0, h: 7, w: 6 },
+                                     { x: 8, y: 7, h: 6, w: 4 }, { x: 4, y: 11, h: 3, w: 4 },
+        { x: 0, y: 16, h: 7, w: 4 }, { x: 4, y: 16, h: 6, w: 4 }, { x: 8, y: 16, h: 6, w: 4 },
+      ]);
+    });
+
+  });
+
+});
+


### PR DESCRIPTION
Ok so this turned out to be quite a tricky little task - basically a packing algorithm to pack items onto pages when exporting pdf - and moving items around creates cascading changes to subsequent pages. I wrote tests so I'm confident everything is working. Here is a pdf created with the new algorithm

[Map Dashboard (29).pdf](https://github.com/akvo/akvo-lumen/files/3111523/Map.Dashboard.29.pdf)

- [ ] **Update release notes if necessary**
