### PR TITLE
Add core/derive-category transformation backend op

### DIFF
--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -40,6 +40,7 @@
 				    "core/filter-column"
 				    "core/generate-geopoints"
 				    "core/merge-datasets"
+                                    "core/derive-category"
 				    "core/remove-sort"
 				    "core/rename-column"
 				    "core/reverse-geocode"
@@ -177,8 +178,6 @@
 (create-ns  'akvo.lumen.specs.transformation.merge-datasets.target)
 (alias 'transformation.merge-datasets.target 'akvo.lumen.specs.transformation.merge-datasets.target)
 
-
-
 (s/def ::transformation.merge-datasets.source/datasetId ::db.dsv.s/dataset-id)
 (s/def ::transformation.merge-datasets.source/aggregationColumn (s/nilable columnName?))
 
@@ -207,6 +206,42 @@
    :req-un [::transformation.merge-datasets/args
             ::transformation.engine/op]))
 
+(create-ns  'akvo.lumen.specs.transformation.derive-category)
+(alias 'transformation.derive-category 'akvo.lumen.specs.transformation.derive-category)
+
+(create-ns  'akvo.lumen.specs.transformation.derive-category.source)
+(alias 'transformation.derive-category.source 'akvo.lumen.specs.transformation.derive-category.source)
+
+(create-ns  'akvo.lumen.specs.transformation.derive-category.target)
+(alias 'transformation.derive-category.target 'akvo.lumen.specs.transformation.derive-category.target)
+
+(create-ns  'akvo.lumen.specs.transformation.derive-category.derivation)
+(alias 'transformation.derive-category.derivation 'akvo.lumen.specs.transformation.derive-category.derivation)
+
+(s/def ::transformation.derive-category.source/columnName ::i.values.s/id)
+(s/def ::transformation.derive-category.source/column (s/keys :req-un [::transformation.derive-category.source/columnName]))
+
+(s/def ::transformation.derive-category/source (s/keys
+                                               :req-un [::transformation.derive-category.source/column]))
+
+(s/def ::transformation.derive-category.target/column (s/keys :req-un [::i.values.s/title]))
+(s/def ::transformation.derive-category/target (s/keys
+                                               :req-un [::transformation.derive-category.target/column]))
+
+(s/def ::transformation.derive-category.derivation/mappings (s/coll-of (s/tuple string? string?) :kind vector?))
+
+(s/def ::transformation.derive-category/derivation
+  (s/keys :req-un [::transformation.derive-category.derivation/mappings]))
+
+(s/def ::transformation.derive-category/args
+  (s/keys :req-un [::transformation.derive-category/source
+                   ::transformation.derive-category/target
+                   ::transformation.derive-category/derivation]))
+
+(defmethod op-spec "core/derive-category"  [_]
+  (s/keys
+   :req-un [::transformation.derive-category/args
+            ::transformation.engine/op]))
 
 (create-ns 'akvo.lumen.specs.transformation.extract-multiple)
 (alias 'transformation.extract-multiple 'akvo.lumen.specs.transformation.extract-multiple)

--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -228,7 +228,8 @@
 (s/def ::transformation.derive-category/target (s/keys
                                                :req-un [::transformation.derive-category.target/column]))
 
-(s/def ::transformation.derive-category.derivation/mappings (s/coll-of (s/tuple string? string?) :kind vector? :min-count 1))
+(s/def ::transformation.derive-category.derivation/mappings (s/coll-of (s/tuple (s/coll-of string? :kind vector? :min-count 1) string?) :kind vector? :min-count 1))
+
 (s/def ::transformation.derive-category.derivation/uncategorizedValue (s/nilable string?))
 
 (s/def ::transformation.derive-category/derivation

--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -228,10 +228,12 @@
 (s/def ::transformation.derive-category/target (s/keys
                                                :req-un [::transformation.derive-category.target/column]))
 
-(s/def ::transformation.derive-category.derivation/mappings (s/coll-of (s/tuple string? string?) :kind vector?))
+(s/def ::transformation.derive-category.derivation/mappings (s/coll-of (s/tuple string? string?) :kind vector? :min-count 1))
+(s/def ::transformation.derive-category.derivation/uncategorizedValue (s/nilable string?))
 
 (s/def ::transformation.derive-category/derivation
-  (s/keys :req-un [::transformation.derive-category.derivation/mappings]))
+  (s/keys :req-un [::transformation.derive-category.derivation/mappings
+                   ::transformation.derive-category.derivation/uncategorizedValue]))
 
 (s/def ::transformation.derive-category/args
   (s/keys :req-un [::transformation.derive-category/source

--- a/backend/src/akvo/lumen/lib/transformation/derive_category.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive_category.clj
@@ -1,0 +1,22 @@
+(ns akvo.lumen.lib.transformation.derive-category
+  (:require [akvo.lumen.util :as util]
+            [akvo.lumen.lib.transformation.engine :as engine]
+            [clojure.java.jdbc :as jdbc]
+            [clojure.tools.logging :as log]
+            [clojure.set :as set]
+            [clojure.set :refer (rename-keys) :as set]
+            [clojure.string :as string]
+            [clojure.walk :as walk]
+            [hugsql.core :as hugsql]
+            [clojure.spec.alpha :as s]
+            [akvo.lumen.specs.transformation :as transformation.s]))
+
+(defmethod engine/valid? "core/derive-category"
+  [op-spec]
+  (s/valid? (transformation.s/op-spec {:op "core/derive-category"}) (walk/keywordize-keys op-spec)))
+
+(defmethod engine/apply-operation "core/derive-category"
+  [{:keys [tenant-conn]} table-name columns op-spec]
+  {:success? true
+   :execution-log ["wow!"]
+   :columns columns})

--- a/backend/src/akvo/lumen/lib/transformation/derive_category.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive_category.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.transformation.derive-category
   (:require [akvo.lumen.util :as util]
             [akvo.lumen.lib.transformation.engine :as engine]
+            [akvo.lumen.lib.dataset.utils :as dataset.utils]
             [clojure.java.jdbc :as jdbc]
             [clojure.tools.logging :as log]
             [clojure.set :as set]
@@ -11,12 +12,43 @@
             [clojure.spec.alpha :as s]
             [akvo.lumen.specs.transformation :as transformation.s]))
 
+(hugsql/def-db-fns "akvo/lumen/lib/transformation/derive.sql")
+(hugsql/def-db-fns "akvo/lumen/lib/transformation/engine.sql")
+
 (defmethod engine/valid? "core/derive-category"
   [op-spec]
   (s/valid? (transformation.s/op-spec {:op "core/derive-category"}) (walk/keywordize-keys op-spec)))
 
 (defmethod engine/apply-operation "core/derive-category"
   [{:keys [tenant-conn]} table-name columns op-spec]
-  {:success? true
-   :execution-log ["wow!"]
-   :columns columns})
+  (let [op-spec (walk/keywordize-keys op-spec)
+        source-column-name (get-in op-spec [:args :source :column :columnName])
+        column-title (get-in op-spec [:args :target :column :title])
+        uncategorized-value (get-in op-spec [:args :derivation :uncategorizedValue])
+        mappings (->> (get-in op-spec [:args :derivation :mappings])
+                      (into {}))
+        new-column-name (engine/next-column-name columns)
+        all-data (all-data tenant-conn {:table-name table-name})]
+    (jdbc/with-db-transaction [tenant-conn tenant-conn]
+      (add-column tenant-conn {:table-name      table-name
+                               :column-type     "text"
+                               :new-column-name new-column-name})
+      (->> all-data
+           (map (fn [i]
+                  (set-cell-value tenant-conn
+                                  {:value (get mappings (get i (keyword source-column-name)) uncategorized-value)
+                                   :rnum (:rnum i)
+                                   :column-name new-column-name
+                                   :table-name table-name} )))
+           doall)
+      {:success? true
+       :execution-log [(format "Derived category '%s' using column: '%s' and mappings: '%s'"
+                               column-title
+                               (:title (dataset.utils/find-column (walk/keywordize-keys columns) source-column-name))
+                               mappings)]
+       :columns (conj columns {"title"      column-title
+                               "type"       "text"
+                               "sort"       nil
+                               "hidden"     false
+                               "direction"  nil
+                               "columnName" new-column-name})})))

--- a/backend/test/akvo/lumen/lib/auth_test.clj
+++ b/backend/test/akvo/lumen/lib/auth_test.clj
@@ -35,7 +35,6 @@
         (let [ds-id "1"
               data (assoc data :datasetId ds-id)]
           (is (not (s/valid? ::visualisation.s/visualisation data)))
-          (clojure.pprint/pprint data)
           (is (= (auth/ids ::visualisation.s/visualisation data)
                  {:dashboard-ids #{}, :collection-ids #{}, :dataset-ids #{ds-id}, :visualisation-ids #{v-id}}))))))
   (testing "visualisation map types, could have datasetId(s) in layer collection"


### PR DESCRIPTION
Relates to #2071 

### expected payload 
```
{
    op: 'core/derive-category',
    args : {
    source: {column: {columnName: 'c1'}},
    target: {column: {title: 'Color'}},
    derivation: {mappings: [
                           [['source-val-1'],'derived-val-1'],
                           [['source-val-2', 'source-val-3'], 'derived-val-2'],
                           [['source-val-4', 'source-val-5', 'source-val-6'],'derived-val-3']],
                 uncategorizedValue: "Uncategorised"
      }

    }
}
```

- [ ] **Update release notes if necessary**
- [x] we should also add the option to search for values in the list and when creating a group  
- [x] [tracking](https://github.com/akvo/akvo-lumen/pull/2136)
