### PR TITLE
Sign up with auth0

### DIFF
--- a/backend/resources/akvo/lumen/email/auth0/create_new_account_and_invite_to_tenant.txt
+++ b/backend/resources/akvo/lumen/email/auth0/create_new_account_and_invite_to_tenant.txt
@@ -1,0 +1,12 @@
+Hi!
+
+You have been invited to join Akvo Lumen by {{author-email}}.
+To complete the invitation process please visit:
+{{location}}/verify/{{invite-id}}?auth=auth0
+
+
+Then, using your email: {{email}} you need to click on "Sign up" or, in case that your email is managed by Google, you could also use the "Log in with Google" button
+
+Thank you
+
+The Akvo Lumen Team

--- a/backend/resources/akvo/lumen/email/auth0/invite_to_tenant.txt
+++ b/backend/resources/akvo/lumen/email/auth0/invite_to_tenant.txt
@@ -1,0 +1,11 @@
+Hi!
+
+You have been invited to join Akvo Lumen by {{author-email}}.
+To complete the invitation process please visit:
+{{location}}/verify/{{invite-id}}?auth=auth0
+
+Then, using your email: {{email}} you need to click on "Sign up" or, in case that your email is managed by Google, you could also use the "Log in with Google" button
+
+Thank you
+
+The Akvo Lumen Team

--- a/backend/resources/akvo/lumen/email/keycloak/create_new_account_and_invite_to_tenant.txt
+++ b/backend/resources/akvo/lumen/email/keycloak/create_new_account_and_invite_to_tenant.txt
@@ -2,7 +2,9 @@ Hi!
 
 You have been invited to join Akvo Lumen by {{author-email}}.
 To complete the invitation process please visit:
-{{location}}/verify/{{invite-id}}?{{feature-flags}}
+{{location}}/verify/{{invite-id}}
+Using your email: {{email}}
+and the temporary password: {{tmp-password}} to login.
 
 Thank you
 

--- a/backend/resources/akvo/lumen/email/keycloak/invite_to_tenant.txt
+++ b/backend/resources/akvo/lumen/email/keycloak/invite_to_tenant.txt
@@ -2,9 +2,7 @@ Hi!
 
 You have been invited to join Akvo Lumen by {{author-email}}.
 To complete the invitation process please visit:
-{{location}}/verify/{{invite-id}}?{{feature-flags}}
-Using your email: {{email}}
-and the temporary password: {{tmp-password}} to login.
+{{location}}/verify/{{invite-id}}
 
 Thank you
 

--- a/backend/src/akvo/lumen/endpoint/invite.clj
+++ b/backend/src/akvo/lumen/endpoint/invite.clj
@@ -23,12 +23,12 @@
                :handler (fn [{tenant :tenant
                               jwt-claims :jwt-claims
                               body :body :as request}]
-                          (let [client-feature-flags  [(if (= (get jwt-claims "iss") (:issuer auth0))
-                                                         "auth=auth0"
-                                                         "auth=keycloak")]]
-                            (user/create-invite emailer keycloak (p/connection tenant-manager tenant)
+                          (let [auth-type            (if (= (get jwt-claims "iss") (:issuer auth0))
+                                                       :auth0
+                                                       :keycloak)]
+                            (user/create-invite emailer keycloak (p/connection tenant-manager tenant) auth-type
                                                 tenant (location (:invite-redirect config) request)
-                                                (get body "email") jwt-claims client-feature-flags)))}}]
+                                                (get body "email") jwt-claims)))}}]
    ["/:id" {:delete {:parameters {:path-params {:id string?}}
                      :handler (fn [{tenant :tenant
                                  {:keys [id]} :path-params}]

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -344,9 +344,8 @@
               (is (= email (-> invitation :recipients first)))
               (is (= "Akvo Lumen invite" (-> invitation :email (get "Subject"))))             
               (let [url (str/replace (re-find #"https.*+" (-> invitation :email (get "Text-part"))) "https://t1.lumen.local" "")
-                    [url auth-flag] (str/split url #"\?")
-                    auth (last (str/split auth-flag #"&"))
-                    res-verify (h (get* url {"auth" auth}))]
+
+                    res-verify (h (get* url ))]
                 (is (= 302 (:status res-verify))))
               (let [users (-> (h (get* (api-url "/admin/users"))) body-kw :users)]
                 (is (= 200 (:status (h (del* (api-url "/admin/users" (:id (first (filter #(= email (:email %)) users))))))))))))))

--- a/backend/test/akvo/lumen/lib/user_test.clj
+++ b/backend/test/akvo/lumen/lib/user_test.clj
@@ -68,8 +68,8 @@
   (testing "Create invite"
     (let [number-of-initial-invites (-> (user/active-invites  *tenant-conn*)
                                         variant/value :invites count)
-          resp (user/create-invite *emailer* *keycloak* *tenant-conn* "t1"
-                                   server-name ruth-email author-claims ["auth=keycloak"])]
+          resp (user/create-invite *emailer* *keycloak* *tenant-conn* :keycloak "t1"
+                                   server-name ruth-email author-claims)]
       (is (= ::lib/ok (variant/tag resp)))
       (is (= (inc number-of-initial-invites)
              (-> (user/active-invites *tenant-conn*)
@@ -91,8 +91,8 @@
 
   (testing "Invite user"
 
-    (let [invite-resp (user/create-invite *emailer* *keycloak* *tenant-conn* "t1"
-                                   server-name ruth-email author-claims ["auth=keycloak"])
+    (let [invite-resp (user/create-invite *emailer* *keycloak* *tenant-conn* :keycloak "t1"
+                                   server-name ruth-email author-claims)
           number-of-original-users (-> (user/users *keycloak* "t1")
                                        variant/value :users count)
           invite-id (-> (user/active-invites *tenant-conn*)

--- a/client/src/components/Users.jsx
+++ b/client/src/components/Users.jsx
@@ -320,7 +320,6 @@ Users.propTypes = {
   profile: PropTypes.shape({
     admin: PropTypes.bool,
     email: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
   }).isRequired,
   dispatch: PropTypes.func.isRequired,


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

After agreeing with Jana about sending an email with auth0 to add the specific email account to use, this PR adds specific email templates for each auth system option (keycloak and auth0) 

About keeping the verification link in auth0 version is just to keep compatibility with keycloak, that's to say that we could remove it once keycloak is removed. So far it's needed  thus keycloak users verification-email is supported by lumen and authorisation is based on keycloak users and verification-email by lumen




