### PR TITLE
[#2218] Call only once http open-id certs for each auth system

### DIFF
--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -59,7 +59,6 @@
  :akvo.lumen.endpoint.env/env {:routes-opts
                                {:middleware [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant]}
                                :keycloak #ig/ref :akvo.lumen.component.keycloak/data
-                               :keycloak-public-client-id #duct/env [ "LUMEN_KEYCLOAK_PUBLIC_CLIENT_ID" :or "akvo-lumen" ]
                                :flow-api #ig/ref :akvo.lumen.component.flow/api
                                :sentry-client-dsn #duct/env "LUMEN_SENTRY_CLIENT_DSN"
                                :piwik-site-id #duct/env "LUMEN_PIWIK_SITE_ID"}
@@ -169,7 +168,8 @@
  :akvo.lumen.component.caddisfly/prod {:schema-uri #duct/env [ "LUMEN_CADDISFLY_SCHEMA_URI" :or "https://s3-eu-west-1.amazonaws.com/akvoflow-public/caddisfly-tests-v2.json"]}
 
  :akvo.lumen.component.keycloak/data {:url #duct/env "LUMEN_KEYCLOAK_URL"
-                                      :realm "akvo"}
+                                      :realm "akvo"
+                                      :client-id #duct/env [ "LUMEN_KEYCLOAK_PUBLIC_CLIENT_ID" :or "akvo-lumen" ]}
 
  :akvo.lumen.component.keycloak/keycloak {:data #ig/ref :akvo.lumen.component.keycloak/data
                                           :credentials {:client_id #duct/env [ "LUMEN_KEYCLOAK_CLIENT_ID" :or "akvo-lumen-confidential" ]

--- a/backend/src/akvo/lumen/component/keycloak.clj
+++ b/backend/src/akvo/lumen/component/keycloak.clj
@@ -1,7 +1,8 @@
 (ns akvo.lumen.component.keycloak
   "We leverage Keycloak groups for tenant partition and admin roles.
    More info can be found in the Keycloak integration doc spec."
-  (:require [akvo.lumen.lib :as lib]
+  (:require [akvo.commons.jwt :as jwt]
+            [akvo.lumen.lib :as lib]
             [akvo.lumen.protocols :as p]
             [cheshire.core :as json]
             [clj-http.client :as client]
@@ -278,13 +279,26 @@
                        :credentials credentials}))
 
 (defmethod ig/init-key :akvo.lumen.component.keycloak/data  [_ {:keys [url realm] :as opts}]
-  opts)
+  (try
+    (let [issuer (str url "/realms/" realm)
+         rsa-key  (-> (str issuer "/protocol/openid-connect/certs")
+                      client/get
+                      :body
+                      (jwt/rsa-key 0))]
+     (assoc opts
+            :issuer issuer
+            :rsa-key rsa-key))
+    (catch Exception e
+      (log/error e "Could not get cert from Keycloak")
+      (throw e))))
 
 (s/def ::url string?)
+(s/def ::client-id string?)
 (s/def ::realm string?)
 
 (s/def ::data (s/keys :req-un [::url
-                               ::realm]))
+                               ::realm
+                               ::client-id]))
 
 (defmethod ig/pre-init-spec :akvo.lumen.component.keycloak/data [_]
   ::data)

--- a/backend/src/akvo/lumen/endpoint/env.clj
+++ b/backend/src/akvo/lumen/endpoint/env.clj
@@ -3,8 +3,7 @@
             [clojure.spec.alpha :as s]
             [ring.util.response :refer [response]]))
 
-(defn handler [{:keys [keycloak-public-client-id keycloak flow-api
-                        piwik-site-id sentry-client-dsn] :as opts}]
+(defn handler [{:keys [keycloak flow-api piwik-site-id sentry-client-dsn] :as opts}]
   (fn [{tenant :tenant :as request}]
     (response
      (cond-> {"authClientId" keycloak-public-client-id
@@ -23,15 +22,13 @@
 (defmethod ig/init-key :akvo.lumen.endpoint.env/env  [_ opts]
   (routes opts))
 
-(s/def ::keycloak-public-client-id string?)
 (s/def ::keycloak :akvo.lumen.component.keycloak/data)
 (s/def ::flow-api :akvo.lumen.component.flow/config)
 (s/def ::sentry-client-dsn string?)
 (s/def ::piwik-site-id string?)
 
 (defmethod ig/pre-init-spec :akvo.lumen.endpoint.env/env [_]
-  (s/keys :req-un [::keycloak-public-client-id
-                   ::keycloak
+  (s/keys :req-un [::keycloak
                    ::flow-api
                    ::sentry-client-dsn
                    ::piwik-site-id]))

--- a/backend/test/resources/test.edn
+++ b/backend/test/resources/test.edn
@@ -16,7 +16,8 @@
  :akvo.lumen.component.handler/handler {:middleware [#ig/ref :akvo.lumen.component.handler/wrap-stacktrace]}
 
  :akvo.lumen.component.keycloak/data {:url "http://auth.lumen.local:8080/auth"
-                                      :realm "akvo"}
+                                      :realm "akvo"
+                                      :client-id "akvo-lumen"}
 
  :akvo.lumen.component.keycloak/keycloak {:credentials
                                           {:client_id "akvo-lumen-confidential"
@@ -42,9 +43,7 @@
 
  :akvo.lumen.component.flow/api {:url "https://api.akvotest.org/flow"}
 
- :akvo.lumen.endpoint.env/env {:keycloak-public-client-id "akvo-lumen"
-                               :keycloak-url "http://auth.lumen.local:8080/auth"
-                               :sentry-client-dsn "dev-sentry-client-dsn"
+ :akvo.lumen.endpoint.env/env {:sentry-client-dsn "dev-sentry-client-dsn"
                                :piwik-site-id "165"}
  
  :akvo.lumen.migrate/migrate {:seed


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Currently we are calling open-id certs for every entrypoint we declare in config.edn, 

working with current keycloak `dev` environment doesn't affect performance thus the http calls are done in local docker, but switching to other not-local auth system  (like auth0) will slow the system startup in `dev` too

