### PR TITLE
[#2218] Add auth0 component [backend]

### DIFF
--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -171,6 +171,9 @@
                                       :realm "akvo"
                                       :client-id #duct/env [ "LUMEN_KEYCLOAK_PUBLIC_CLIENT_ID" :or "akvo-lumen" ]}
 
+ :akvo.lumen.component.auth0/data {:url #duct/env ["LUMEN_AUTH0_URL" :or "https://akvotest.eu.auth0.com"]
+                                   :client-id #duct/env [ "LUMEN_AUTH0_PUBLIC_CLIENT_ID" :or "D5LayiXP1pzq-6g2B_QVvzCw_eycZxQK"]}
+
  :akvo.lumen.component.keycloak/keycloak {:data #ig/ref :akvo.lumen.component.keycloak/data
                                           :credentials {:client_id #duct/env [ "LUMEN_KEYCLOAK_CLIENT_ID" :or "akvo-lumen-confidential" ]
                                                         :client_secret #duct/env "LUMEN_KEYCLOAK_CLIENT_SECRET"}}

--- a/backend/src/akvo/lumen/component/auth0.clj
+++ b/backend/src/akvo/lumen/component/auth0.clj
@@ -1,0 +1,34 @@
+(ns akvo.lumen.component.auth0
+  "moving to auth0"
+  (:require [akvo.commons.jwt :as jwt]
+            [akvo.lumen.lib :as lib]
+            [akvo.lumen.protocols :as p]
+            [cheshire.core :as json]
+            [clj-http.client :as client]
+            [integrant.core :as ig]
+            [clojure.spec.alpha :as s]
+            [clojure.set :as set]
+            [clojure.tools.logging :as log]
+            [ring.util.response :refer [response]]))
+
+(defmethod ig/init-key :akvo.lumen.component.auth0/data  [_ {:keys [url] :as opts}]
+  (try
+    (let [issuer (format "%s/" url)
+          rsa-key  (-> (format  "%s.well-known/jwks.json" issuer)
+                             client/get
+                             :body
+                             (jwt/rsa-key 0))]
+      (assoc opts
+             :issuer issuer
+             :rsa-key rsa-key))
+    (catch Exception e
+      (log/error e "Could not get cert from auth0")
+      (throw e))))
+
+(s/def ::url string?)
+(s/def ::client-id string?)
+
+(s/def ::data (s/keys :req-un [::url ::client-id]))
+
+(defmethod ig/pre-init-spec :akvo.lumen.component.auth0/data [_]
+  ::data)

--- a/backend/test/resources/test.edn
+++ b/backend/test/resources/test.edn
@@ -19,6 +19,9 @@
                                       :realm "akvo"
                                       :client-id "akvo-lumen"}
 
+ :akvo.lumen.component.auth0/data {:url "https://akvotest.eu.auth0.com"
+                                   :client-id "D5LayiXP1pzq-6g2B_QVvzCw_eycZxQK"}
+
  :akvo.lumen.component.keycloak/keycloak {:credentials
                                           {:client_id "akvo-lumen-confidential"
                                            :client_secret "caed3964-09dd-4752-b0bb-22c8e8ffd631"}}


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

So far, this component is in charge of wrapping auth0 config data and to get the rsa-cert doing an http call ... so same functionality as the current keycloak component