### PR TITLE
Use Auth0 or Keycloak as authentication system

### DIFF
--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -61,6 +61,7 @@
  :akvo.lumen.endpoint.env/env {:routes-opts
                                {:middleware [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant]}
                                :keycloak #ig/ref :akvo.lumen.component.keycloak/data
+                               :auth0 #ig/ref :akvo.lumen.component.auth0/data
                                :keycloak-public-client-id #duct/env [ "LUMEN_KEYCLOAK_PUBLIC_CLIENT_ID" :or "akvo-lumen" ]
                                :flow-api #ig/ref :akvo.lumen.component.flow/api
                                :sentry-client-dsn #duct/env "LUMEN_SENTRY_CLIENT_DSN"

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -171,6 +171,8 @@
  :akvo.lumen.component.keycloak/data {:url #duct/env "LUMEN_KEYCLOAK_URL"
                                       :realm "akvo"}
 
+ :akvo.lumen.component.auth0/data {:url #duct/env "LUMEN_AUTH0_URL"}
+
  :akvo.lumen.component.keycloak/keycloak {:data #ig/ref :akvo.lumen.component.keycloak/data
                                           :credentials {:client_id #duct/env [ "LUMEN_KEYCLOAK_CLIENT_ID" :or "akvo-lumen-confidential" ]
                                                         :client_secret #duct/env "LUMEN_KEYCLOAK_CLIENT_SECRET"}}

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -62,7 +62,6 @@
                                {:middleware [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant]}
                                :keycloak #ig/ref :akvo.lumen.component.keycloak/data
                                :auth0 #ig/ref :akvo.lumen.component.auth0/data
-                               :keycloak-public-client-id #duct/env [ "LUMEN_KEYCLOAK_PUBLIC_CLIENT_ID" :or "akvo-lumen" ]
                                :flow-api #ig/ref :akvo.lumen.component.flow/api
                                :sentry-client-dsn #duct/env "LUMEN_SENTRY_CLIENT_DSN"
                                :piwik-site-id #duct/env "LUMEN_PIWIK_SITE_ID"}
@@ -172,9 +171,11 @@
  :akvo.lumen.component.caddisfly/prod {:schema-uri #duct/env [ "LUMEN_CADDISFLY_SCHEMA_URI" :or "https://s3-eu-west-1.amazonaws.com/akvoflow-public/caddisfly-tests-v2.json"]}
 
  :akvo.lumen.component.keycloak/data {:url #duct/env "LUMEN_KEYCLOAK_URL"
-                                      :realm "akvo"}
+                                      :realm "akvo"
+                                      :client-id #duct/env [ "LUMEN_KEYCLOAK_PUBLIC_CLIENT_ID" :or "akvo-lumen" ]}
 
- :akvo.lumen.component.auth0/data {:url #duct/env ["LUMEN_AUTH0_URL" :or "https://tangrammer.eu.auth0.com"]}
+ :akvo.lumen.component.auth0/data {:url #duct/env ["LUMEN_AUTH0_URL" :or "https://akvotest.eu.auth0.com"]
+                                   :client-id #duct/env [ "LUMEN_AUTH0_PUBLIC_CLIENT_ID" :or "D5LayiXP1pzq-6g2B_QVvzCw_eycZxQK"]}
 
  :akvo.lumen.component.keycloak/keycloak {:data #ig/ref :akvo.lumen.component.keycloak/data
                                           :credentials {:client_id #duct/env [ "LUMEN_KEYCLOAK_CLIENT_ID" :or "akvo-lumen-confidential" ]

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -27,7 +27,8 @@
                                                           :content-types true
                                                           :default-charset "utf-8"}}
 
- :akvo.lumen.auth/wrap-auth {}
+ :akvo.lumen.auth/wrap-auth {:keycloak #ig/ref :akvo.lumen.component.keycloak/data
+                             :auth0 #ig/ref :akvo.lumen.component.auth0/data}
 
  :akvo.lumen.lib.auth/wrap-auth-datasets {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                           :flow-api #ig/ref :akvo.lumen.component.flow/api
@@ -172,7 +173,7 @@
  :akvo.lumen.component.keycloak/data {:url #duct/env "LUMEN_KEYCLOAK_URL"
                                       :realm "akvo"}
 
- :akvo.lumen.component.auth0/data {:url #duct/env "LUMEN_AUTH0_URL"}
+ :akvo.lumen.component.auth0/data {:url #duct/env ["LUMEN_AUTH0_URL" :or "https://tangrammer.eu.auth0.com"]}
 
  :akvo.lumen.component.keycloak/keycloak {:data #ig/ref :akvo.lumen.component.keycloak/data
                                           :credentials {:client_id #duct/env [ "LUMEN_KEYCLOAK_CLIENT_ID" :or "akvo-lumen-confidential" ]

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -33,7 +33,8 @@
                                           :flow-api #ig/ref :akvo.lumen.component.flow/api
                                           :monitoring {:collector #ig/ref :akvo.lumen.monitoring/collector}}
 
- :akvo.lumen.auth/wrap-jwt {:keycloak #ig/ref :akvo.lumen.component.keycloak/data}
+ :akvo.lumen.auth/wrap-jwt {:keycloak #ig/ref :akvo.lumen.component.keycloak/data
+                            :auth0 #ig/ref :akvo.lumen.component.auth0/data}
 
  :akvo.lumen.component.tenant-manager/wrap-label-tenant {}
 

--- a/backend/src/akvo/lumen/component/auth0.clj
+++ b/backend/src/akvo/lumen/component/auth0.clj
@@ -26,8 +26,9 @@
       (throw e))))
 
 (s/def ::url string?)
+(s/def ::client-id string?)
 
-(s/def ::data (s/keys :req-un [::url]))
+(s/def ::data (s/keys :req-un [::url ::client-id]))
 
 (defmethod ig/pre-init-spec :akvo.lumen.component.auth0/data [_]
   ::data)

--- a/backend/src/akvo/lumen/component/auth0.clj
+++ b/backend/src/akvo/lumen/component/auth0.clj
@@ -1,0 +1,21 @@
+(ns akvo.lumen.component.auth0
+  "moving to auth0"
+  (:require [akvo.lumen.lib :as lib]
+            [akvo.lumen.protocols :as p]
+            [cheshire.core :as json]
+            [clj-http.client :as client]
+            [integrant.core :as ig]
+            [clojure.spec.alpha :as s]
+            [clojure.set :as set]
+            [clojure.tools.logging :as log]
+            [ring.util.response :refer [response]]))
+
+(defmethod ig/init-key :akvo.lumen.component.auth0/data  [_ {:keys [url] :as opts}]
+  opts)
+
+(s/def ::url string?)
+
+(s/def ::data (s/keys :req-un [::url]))
+
+(defmethod ig/pre-init-spec :akvo.lumen.component.auth0/data [_]
+  ::data)

--- a/backend/src/akvo/lumen/component/keycloak.clj
+++ b/backend/src/akvo/lumen/component/keycloak.clj
@@ -293,10 +293,12 @@
       (throw e))))
 
 (s/def ::url string?)
+(s/def ::client-id string?)
 (s/def ::realm string?)
 
 (s/def ::data (s/keys :req-un [::url
-                               ::realm]))
+                               ::realm
+                               ::client-id]))
 
 (defmethod ig/pre-init-spec :akvo.lumen.component.keycloak/data [_]
   ::data)

--- a/backend/src/akvo/lumen/endpoint/env.clj
+++ b/backend/src/akvo/lumen/endpoint/env.clj
@@ -13,7 +13,7 @@
         :as request}]
     (let [auth-type (get query-params "auth")]
       (if (s/valid? ::auth-type auth-type)
-        (response
+        (response/response
          (cond-> {"keycloakClient" keycloak-public-client-id
                   "keycloakURL" (:url keycloak)
                   "flowApiUrl" (:url flow-api)

--- a/backend/src/akvo/lumen/endpoint/env.clj
+++ b/backend/src/akvo/lumen/endpoint/env.clj
@@ -22,6 +22,7 @@
         (response/response
          (cond-> {"keycloakClient" keycloak-public-client-id
                   "authURL" auth-url
+                  "authProvider" auth-type
                   "flowApiUrl" (:url flow-api)
                   "piwikSiteId" piwik-site-id
                   "tenant" (:tenant request)}

--- a/backend/src/akvo/lumen/endpoint/env.clj
+++ b/backend/src/akvo/lumen/endpoint/env.clj
@@ -15,7 +15,7 @@
       (if (s/valid? ::auth-type auth-type)
         (response/response
          (cond-> {"keycloakClient" keycloak-public-client-id
-                  "keycloakURL" (:url keycloak)
+                  "authURL" (:url keycloak)
                   "flowApiUrl" (:url flow-api)
                   "piwikSiteId" piwik-site-id
                   "tenant" (:tenant request)}

--- a/backend/src/akvo/lumen/endpoint/env.clj
+++ b/backend/src/akvo/lumen/endpoint/env.clj
@@ -1,21 +1,27 @@
 (ns akvo.lumen.endpoint.env
   (:require [integrant.core :as ig]
             [clojure.spec.alpha :as s]
+            [akvo.lumen.component.keycloak]
+            [akvo.lumen.component.auth0]
             [clojure.tools.logging :as log]
             [ring.util.response :as response]))
 
 (s/def ::auth-type #{"keycloak" "auth0"})
 
-(defn handler [{:keys [keycloak-public-client-id keycloak flow-api
+(defn handler [{:keys [keycloak-public-client-id keycloak flow-api auth0
                         piwik-site-id sentry-client-dsn] :as opts}]
   (fn [{tenant :tenant
         query-params :query-params
         :as request}]
-    (let [auth-type (get query-params "auth")]
+    (let [auth-type (get query-params "auth")
+          auth-url (condp = auth-type
+                     "keycloak" (:url keycloak)
+                     "auth0" (:url auth0)
+                     (:url keycloak))]
       (if (s/valid? ::auth-type auth-type)
         (response/response
          (cond-> {"keycloakClient" keycloak-public-client-id
-                  "authURL" (:url keycloak)
+                  "authURL" auth-url
                   "flowApiUrl" (:url flow-api)
                   "piwikSiteId" piwik-site-id
                   "tenant" (:tenant request)}
@@ -35,6 +41,7 @@
 
 (s/def ::keycloak-public-client-id string?)
 (s/def ::keycloak :akvo.lumen.component.keycloak/data)
+(s/def ::auth0 :akvo.lumen.component.auth0/data)
 (s/def ::flow-api :akvo.lumen.component.flow/config)
 (s/def ::sentry-client-dsn string?)
 (s/def ::piwik-site-id string?)
@@ -42,6 +49,7 @@
 (defmethod ig/pre-init-spec :akvo.lumen.endpoint.env/env [_]
   (s/keys :req-un [::keycloak-public-client-id
                    ::keycloak
+                   ::auth0
                    ::flow-api
                    ::sentry-client-dsn
                    ::piwik-site-id]))

--- a/backend/test/akvo/lumen/auth_test.clj
+++ b/backend/test/akvo/lumen/auth_test.clj
@@ -25,21 +25,22 @@
     401 (is (= "Not authenticated" (:body response)))
     403 (is (= "Not authorized" (:body response)))))
 
-(deftest wrap-auth-test
+(def wrap-auth (m/wrap-auth {:issuer "keyclaoak"} {:issuer "auth0"}))
 
+(deftest wrap-auth-test
   (testing "GET / without claims"
-    (let [response ((m/wrap-auth test-handler)
+    (let [response ((wrap-auth test-handler)
                     (immutant-request :get "/"))]
       (is (= 401 (:status response)))))
 
   (testing "POST /api without claims"
-    (let [response ((m/wrap-auth test-handler)
+    (let [response ((wrap-auth test-handler)
                     (immutant-request :post "/api"))]
       (is (= 401 (:status response)))))
 
   (testing "GET resource with claims but no tenant"
     (check-response
-     ((m/wrap-auth test-handler)
+     ((wrap-auth test-handler)
       (-> (immutant-request :get "/api/resource")
           (assoc-in [:jwt-claims "realm_access" "roles"]
                     ["akvo:lumen:t0"])))
@@ -47,7 +48,7 @@
 
   (testing "GET resource with claims and tenant"
     (check-response
-     ((m/wrap-auth test-handler)
+     ((wrap-auth test-handler)
       (-> (immutant-request :get "/api/resource")
           (assoc-in [:jwt-claims "realm_access" "roles"]
                     ["akvo:lumen:t0"])
@@ -56,7 +57,7 @@
 
   (testing "GET resource as admin with claims and tenant"
     (check-response
-     ((m/wrap-auth test-handler)
+     ((wrap-auth test-handler)
       (-> (immutant-request :get "/api/resource")
           (assoc-in [:jwt-claims "realm_access" "roles"]
                     ["akvo:lumen:t0"
@@ -66,7 +67,7 @@
 
   (testing "GET admin resource as admin with claims and tenant"
     (check-response
-     ((m/wrap-auth test-handler)
+     ((wrap-auth test-handler)
       (-> (immutant-request :get "/api/admin/resource")
           (assoc-in [:jwt-claims "realm_access" "roles"]
                     ["akvo:lumen:t0"
@@ -76,7 +77,7 @@
 
   (testing "GET admin resource as non admin with claims and tenant"
     (check-response
-     ((m/wrap-auth test-handler)
+     ((wrap-auth test-handler)
       (-> (immutant-request :get "/api/admin/resource")
           (assoc-in [:jwt-claims "realm_access" "roles"]
                     ["akvo:lumen:t0"])
@@ -84,41 +85,41 @@
      403))
 
   (testing "GET resource without claims"
-    (let [response ((m/wrap-auth test-handler)
+    (let [response ((wrap-auth test-handler)
                     (immutant-request :get "/api/resource"))]
       (check-response response 401)))
 
   (testing "POST resource without claims"
-    (let [response ((m/wrap-auth test-handler)
+    (let [response ((wrap-auth test-handler)
                     (immutant-request :post "/api/resource"))]
       (check-response response 401)))
 
   (testing "PATCH resource without claims"
-    (let [response ((m/wrap-auth test-handler)
+    (let [response ((wrap-auth test-handler)
                     (immutant-request :patch "/api/resource"))]
       (check-response response 401)))
 
   (testing "HEAD resource without claims"
-    (let [response ((m/wrap-auth test-handler)
+    (let [response ((wrap-auth test-handler)
                     (immutant-request :patch "/api/resource"))]
       (check-response response 401)))
 
   (testing "GET resource without claim role"
-    (let [response ((m/wrap-auth test-handler)
+    (let [response ((wrap-auth test-handler)
                     (assoc-in (immutant-request :get "/api/resource")
                               [:jwt-claims "realm_access" "roles"]
                               []))]
       (check-response response 403)))
 
   (testing "POST resource without claim role"
-    (let [response ((m/wrap-auth test-handler)
+    (let [response ((wrap-auth test-handler)
                     (assoc-in (immutant-request :post "/api/resource")
                               [:jwt-claims "realm_access" "roles"]
                               []))]
       (check-response response 403)))
 
   (testing "Faulty claims should return not authenticated"
-    (let [response ((m/wrap-auth test-handler)
+    (let [response ((wrap-auth test-handler)
                     (assoc-in (immutant-request :get "/api/resource")
                               [:jwt-claims]
                               "realm_access"))]

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -27,6 +27,7 @@
           (is (= 200 (:status r)))
           (is (= {:keycloakClient "akvo-lumen",
                   :authURL "http://auth.lumen.local:8080/auth",
+                  :authProvider "keycloak",
                   :flowApiUrl "https://api.akvotest.org/flow",
                   :piwikSiteId "165",
                   :tenant "t1",

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -25,7 +25,7 @@
       (testing "/env"
         (let [r (h (get*  "/env" {"auth" "keycloak"}))]
           (is (= 200 (:status r)))
-          (is (= {:keycloakClient "akvo-lumen",
+          (is (= {:authClientId "akvo-lumen",
                   :authURL "http://auth.lumen.local:8080/auth",
                   :authProvider "keycloak",
                   :flowApiUrl "https://api.akvotest.org/flow",

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -26,7 +26,7 @@
         (let [r (h (get*  "/env" {"auth" "keycloak"}))]
           (is (= 200 (:status r)))
           (is (= {:keycloakClient "akvo-lumen",
-                  :keycloakURL "http://auth.lumen.local:8080/auth",
+                  :authURL "http://auth.lumen.local:8080/auth",
                   :flowApiUrl "https://api.akvotest.org/flow",
                   :piwikSiteId "165",
                   :tenant "t1",

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -23,7 +23,7 @@
                  (body-kw r)))))
 
       (testing "/env"
-        (let [r (h (get*  "/env"))]
+        (let [r (h (get*  "/env" {"auth" "keycloak"}))]
           (is (= 200 (:status r)))
           (is (= {:keycloakClient "akvo-lumen",
                   :keycloakURL "http://auth.lumen.local:8080/auth",

--- a/backend/test/resources/test.edn
+++ b/backend/test/resources/test.edn
@@ -18,7 +18,7 @@
  :akvo.lumen.component.keycloak/data {:url "http://auth.lumen.local:8080/auth"
                                       :realm "akvo"}
 
- :akvo.lumen.component.auth0/data {:url "https://tangrammer.eu.auth0.com"}
+ :akvo.lumen.component.auth0/data {:url "https://akvotest.eu.auth0.com"}
 
  :akvo.lumen.component.keycloak/keycloak {:credentials
                                           {:client_id "akvo-lumen-confidential"

--- a/backend/test/resources/test.edn
+++ b/backend/test/resources/test.edn
@@ -16,9 +16,11 @@
  :akvo.lumen.component.handler/handler {:middleware [#ig/ref :akvo.lumen.component.handler/wrap-stacktrace]}
 
  :akvo.lumen.component.keycloak/data {:url "http://auth.lumen.local:8080/auth"
-                                      :realm "akvo"}
+                                      :realm "akvo"
+                                      :client-id "akvo-lumen"}
 
- :akvo.lumen.component.auth0/data {:url "https://akvotest.eu.auth0.com"}
+ :akvo.lumen.component.auth0/data {:url "https://akvotest.eu.auth0.com"
+                                   :client-id "D5LayiXP1pzq-6g2B_QVvzCw_eycZxQK"}
 
  :akvo.lumen.component.keycloak/keycloak {:credentials
                                           {:client_id "akvo-lumen-confidential"
@@ -44,9 +46,7 @@
 
  :akvo.lumen.component.flow/api {:url "https://api.akvotest.org/flow"}
 
- :akvo.lumen.endpoint.env/env {:keycloak-public-client-id "akvo-lumen"
-                               :keycloak-url "http://auth.lumen.local:8080/auth"
-                               :sentry-client-dsn "dev-sentry-client-dsn"
+ :akvo.lumen.endpoint.env/env {:sentry-client-dsn "dev-sentry-client-dsn"
                                :piwik-site-id "165"}
  
  :akvo.lumen.migrate/migrate {:seed

--- a/backend/test/resources/test.edn
+++ b/backend/test/resources/test.edn
@@ -18,6 +18,8 @@
  :akvo.lumen.component.keycloak/data {:url "http://auth.lumen.local:8080/auth"
                                       :realm "akvo"}
 
+ :akvo.lumen.component.auth0/data {:url "https://tangrammer.eu.auth0.com"}
+
  :akvo.lumen.component.keycloak/keycloak {:credentials
                                           {:client_id "akvo-lumen-confidential"
                                            :client_secret "caed3964-09dd-4752-b0bb-22c8e8ffd631"}}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1885,6 +1885,27 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "auth0-js": {
+      "version": "9.10.4",
+      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.10.4.tgz",
+      "integrity": "sha512-FKwwA0E9NDrn/MxCzeftA5wx6YCos9wINhuvXeFHDdx+Lis7ykR46kBXJF4+dYjDdC5QhQ7W0cAp6bBS5gS75Q==",
+      "requires": {
+        "base64-js": "^1.2.0",
+        "idtoken-verifier": "^1.2.0",
+        "js-cookie": "^2.2.0",
+        "qs": "^6.4.0",
+        "superagent": "^3.8.2",
+        "url-join": "^4.0.0",
+        "winchan": "^0.2.1"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
+      }
+    },
     "autoprefixer": {
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
@@ -4771,6 +4792,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -4912,6 +4938,11 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -6048,6 +6079,11 @@
         "event-emitter": "~0.3.5"
       }
     },
+    "es6-promise-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
+      "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4="
+    },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
@@ -7026,6 +7062,21 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.4.0.tgz",
+      "integrity": "sha512-4FinE8RfqYnNim20xDwZZE0V2kOs/AuElIjFUbPuegQSaoZM+vUT5FnwSl10KPugH4voTg1bEQlcbCG9ka75TA==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -8302,6 +8353,26 @@
         "harmony-reflect": "^1.4.6"
       }
     },
+    "idtoken-verifier": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/idtoken-verifier/-/idtoken-verifier-1.4.0.tgz",
+      "integrity": "sha512-644kKg9712hhEkyrRPncBGWKHd9pEh6b3r9DtkQ5zlqgoaX6YtsZGghNLXFVF+541MnwTLjFQqaDDmdQvT4qCQ==",
+      "requires": {
+        "base64-js": "^1.2.0",
+        "crypto-js": "^3.1.9-1",
+        "es6-promise-polyfill": "^1.2.0",
+        "isomorphic-unfetch": "^3.0.0",
+        "jsbn": "^0.1.0",
+        "url-join": "^1.1.0"
+      },
+      "dependencies": {
+        "url-join": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
+        }
+      }
+    },
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
@@ -8863,6 +8934,22 @@
         "whatwg-fetch": ">=0.10.0"
       }
     },
+    "isomorphic-unfetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.0.0.tgz",
+      "integrity": "sha512-V0tmJSYfkKokZ5mgl0cmfQMTb7MLHsBMngTkbLY0eXvKqiVRRoZP04Ly+KhKrJfKtzC9E6Pp15Jo+bwh7Vi2XQ==",
+      "requires": {
+        "node-fetch": "^2.2.0",
+        "unfetch": "^4.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -8901,6 +8988,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.8.tgz",
       "integrity": "sha512-hm2nYpDrwoO/OzBhdcqs/XGT6XjSuSSCVEpia+Kl2J6x4CYt5hISlVL/AYU1khoDXv0AQVgxtdJySb9gjAn56Q=="
     },
+    "js-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
+      "integrity": "sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8925,8 +9017,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "9.12.0",
@@ -15544,6 +15635,43 @@
         "schema-utils": "^0.3.0"
       }
     },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
+      }
+    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -16358,6 +16486,11 @@
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
     },
+    "unfetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
+      "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg=="
+    },
     "unicons": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/unicons/-/unicons-0.0.3.tgz",
@@ -16520,6 +16653,11 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
+    },
+    "url-join": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
+      "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
     },
     "url-loader": {
       "version": "1.0.1",
@@ -17465,6 +17603,11 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "winchan": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/winchan/-/winchan-0.2.2.tgz",
+      "integrity": "sha512-pvN+IFAbRP74n/6mc6phNyCH8oVkzXsto4KCHPJ2AScniAnA1AmeLI03I2BzjePpaClGSI4GUMowzsD3qz5PRQ=="
     },
     "window-size": {
       "version": "0.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -79,6 +79,7 @@
     "json-loader": "0.5.4",
     "js-yaml": "^3.13.1",
     "keycloak-js": "3.1.0",
+    "auth0-js": "9.10.4",
     "leaflet": "^1.0.3",
     "lodash": "^4.17.5",
     "moment": "^2.17.1",

--- a/client/package.json
+++ b/client/package.json
@@ -122,6 +122,7 @@
     "style-loader": "0.19.0",
     "tinycolor2": "^1.4.1",
     "tus-js-client": "^1.4.2",
+    "url": "0.11.0",
     "warning": "^3.0.0",
     "webpack": "3.1.0",
     "webpack-bundle-analyzer": "^3.0.3",

--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -25,7 +25,7 @@ function initAuthenticated(profile, env) {
 
   // Refreshing the token on a fixed schedule (every 10 minutes)
   // will disable SSO Idle Timeout
-  setInterval(auth.token, 1000 * 60 * 10);
+  setInterval(auth.token, 1000 * 60 * 1);
 
   render(
     <AppContainer>
@@ -95,18 +95,23 @@ function dispatchOnMode() {
       // eslint-disable-next-line consistent-return
       }) => {
         console.log('env auth0', body);
-        auth.initService(body).parseHash({ hash: window.location.hash }, (err, authResult) => {
+        const auth0 = auth.initService(body);
+        auth.setAuth0(auth0);
+        // eslint-disable-next-line consistent-return
+        auth0.parseHash({ hash: window.location.hash }, (err, authResult) => {
           if (err) {
             return console.log(err);
           }
 
-          auth.initService(body).client.userInfo(authResult.accessToken, (err2, user) => {
+          // eslint-disable-next-line consistent-return
+          auth0.client.userInfo(authResult.accessToken, (err2, user) => {
             // Now you have the user's information
-            user.admin = false;
+            const userr = user;
+            userr.admin = false;
             if (err2) {
               return console.log(err2);
             }
-            auth.initExport(idToken).then(initAuthenticated(user, body));
+            auth.initExport(idToken).then(initAuthenticated(userr, body));
           });
         });
       });

--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -65,7 +65,7 @@ function initWithAuthToken(locale) {
 function initNotAuthenticated(msg) {
   document.querySelector('#root').innerHTML = msg;
 }
-const locales = new Set([1, 2, 3, 4, 5]);
+const locales = new Set(['en', 'es', 'fr']);
 function userLocale(lo) {
   if (lo) {
     const l = lo.toLowerCase().substring(0, 2);

--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -86,7 +86,7 @@ function dispatchOnMode() {
   } else if (accessToken != null) {
     auth.initExport(accessToken).then(initAuthenticated(queryParams.locale));
   } else {
-    const idToken = queryString.parse(location.hash).id_token;
+//    const idToken = queryString.parse(location.hash).id_token;
     console.log(queryString.parse(location.hash));
     get('/env', { auth: 'auth0' })
     .then(

--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -108,10 +108,13 @@ function dispatchOnMode() {
             // Now you have the user's information
             const userr = user;
             userr.admin = false;
+            userr.firstName = user.firstName || user.given_name;
+            userr.lastName = user.lastName || user.family_name;
+            userr.username = user.username || user.nickname;
             if (err2) {
               return console.log(err2);
             }
-            auth.initExport(idToken).then(initAuthenticated(userr, body));
+            initAuthenticated(userr, body);
           });
         });
       });

--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -11,6 +11,7 @@ import { init as initAnalytics } from './utilities/analytics';
 import queryString from 'querystringify';
 import url from 'url';
 import { get } from './utilities/api';
+import Raven from 'raven-js';
 
 function initAuthenticated(profile, env) {
   const initialState = { profile, env };
@@ -115,6 +116,9 @@ function dispatchOnMode() {
 
           // eslint-disable-next-line consistent-return
           auth0.client.userInfo(authResult.accessToken, (err2, user) => {
+            if (err2) {
+              return console.log(err2);
+            }
             // Now you have the user's information
             const userr = user;
             userr.admin = false;
@@ -122,9 +126,10 @@ function dispatchOnMode() {
             userr.lastName = user.lastName || user.family_name;
             userr.attributes = user.attributes || { locale: [userLocale(user.locale)] };
             userr.username = user.username || user.nickname;
-            if (err2) {
-              return console.log(err2);
+            if (process.env.NODE_ENV === 'production') {
+              Raven.setUserContext(userr);
             }
+
             initAuthenticated(userr, body);
           });
         });

--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -65,6 +65,16 @@ function initWithAuthToken(locale) {
 function initNotAuthenticated(msg) {
   document.querySelector('#root').innerHTML = msg;
 }
+const locales = new Set([1, 2, 3, 4, 5]);
+function userLocale(lo) {
+  if (lo) {
+    const l = lo.toLowerCase().substring(0, 2);
+    if (locales.has(l)) {
+      return l;
+    }
+  }
+  return 'en';
+}
 
 function dispatchOnMode() {
   const queryParams = queryString.parse(location.search);
@@ -110,6 +120,7 @@ function dispatchOnMode() {
             userr.admin = false;
             userr.firstName = user.firstName || user.given_name;
             userr.lastName = user.lastName || user.family_name;
+            userr.attributes = user.attributes || { locale: [userLocale(user.locale)] };
             userr.username = user.username || user.nickname;
             if (err2) {
               return console.log(err2);

--- a/client/src/components/modals/createDataset/AkvoFlowDataSourceSettings.jsx
+++ b/client/src/components/modals/createDataset/AkvoFlowDataSourceSettings.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { injectIntl, intlShape } from 'react-intl';
 
 import * as api from '../../../utilities/api';
-import * as keycloak from '../../../utilities/auth';
+import * as auth from '../../../utilities/auth';
 import { showNotification } from '../../../actions/notification';
 
 require('../../../../node_modules/react-select/dist/react-select.css');
@@ -186,7 +186,7 @@ class AkvoFlowDataSourceSettings extends Component {
       instance,
       surveyId: selectedSurveyId,
       formId: selectedFormId,
-      refreshToken: keycloak.refreshToken(),
+      refreshToken: auth.refreshToken(),
       version: 3,
     });
     this.props.onChangeSettings({ name: form.name });

--- a/client/src/components/workspace-nav/OrganizationMenu.jsx
+++ b/client/src/components/workspace-nav/OrganizationMenu.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-function OrganizationMenu({ profile, keycloakURL }) {
+function OrganizationMenu({ profile, authURL }) {
   return (
     <div className="OrganizationMenu">
       <div className="name">
-        <a href={`${keycloakURL}/realms/akvo/account`}>
+        <a href={`${authURL}/realms/akvo/account`}>
           <i className="fa fa-user-o" aria-hidden="true" /> {profile.username}
         </a>
       </div>
@@ -16,7 +16,7 @@ function OrganizationMenu({ profile, keycloakURL }) {
 }
 
 OrganizationMenu.propTypes = {
-  keycloakURL: PropTypes.string.isRequired,
+  authURL: PropTypes.string.isRequired,
   profile: PropTypes.shape({
     username: PropTypes.string,
   }).isRequired,
@@ -24,7 +24,7 @@ OrganizationMenu.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    keycloakURL: state.env.keycloakURL,
+    authURL: state.env.authURL,
   };
 }
 

--- a/client/src/components/workspace-nav/OrganizationMenu.jsx
+++ b/client/src/components/workspace-nav/OrganizationMenu.jsx
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 function OrganizationMenu({ profile, authURL }) {
+  const url = authURL.includes('auth0') ? 'https://manage.auth0.com' : `${authURL}/realms/akvo/account`;
   return (
     <div className="OrganizationMenu">
       <div className="name">
-        <a href={`${authURL}/realms/akvo/account`}>
+        <a href={url}>
           <i className="fa fa-user-o" aria-hidden="true" /> {profile.username}
         </a>
       </div>

--- a/client/src/components/workspace-nav/OrganizationMenu.jsx
+++ b/client/src/components/workspace-nav/OrganizationMenu.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import * as auth from './../../utilities/auth';
 
 function OrganizationMenu({ profile, authURL }) {
   const url = authURL.includes('auth0') ? 'https://manage.auth0.com' : `${authURL}/realms/akvo/account`;
+  const logout = authURL.includes('auth0') ? <a onClick={() => auth.logout()}>&nbsp; <i className="fa fa-power-off" aria-hidden="true" /> LOGOUT</a> : '';
   return (
     <div className="OrganizationMenu">
       <div className="name">
         <a href={url}>
           <i className="fa fa-user-o" aria-hidden="true" /> {profile.username}
         </a>
+        {logout}
       </div>
       <div className="organization">Akvo Lumen</div>
     </div>

--- a/client/src/containers/App.jsx
+++ b/client/src/containers/App.jsx
@@ -21,6 +21,7 @@ export default function App({ history, location }) {
       <Router history={history}>
         <Route path="/" component={Main}>
           <IndexRedirect from="" to="library" />
+          <Redirect from="auth0/callback" to="/" />
           <Route
             path="library"
             components={{ sidebar: WorkspaceNav, content: Library }}

--- a/client/src/containers/App.jsx
+++ b/client/src/containers/App.jsx
@@ -20,8 +20,8 @@ export default function App({ history, location }) {
     <IntlWrapper>
       <Router history={history}>
         <Route path="/" component={Main}>
+          <Redirect from="auth0_callback" to="/" />
           <IndexRedirect from="" to="library" />
-          <Redirect from="auth0/callback" to="/" />
           <Route
             path="library"
             components={{ sidebar: WorkspaceNav, content: Library }}

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-underscore-dangle */
 import Keycloak from 'keycloak-js';
 import Auth0 from 'auth0-js';
-import Raven from 'raven-js';
 import queryString from 'querystringify';
 import url from 'url';
+import * as k from './keycloak';
 
 import { get } from './api';
 
@@ -11,27 +11,31 @@ let keycloak = null;
 let auth0 = null;
 let accessToken = null;
 
+function service() {
+  if (keycloak) {
+    return keycloak;
+  }
+  return auth0;
+}
+function lib() {
+  if (keycloak) {
+    return k;
+  }
+  return null;
+}
+
 export function token() {
-  if (!keycloak) {
+  if (!service()) {
     return Promise.resolve(accessToken);
   }
-
-  return new Promise(resolve =>
-    keycloak
-      .updateToken()
-      .success(() => resolve(keycloak.token))
-      .error(() => {
-        // Redirect to login page
-        keycloak.login();
-      })
-  );
+  return lib().token(service());
 }
 
 export function refreshToken() {
-  if (keycloak == null) {
-    throw new Error('Keycloak not initialized');
+  if (service() == null) {
+    throw new Error('Auth not initialized');
   }
-  return keycloak.refreshToken;
+  return lib().refreshToken(service());
 }
 
 export function init() {
@@ -42,75 +46,37 @@ export function init() {
   return get('/env', { auth })
     .then(
       ({
-        body: {
+        body,
+      // eslint-disable-next-line consistent-return
+      }) => {
+        const {
           keycloakClient,
-          authURL,
           authProvider,
-          tenant,
-          sentryDSN,
-          flowApiUrl,
-          piwikSiteId,
-          exporterUrl,
-        },
-      }) =>
-        new Promise((resolve, reject) => {
-          if (process.env.NODE_ENV === 'production') {
-            Raven.config(sentryDSN).install();
-            Raven.setExtraContext({ tenant });
+          authURL,
+        } = body;
+        if (authProvider === 'keycloak') {
+          if (keycloak != null) {
+            throw new Error('Keycloak already initialized');
           }
-
-          const queryParams = queryString.parse(location.search);
-
-          if (authProvider === 'keycloak') {
-            keycloak = new Keycloak({
-              url: authURL,
-              realm: 'akvo',
-              clientId: keycloakClient,
-            });
-
-            keycloak
-            .init({
-              onLoad: 'login-required',
-              checkLoginIframe: false,
-              token: queryParams.token,
-              refreshToken: queryParams.refresh_token,
-            })
-            .success((authenticated) => {
-              if (authenticated) {
-                keycloak
-                  .loadUserProfile()
-                  .success((profile) => {
-                    if (process.env.NODE_ENV === 'production') {
-                      Raven.setUserContext(profile);
-                    }
-                    resolve({
-                      profile: Object.assign({}, profile, {
-                        admin: keycloak.hasRealmRole(`akvo:lumen:${tenant}:admin`),
-                      }),
-                      env: { flowApiUrl, authURL, piwikSiteId, exporterUrl },
-                    });
-                  })
-                  .error(() => {
-                    reject(new Error('Could not load user profile'));
-                  });
-              } else {
-                reject(new Error('Could not authenticate'));
-              }
-            })
-            .error(() => {
-              reject(new Error('Login attempt failed'));
-            });
-          } else if (authProvider === 'auth0') {
-            auth0 = new Auth0.WebAuth({
-              domain: url.parse(authURL).host,
-              clientID: 'kU4u9d2IJIMXnTGUe7WZ7ITi9c7VN0An',
-              redirectUri: 'http://t1.lumen.local:3030/auth0/callback',
-              responseType: 'token id_token',
-              scope: 'openid email',
-            });
-            auth0.authorize();
-          }
-        })
+          keycloak = new Keycloak({
+            url: authURL,
+            realm: 'akvo',
+            clientId: keycloakClient,
+          });
+          keycloak.token = k.token;
+          return k.init(body, keycloak);
+        } else if (authProvider === 'auth0') {
+          auth0 = new Auth0.WebAuth({
+            domain: url.parse(authURL).host,
+            clientID: 'kU4u9d2IJIMXnTGUe7WZ7ITi9c7VN0An',
+            redirectUri: 'http://t1.lumen.local:3030/auth0/callback',
+            responseType: 'token id_token',
+            audience: 't1.lumen.local:3030',
+            scope: 'openid email',
+          });
+          auth0.authorize();
+        }
+      }
     );
 }
 

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -3,6 +3,7 @@ import Keycloak from 'keycloak-js';
 import Auth0 from 'auth0-js';
 import url from 'url';
 import * as k from './keycloak';
+import * as a0 from './auth0';
 import { get } from './api';
 
 let keycloak = null;
@@ -15,11 +16,20 @@ function service() {
   }
   return auth0;
 }
+
+export function setKeycloak(K) {
+  keycloak = K;
+}
+export function setAuth0(A) {
+  auth0 = A;
+}
+
+
 function lib() {
   if (keycloak) {
     return k;
   }
-  return null;
+  return a0;
 }
 
 export function token() {
@@ -54,10 +64,15 @@ export function initService(env) {
       clientID: 'kU4u9d2IJIMXnTGUe7WZ7ITi9c7VN0An',
       redirectUri: 'http://t1.lumen.local:3030/auth0_callback',
       responseType: 'token id_token',
-      audience: 't1.lumen.local:3030',
       scope: 'openid email profile',
+      audience: 'https://tangrammer.eu.auth0.com/userinfo',
+      connection: 'google-oauth2',
+//      once: '1',
+//      state: '1',
+
     });
   }
+
   return s;
 }
 export function init(env, s) {

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -1,10 +1,8 @@
 /* eslint-disable no-underscore-dangle */
 import Keycloak from 'keycloak-js';
 import Auth0 from 'auth0-js';
-import queryString from 'querystringify';
 import url from 'url';
 import * as k from './keycloak';
-
 import { get } from './api';
 
 let keycloak = null;
@@ -37,47 +35,47 @@ export function refreshToken() {
   }
   return lib().refreshToken(service());
 }
-
-export function init() {
+export function initService(env) {
+  const {
+    keycloakClient,
+    authProvider,
+    authURL,
+  } = env;
+  let s = null;
+  if (authProvider === 'keycloak') {
+    s = new Keycloak({
+      url: authURL,
+      realm: 'akvo',
+      clientId: keycloakClient,
+    });
+  } else {
+    s = new Auth0.WebAuth({
+      domain: url.parse(authURL).host,
+      clientID: 'kU4u9d2IJIMXnTGUe7WZ7ITi9c7VN0An',
+      redirectUri: 'http://t1.lumen.local:3030/auth0_callback',
+      responseType: 'token id_token',
+      audience: 't1.lumen.local:3030',
+      scope: 'openid email profile',
+    });
+  }
+  return s;
+}
+export function init(env, s) {
   if (keycloak != null) {
     throw new Error('Keycloak already initialized');
   }
-  const auth = queryString.parse(location.search).auth || 'keycloak';
-  return get('/env', { auth })
-    .then(
-      ({
-        body,
-      // eslint-disable-next-line consistent-return
-      }) => {
-        const {
-          keycloakClient,
-          authProvider,
-          authURL,
-        } = body;
-        if (authProvider === 'keycloak') {
-          if (keycloak != null) {
-            throw new Error('Keycloak already initialized');
-          }
-          keycloak = new Keycloak({
-            url: authURL,
-            realm: 'akvo',
-            clientId: keycloakClient,
-          });
-          keycloak.token = k.token;
-          return k.init(body, keycloak);
-        } else if (authProvider === 'auth0') {
-          auth0 = new Auth0.WebAuth({
-            domain: url.parse(authURL).host,
-            clientID: 'kU4u9d2IJIMXnTGUe7WZ7ITi9c7VN0An',
-            redirectUri: 'http://t1.lumen.local:3030/auth0/callback',
-            responseType: 'token id_token',
-            audience: 't1.lumen.local:3030',
-            scope: 'openid email',
-          });
-          auth0.authorize();
-        }
-      }
-    );
+  if (env.authProvider === 'keycloak') {
+    if (keycloak != null) {
+      throw new Error('Keycloak already initialized');
+    }
+    keycloak = s;
+    return lib().init(env, service());
+  } else if (env.authProvider === 'auth0') {
+    auth0 = s;
+    auth0.authorize();
+    return new Promise(() => null);
+  }
+  return null;
 }
 
 export function initPublic() {

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -41,7 +41,7 @@ export function init() {
       ({
         body: {
           keycloakClient,
-          keycloakURL,
+          authURL,
           tenant,
           sentryDSN,
           flowApiUrl,
@@ -55,7 +55,7 @@ export function init() {
             Raven.setExtraContext({ tenant });
           }
           keycloak = new Keycloak({
-            url: keycloakURL,
+            url: authURL,
             realm: 'akvo',
             clientId: keycloakClient,
           });
@@ -81,7 +81,7 @@ export function init() {
                       profile: Object.assign({}, profile, {
                         admin: keycloak.hasRealmRole(`akvo:lumen:${tenant}:admin`),
                       }),
-                      env: { flowApiUrl, keycloakURL, piwikSiteId, exporterUrl },
+                      env: { flowApiUrl, authURL, piwikSiteId, exporterUrl },
                     });
                   })
                   .error(() => {

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -17,6 +17,7 @@ function service() {
   return auth0;
 }
 
+
 export function setKeycloak(K) {
   keycloak = K;
 }
@@ -30,6 +31,10 @@ function lib() {
     return k;
   }
   return a0;
+}
+
+export function logout() {
+  lib().logout(service());
 }
 
 export function token() {
@@ -72,7 +77,6 @@ export function initService(env) {
 
     });
   }
-
   return s;
 }
 export function init(env, s) {

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -67,7 +67,7 @@ export function initService(env) {
     s = new Auth0.WebAuth({
       domain: url.parse(authURL).host,
       clientID: 'D5LayiXP1pzq-6g2B_QVvzCw_eycZxQK',
-      redirectUri: 'http://t1.lumen.local:3030/auth0_callback',
+      redirectUri: `${location.protocol}//${location.host}/auth0_callback`,
       responseType: 'token id_token',
       scope: 'openid email profile',
       audience: 'https://akvotest.eu.auth0.com/userinfo',

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -104,11 +104,10 @@ export function init() {
             auth0 = new Auth0.WebAuth({
               domain: url.parse(authURL).host,
               clientID: 'kU4u9d2IJIMXnTGUe7WZ7ITi9c7VN0An',
-              redirectUri: 'http://t1.lumen.local:3030/',
+              redirectUri: 'http://t1.lumen.local:3030/auth0/callback',
               responseType: 'token id_token',
               scope: 'openid email',
             });
-            alert('auth0 selected');
             auth0.authorize();
           }
         })

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -42,6 +42,7 @@ export function init() {
         body: {
           keycloakClient,
           authURL,
+          authProvider,
           tenant,
           sentryDSN,
           flowApiUrl,
@@ -54,15 +55,17 @@ export function init() {
             Raven.config(sentryDSN).install();
             Raven.setExtraContext({ tenant });
           }
-          keycloak = new Keycloak({
-            url: authURL,
-            realm: 'akvo',
-            clientId: keycloakClient,
-          });
 
           const queryParams = queryString.parse(location.search);
 
-          keycloak
+          if (authProvider === 'keycloak') {
+            keycloak = new Keycloak({
+              url: authURL,
+              realm: 'akvo',
+              clientId: keycloakClient,
+            });
+
+            keycloak
             .init({
               onLoad: 'login-required',
               checkLoginIframe: false,
@@ -94,6 +97,9 @@ export function init() {
             .error(() => {
               reject(new Error('Login attempt failed'));
             });
+          } else if (authProvider === 'auth0') {
+            alert('auth0 selected');
+          }
         })
     );
 }

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -52,7 +52,7 @@ export function refreshToken() {
 }
 export function initService(env) {
   const {
-    keycloakClient,
+    authClientId,
     authProvider,
     authURL,
   } = env;
@@ -61,16 +61,16 @@ export function initService(env) {
     s = new Keycloak({
       url: authURL,
       realm: 'akvo',
-      clientId: keycloakClient,
+      clientId: authClientId,
     });
   } else {
     s = new Auth0.WebAuth({
       domain: url.parse(authURL).host,
-      clientID: 'D5LayiXP1pzq-6g2B_QVvzCw_eycZxQK',
+      clientID: authClientId,
       redirectUri: `${location.protocol}//${location.host}/auth0_callback`,
       responseType: 'token id_token',
       scope: 'openid email profile',
-      audience: 'https://akvotest.eu.auth0.com/userinfo',
+      audience: `${authURL}/userinfo`,
       connection: 'google-oauth2',
 //      once: '1',
 //      state: '1',

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -66,11 +66,11 @@ export function initService(env) {
   } else {
     s = new Auth0.WebAuth({
       domain: url.parse(authURL).host,
-      clientID: 'kU4u9d2IJIMXnTGUe7WZ7ITi9c7VN0An',
+      clientID: 'D5LayiXP1pzq-6g2B_QVvzCw_eycZxQK',
       redirectUri: 'http://t1.lumen.local:3030/auth0_callback',
       responseType: 'token id_token',
       scope: 'openid email profile',
-      audience: 'https://tangrammer.eu.auth0.com/userinfo',
+      audience: 'https://akvotest.eu.auth0.com/userinfo',
       connection: 'google-oauth2',
 //      once: '1',
 //      state: '1',

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -1,11 +1,14 @@
 /* eslint-disable no-underscore-dangle */
 import Keycloak from 'keycloak-js';
+import Auth0 from 'auth0-js';
 import Raven from 'raven-js';
 import queryString from 'querystringify';
+import url from 'url';
 
 import { get } from './api';
 
 let keycloak = null;
+let auth0 = null;
 let accessToken = null;
 
 export function token() {
@@ -98,7 +101,15 @@ export function init() {
               reject(new Error('Login attempt failed'));
             });
           } else if (authProvider === 'auth0') {
+            auth0 = new Auth0.WebAuth({
+              domain: url.parse(authURL).host,
+              clientID: 'kU4u9d2IJIMXnTGUe7WZ7ITi9c7VN0An',
+              redirectUri: 'http://t1.lumen.local:3030/',
+              responseType: 'token id_token',
+              scope: 'openid email',
+            });
             alert('auth0 selected');
+            auth0.authorize();
           }
         })
     );

--- a/client/src/utilities/auth.js
+++ b/client/src/utilities/auth.js
@@ -35,7 +35,8 @@ export function init() {
   if (keycloak != null) {
     throw new Error('Keycloak already initialized');
   }
-  return get('/env')
+  const auth = queryString.parse(location.search).auth || 'keycloak';
+  return get('/env', { auth })
     .then(
       ({
         body: {

--- a/client/src/utilities/auth0.js
+++ b/client/src/utilities/auth0.js
@@ -1,0 +1,35 @@
+/* eslint-disable no-underscore-dangle */
+// import Raven from 'raven-js';
+// import queryString from 'querystringify';
+// import Auth0 from 'auth0-js';
+// import url from 'url';
+
+export function token(auth0) {
+  return new Promise((resolve) => {
+    console.log('auth0', auth0.client);
+    console.log(location);
+    auth0.checkSession({}, (err, authResult) => {
+      console.log('checkSessionerr', err);
+      console.log('checkSession', authResult);
+      resolve(authResult.idToken);
+    });
+  });
+}
+
+
+// eslint-disable-next-line no-unused-vars
+export function refreshToken(auht0) {
+  throw new Error('auth0 dont have refresh-tokens');
+}
+export function login(auth0) {
+  if (auth0 == null) {
+    throw new Error('auth0 not initialized');
+  }
+  return auth0.authorize();
+}
+
+// eslint-disable-next-line no-unused-vars
+export function init(env, auth0) {
+
+}
+

--- a/client/src/utilities/auth0.js
+++ b/client/src/utilities/auth0.js
@@ -16,6 +16,10 @@ export function token(auth0) {
   });
 }
 
+export function logout(auth0) {
+  auth0.logout({ returnTo: 'http://t1.lumen.local:3030' });
+}
+
 
 // eslint-disable-next-line no-unused-vars
 export function refreshToken(auht0) {

--- a/client/src/utilities/auth0.js
+++ b/client/src/utilities/auth0.js
@@ -17,7 +17,7 @@ export function token(auth0) {
 }
 
 export function logout(auth0) {
-  auth0.logout({ returnTo: 'http://t1.lumen.local:3030' });
+  auth0.logout({ returnTo: `${location.protocol}//${location.host}` });
 }
 
 

--- a/client/src/utilities/keycloak.js
+++ b/client/src/utilities/keycloak.js
@@ -1,0 +1,74 @@
+/* eslint-disable no-underscore-dangle */
+import Raven from 'raven-js';
+import queryString from 'querystringify';
+
+export function token(keycloak) {
+  return new Promise(resolve =>
+    keycloak
+      .updateToken()
+      .success(() => resolve(keycloak.token))
+      .error(() => {
+        // Redirect to login page
+        keycloak.login();
+      })
+  );
+}
+
+export function refreshToken(keycloak) {
+  if (keycloak == null) {
+    throw new Error('Keycloak not initialized');
+  }
+  return keycloak.refreshToken;
+}
+export function login(keycloak) {
+  if (keycloak == null) {
+    throw new Error('Keycloak not initialized');
+  }
+  return keycloak.login();
+}
+
+export function init(env, keycloak) {
+  const { tenant, sentryDSN } = env;
+  return new Promise((resolve, reject) => {
+    if (process.env.NODE_ENV === 'production') {
+      Raven.config(sentryDSN).install();
+      Raven.setExtraContext({ tenant });
+    }
+
+    const queryParams = queryString.parse(location.search);
+    keycloak
+    .init({
+      onLoad: 'login-required',
+      checkLoginIframe: false,
+      token: queryParams.token,
+      refreshToken: queryParams.refresh_token,
+    })
+    .success((authenticated) => {
+      if (authenticated) {
+        keycloak
+          .loadUserProfile()
+          .success((profile) => {
+            if (process.env.NODE_ENV === 'production') {
+              Raven.setUserContext(profile);
+            }
+            console.log('profile', profile);
+            resolve({
+              profile: Object.assign({}, profile, {
+                admin: keycloak.hasRealmRole(`akvo:lumen:${tenant}:admin`),
+              }),
+              env,
+            });
+          })
+          .error(() => {
+            reject(new Error('Could not load user profile'));
+          });
+      } else {
+        reject(new Error('Could not authenticate'));
+      }
+    })
+    .error(() => {
+      reject(new Error('Login attempt failed'));
+    });
+  });
+}
+

--- a/client/src/utilities/keycloak.js
+++ b/client/src/utilities/keycloak.js
@@ -26,6 +26,10 @@ export function login(keycloak) {
   }
   return keycloak.login();
 }
+// eslint-disable-next-line no-unused-vars
+export function logout(keycloak) {
+  throw new Error('Keycloak dont have this logout functionality');
+}
 
 export function init(env, keycloak) {
   const { tenant, sentryDSN } = env;


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

This PR offers auth0 behind a feature flag in client side. 


- [x] New ENV var `LUMEN_AUTH0_URL`  and `LUMEN_AUTH0_PUBLIC_CLIENT_ID`
- [x] client feature flag to select auth provider http://t1.lumen.local:3030?auth=auth0 or `http://t1.lumen.local:3030?auth=keycloak` ... the absense of value will select `keycloak` by default
- [ ] TODO: [refresh-token](https://github.com/akvo/akvo-lumen/pull/2222#issuecomment-505924175) auth0 technique https://github.com/akvo/akvo-lumen/issues/2228
- [x] Double check client side auth [uses](https://github.com/akvo/akvo-lumen/pull/2222#issuecomment-504454320)
- [x] Fix profile language locales
- [x] Fix profile user name
- [x] Log out `auth0Client.logout(...p) ` from [tutorial](https://auth0.com/docs/quickstart/spa/react)
- [x] Add google cloud auth0 credentials
- [x] use akvotest.eu.auth0.com instead of tangrammer.eu.auth0.com identity
- [x] feed all auth values with ENV data
- [x]  config Raven production  
- [ ] refactor and remove console.logs in client side
