### PR TITLE
Add number type support for derive-category transformation

### DIFF
--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -215,8 +215,13 @@
 (create-ns  'akvo.lumen.specs.transformation.derive-category.target)
 (alias 'transformation.derive-category.target 'akvo.lumen.specs.transformation.derive-category.target)
 
+
 (create-ns  'akvo.lumen.specs.transformation.derive-category.derivation)
 (alias 'transformation.derive-category.derivation 'akvo.lumen.specs.transformation.derive-category.derivation)
+
+(create-ns  'akvo.lumen.specs.transformation.derive-category.derivation.text)
+(alias 'transformation.derive-category.derivation.text 'akvo.lumen.specs.transformation.derive-category.derivation.text)
+
 
 (s/def ::transformation.derive-category.source/columnName ::i.values.s/id)
 (s/def ::transformation.derive-category.source/column (s/keys :req-un [::transformation.derive-category.source/columnName]))
@@ -228,18 +233,27 @@
 (s/def ::transformation.derive-category/target (s/keys
                                                :req-un [::transformation.derive-category.target/column]))
 
-(s/def ::transformation.derive-category.derivation/mappings (s/coll-of (s/tuple (s/coll-of ::lumen.s/non-empty-string :kind vector? :min-count 1) ::lumen.s/non-empty-string) :kind vector? :min-count 1))
+(s/def ::transformation.derive-category.derivation.text/mappings (s/coll-of (s/tuple (s/coll-of ::lumen.s/non-empty-string :kind vector? :min-count 1) ::lumen.s/non-empty-string) :kind vector? :min-count 1))
 
 (s/def ::transformation.derive-category.derivation/uncategorizedValue ::lumen.s/non-empty-string)
+(s/def ::transformation.derive-category.derivation/type #{"text"})
+
+(defmulti derivation :type)
+
+(defmethod derivation "text" [_]
+  (s/keys :req-un [::transformation.derive-category.derivation.text/mappings
+                   ::transformation.derive-category.derivation/type]))
 
 (s/def ::transformation.derive-category/derivation
-  (s/keys :req-un [::transformation.derive-category.derivation/mappings
-                   ::transformation.derive-category.derivation/uncategorizedValue]))
+  (s/merge (s/keys :req-un [::transformation.derive-category.derivation/uncategorizedValue])
+           (s/multi-spec derivation :type)))
 
 (s/def ::transformation.derive-category/args
   (s/keys :req-un [::transformation.derive-category/source
                    ::transformation.derive-category/target
                    ::transformation.derive-category/derivation]))
+
+(lumen.s/sample ::transformation.derive-category/derivation)
 
 (defmethod op-spec "core/derive-category"  [_]
   (s/keys

--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -245,8 +245,6 @@
   (s/tuple ::transformation.derive-category.derivation.number/op
            number?))
 
-(lumen.s/sample ::transformation.derive-category.derivation.number/op*)
-
 (s/def ::transformation.derive-category.derivation.number/mappings
   (s/coll-of
    (s/tuple
@@ -254,9 +252,6 @@
     (s/nilable ::transformation.derive-category.derivation.number/op*)
     ::lumen.s/non-empty-string)
    :kind vector? :min-count 1))
-
-(lumen.s/sample ::transformation.derive-category.derivation.number/mappings)
-
 
 (s/def ::transformation.derive-category.derivation/uncategorizedValue ::lumen.s/non-empty-string)
 
@@ -272,6 +267,8 @@
   (s/keys :req-un [::transformation.derive-category.derivation.number/mappings
                    ::transformation.derive-category.derivation/type]))
 
+(defmethod derivation :default [_]
+  (s/keys :req-un [::transformation.derive-category.derivation.text/mappings]))
 
 (s/def ::transformation.derive-category/derivation
   (s/merge (s/keys :req-un [::transformation.derive-category.derivation/uncategorizedValue])
@@ -281,8 +278,6 @@
   (s/keys :req-un [::transformation.derive-category/source
                    ::transformation.derive-category/target
                    ::transformation.derive-category/derivation]))
-
-(lumen.s/sample ::transformation.derive-category/derivation)
 
 (defmethod op-spec "core/derive-category"  [_]
   (s/keys

--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -222,6 +222,9 @@
 (create-ns  'akvo.lumen.specs.transformation.derive-category.derivation.text)
 (alias 'transformation.derive-category.derivation.text 'akvo.lumen.specs.transformation.derive-category.derivation.text)
 
+(create-ns  'akvo.lumen.specs.transformation.derive-category.derivation.number)
+(alias 'transformation.derive-category.derivation.number 'akvo.lumen.specs.transformation.derive-category.derivation.number)
+
 
 (s/def ::transformation.derive-category.source/columnName ::i.values.s/id)
 (s/def ::transformation.derive-category.source/column (s/keys :req-un [::transformation.derive-category.source/columnName]))
@@ -235,14 +238,40 @@
 
 (s/def ::transformation.derive-category.derivation.text/mappings (s/coll-of (s/tuple (s/coll-of ::lumen.s/non-empty-string :kind vector? :min-count 1) ::lumen.s/non-empty-string) :kind vector? :min-count 1))
 
+
+(s/def ::transformation.derive-category.derivation.number/op #{">" "<" ">=" "<=" "="})
+
+(s/def ::transformation.derive-category.derivation.number/op*
+  (s/tuple ::transformation.derive-category.derivation.number/op
+           number?))
+
+(lumen.s/sample ::transformation.derive-category.derivation.number/op*)
+
+(s/def ::transformation.derive-category.derivation.number/mappings
+  (s/coll-of
+   (s/tuple
+    ::transformation.derive-category.derivation.number/op*
+    (s/nilable ::transformation.derive-category.derivation.number/op*)
+    ::lumen.s/non-empty-string)
+   :kind vector? :min-count 1))
+
+(lumen.s/sample ::transformation.derive-category.derivation.number/mappings)
+
+
 (s/def ::transformation.derive-category.derivation/uncategorizedValue ::lumen.s/non-empty-string)
-(s/def ::transformation.derive-category.derivation/type #{"text"})
+
+(s/def ::transformation.derive-category.derivation/type #{"text" "number"})
 
 (defmulti derivation :type)
 
 (defmethod derivation "text" [_]
   (s/keys :req-un [::transformation.derive-category.derivation.text/mappings
                    ::transformation.derive-category.derivation/type]))
+
+(defmethod derivation "number" [_]
+  (s/keys :req-un [::transformation.derive-category.derivation.number/mappings
+                   ::transformation.derive-category.derivation/type]))
+
 
 (s/def ::transformation.derive-category/derivation
   (s/merge (s/keys :req-un [::transformation.derive-category.derivation/uncategorizedValue])

--- a/backend/src/akvo/lumen/lib/transformation/derive_category.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive_category.clj
@@ -53,7 +53,7 @@
         new-column-name       (engine/next-column-name columns)
         all-data              (all-data tenant-conn {:table-name table-name})
         mappings              (get-in op-spec [:args :derivation :mappings])
-        derivation-type       (get-in op-spec [:args :derivation :type])
+        derivation-type       (get-in op-spec [:args :derivation :type] "text")
         execution-log-message (format "Derived %s category '%s' using column: '%s' and mappings: '%s'"
                                       derivation-type
                                       column-title

--- a/backend/test/akvo/lumen/lib/transformation/derive_category_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation/derive_category_test.clj
@@ -1,0 +1,17 @@
+(ns akvo.lumen.lib.transformation.derive-category-test
+  (:require [akvo.lumen.lib.transformation.derive-category :as derive-category]
+            [clojure.tools.logging :as log]
+            [clojure.test.check.clojure-test :refer (defspec)]
+            [clojure.test :refer :all]))
+
+(deftest find-category-test
+  (testing "mapping number type"
+    (let [uncategorized-val "no-cat"
+          cat-one           "one"
+          cat-two           "two"
+          mappings          [[[">=" 0] ["<=" 1] cat-one]
+                             [["=" 2] nil cat-two]]]
+      (is (= cat-one (derive-category/find-number-cat mappings 1 uncategorized-val)))
+      (is (= cat-two (derive-category/find-number-cat mappings 2 uncategorized-val)))
+      (is (= uncategorized-val (derive-category/find-number-cat mappings 3 uncategorized-val))))))
+

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -622,6 +622,7 @@
                                                  [:source :column :columnName] "c1"
                                                  [:target :column :title] new-column-name
                                                  [:derivation :mappings] mappings*
+                                                 [:derivation :type] "text"
                                                  [:derivation :uncategorizedValue] uncategorized-value)
 
         [tag _ :as res] (apply-transformation {:type           :transformation

--- a/client/src/components/transformation/DeriveCategoryTransformation.jsx
+++ b/client/src/components/transformation/DeriveCategoryTransformation.jsx
@@ -82,6 +82,7 @@ class DeriveCategoryTransformation extends Component {
               ...transformation.args,
               derivation: {
                 ...transformation.args.derivation,
+                type: 'text',
                 mappings: transformation.args.derivation.mappings.map(([sourceValues, target]) =>
                   [
                     // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
- [ ] **Update release notes if necessary**
#2071 

Example payload: 
```clojure
{:source {:column {:columnName "c3"}},
 :target {:column {:title "Column 1"}},
 :derivation
 {:uncategorizedValue "8",
  :mappings
  [[["<=" -1] ["<" -1] "0"]
   [[">" -1] ["=" -2.0] "q"]
   [[">=" -1] [">" 0] "0a"]
   [["<=" -1.0] ["<" 2.0] "Z5"]
   [["<" 1.0] [">=" 0] "G"]
   [[">" 0] [">" 2.0] "3"]
   [[">" -1] ["=" -1.0] "C"]
   [["<=" -1] ["=" -1] "1s"]
   [["=" 0] ["<" -1.0] "S"]
   [[">=" 1.0] nil "2tk1"]],
  :type "number"}}
```

### meanings of each mapping entry 
##### example with `and` 
`[["<=" -1] ["<" -1] "0"]` 

+ First expression `["<=" -1]`
+ Second/optional/and expression `["<" -1] `
+ mapped category `"0"`

##### example without `and` 
`[["<=" -1] nil "0"]` 

+ First expression `["<=" -1]`
+ Second/optional/and expression `nil`
+ mapped category `"0"`