### PR TITLE
Avoid refresh-token support with no auth in internal-flow-api 

### DIFF
--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -51,6 +51,7 @@
  :akvo.lumen.endpoint.dashboard/dashboard {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
 
  :akvo.lumen.component.flow/api {:url #duct/env "LUMEN_FLOW_API_URL"
+                                 :internal-url "http://flow-api-internal"
                                  :keycloak #ig/ref :akvo.lumen.component.keycloak/data}
 
  :akvo.lumen.endpoint.dataset/dataset {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -50,9 +50,15 @@
 
  :akvo.lumen.endpoint.dashboard/dashboard {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
 
+ :akvo.lumen.component.flow/api-headers {}
+
+ :akvo.lumen.component.flow/internal-api-headers {}
+
  :akvo.lumen.component.flow/api {:url #duct/env "LUMEN_FLOW_API_URL"
                                  :internal-url "http://flow-api-internal"
-                                 :keycloak #ig/ref :akvo.lumen.component.keycloak/data}
+                                 :keycloak #ig/ref :akvo.lumen.component.keycloak/data
+                                 :api-headers #ig/ref :akvo.lumen.component.flow/api-headers
+                                 :internal-api-headers #ig/ref :akvo.lumen.component.flow/internal-api-headers}
 
  :akvo.lumen.endpoint.dataset/dataset {:tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager
                                        :error-tracker #ig/ref :akvo.lumen.component.error-tracker/error-tracker

--- a/backend/src/akvo/lumen/auth.clj
+++ b/backend/src/akvo/lumen/auth.clj
@@ -92,7 +92,9 @@
           (try
             (if-let [claims (or (jwt/verified-claims token keycloak-verifier (:issuer keycloak) {})
                                 (jwt/verified-claims token auth0-verifier (:issuer auth0) {}))]
-              (handler (assoc req :jwt-claims claims))
+              (handler (assoc req
+                              :jwt-claims claims
+                              :jwt-token token))
               (handler req))
             (catch ParseException e
               (handler req)))

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -23,13 +23,19 @@
         :body
         :access_token)))
 
-
-(defn api-headers
-  [token]
-  {"Authorization" (format "Bearer %s" token)
-   "User-Agent" "lumen"
+(def commons-api-headers
+  {"User-Agent" "lumen"
    "Accept" "application/vnd.akvo.flow.v2+json"})
 
+(defn api-headers
+  "JWT token required thus the call could be used externally"
+  [token]
+  (merge commons-api-headers {"Authorization" (format "Bearer %s" token)}))
+
+(defn internal-api-headers
+  "No authorization is required thus it's an internal owned k8s call"
+  [email]
+  (merge commons-api-headers {"X-Akvo-Email" email}))
 
 (defn check-permissions
   [flow-api token body]

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -8,33 +8,18 @@
 
 (def http-client-req-defaults (http.client/req-opts 5000))
 
-(defn access-token
-  "Fetch a new access token using a refresh token"
-  [this refresh-token]
-  (let [token-endpoint (format "%s/realms/%s/protocol/openid-connect/token"
-                               (-> this :keycloak :url)
-                               (-> this :keycloak :realm))]
-    (-> (http.client/post* token-endpoint
-                           (merge http-client-req-defaults
-                                 {:form-params {"client_id" "akvo-lumen"
-                                                "refresh_token" refresh-token
-                                                "grant_type" "refresh_token"}
-                                  :as :json}))
-        :body
-        :access_token)))
-
 (def commons-api-headers
   {"User-Agent" "lumen"
    "Accept" "application/vnd.akvo.flow.v2+json"})
 
 (defn api-headers
   "JWT token required thus the call could be used externally"
-  [token]
+  [{:keys [token]}]
   (merge commons-api-headers {"Authorization" (format "Bearer %s" token)}))
 
 (defn internal-api-headers
   "No authorization is required thus it's an internal owned k8s call"
-  [email]
+  [{:keys [email]}]
   (merge commons-api-headers {"X-Akvo-Email" email}))
 
 (defn check-permissions

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -22,6 +22,18 @@
   [{:keys [email]}]
   (merge commons-api-headers {"X-Akvo-Email" email}))
 
+(defmethod ig/init-key ::api-headers  [_ _]
+  api-headers)
+
+(defmethod ig/init-key ::internal-api-headers  [_ _]
+  internal-api-headers)
+
+(defmethod ig/pre-init-spec ::api-headers [_]
+  empty?)
+
+(defmethod ig/pre-init-spec ::internal-api-headers [_]
+  empty?)
+
 (defn check-permissions
   [flow-api token body]
   (let [start (. System (nanoTime))
@@ -45,7 +57,9 @@
 (s/def ::url string?)
 (s/def ::internal-url string?)
 (s/def ::keycloak :akvo.lumen.component.keycloak/data)
-(s/def ::config (s/keys :req-un [::url ::internal-url ::keycloak]))
+(s/def ::api-headers fn?)
+(s/def ::internal-api-headers fn?)
+(s/def ::config (s/keys :req-un [::url ::internal-url ::keycloak ::api-headers ::internal-api-headers]))
 
 (defmethod ig/pre-init-spec ::api [_]
   ::config)

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -52,8 +52,9 @@
   opts)
 
 (s/def ::url string?)
+(s/def ::internal-url string?)
 (s/def ::keycloak :akvo.lumen.component.keycloak/data)
-(s/def ::config (s/keys :req-un [::url ::keycloak]))
+(s/def ::config (s/keys :req-un [::url ::internal-url ::keycloak]))
 
 (defmethod ig/pre-init-spec ::api [_]
   ::config)

--- a/backend/src/akvo/lumen/config.clj
+++ b/backend/src/akvo/lumen/config.clj
@@ -20,7 +20,8 @@
     (assert (:lumen-email-user env) (error-msg "LUMEN_EMAIL_USER"))
     (assert (:lumen-sentry-backend-dsn env) (error-msg "LUMEN_SENTRY_BACKEND_DSN"))
     (assert (:lumen-sentry-client-dsn env) (error-msg "LUMEN_SENTRY_CLIENT_DSN"))
-    (assert (:lumen-flow-api-url env) (error-msg "LUMEN_FLOW_API_URL"))))
+    (assert (:lumen-flow-api-url env) (error-msg "LUMEN_FLOW_API_URL"))
+    (assert (:lumen-flow-api-internal-url env) (error-msg "LUMEN_FLOW_API_INTERNAL_URL"))))
 
 (defn construct
   "Create a system definition."

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -108,7 +108,7 @@
     (lib/not-found {:error "Not found"})))
 
 (defn update
-  [tenant-conn import-config error-tracker dataset-id claims {:strs [token]}]
+  [tenant-conn import-config error-tracker dataset-id {:strs [token email]}]
   (if-let [{data-source-spec :spec
             data-source-id   :id} (data-source-by-dataset-id tenant-conn {:dataset-id dataset-id})]
     (if-let [error (transformation.merge-datasets/consistency-error? tenant-conn dataset-id)]
@@ -117,7 +117,7 @@
         (update/update-dataset tenant-conn import-config error-tracker dataset-id data-source-id
                                (-> data-source-spec
                                    (assoc-in ["source" "token"] token)
-                                   (assoc-in ["source" "email"] (get claims "email"))))
+                                   (assoc-in ["source" "email"] email)))
         (lib/bad-request {:error "Can't update uploaded dataset"})))
     (lib/not-found {:id dataset-id})))
 

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -108,14 +108,16 @@
     (lib/not-found {:error "Not found"})))
 
 (defn update
-  [tenant-conn import-config error-tracker dataset-id {refresh-token "refreshToken"}]
+  [tenant-conn import-config error-tracker dataset-id claims {:strs [token]}]
   (if-let [{data-source-spec :spec
             data-source-id   :id} (data-source-by-dataset-id tenant-conn {:dataset-id dataset-id})]
     (if-let [error (transformation.merge-datasets/consistency-error? tenant-conn dataset-id)]
       (lib/conflict error)
       (if-not (= (get-in data-source-spec ["source" "kind"]) "DATA_FILE")
         (update/update-dataset tenant-conn import-config error-tracker dataset-id data-source-id
-                               (assoc-in data-source-spec ["source" "refreshToken"] refresh-token))
+                               (-> data-source-spec
+                                   (assoc-in ["source" "token"] token)
+                                   (assoc-in ["source" "email"] (get claims "email"))))
         (lib/bad-request {:error "Can't update uploaded dataset"})))
     (lib/not-found {:id dataset-id})))
 

--- a/backend/src/akvo/lumen/lib/import/flow.clj
+++ b/backend/src/akvo/lumen/lib/import/flow.clj
@@ -12,12 +12,11 @@
 (defmethod import/dataset-importer "AKVO_FLOW"
   [{:strs [instance surveyId formId token email version] :as spec}
    {:keys [flow-api] :as config}]
-  (log/error :token token)
   (let [version (if version version 1)
-        headers-fn #(c.flow/api-headers {:email email :token token})
+        headers-fn #((:internal-api-headers flow-api) {:email email :token token})
         survey (delay (flow-common/survey-definition (:internal-url flow-api)
                                                      headers-fn
-                                                     instance?
+                                                     instance
                                                      surveyId))]
     (reify
       java.io.Closeable

--- a/backend/src/akvo/lumen/lib/import/flow.clj
+++ b/backend/src/akvo/lumen/lib/import/flow.clj
@@ -10,13 +10,14 @@
 
 
 (defmethod import/dataset-importer "AKVO_FLOW"
-  [{:strs [instance surveyId formId refreshToken version] :as spec}
+  [{:strs [instance surveyId formId token email version] :as spec}
    {:keys [flow-api] :as config}]
+  (log/error :token token)
   (let [version (if version version 1)
-        headers-fn #(c.flow/api-headers (c.flow/access-token flow-api refreshToken))
-        survey (delay (flow-common/survey-definition (:url flow-api)
+        headers-fn #(c.flow/api-headers {:email email :token token})
+        survey (delay (flow-common/survey-definition (:internal-url flow-api)
                                                      headers-fn
-                                                     instance
+                                                     instance?
                                                      surveyId))]
     (reify
       java.io.Closeable

--- a/backend/test/resources/test.edn
+++ b/backend/test/resources/test.edn
@@ -45,7 +45,8 @@
  :akvo.lumen.upload/data {:file-upload-path "/tmp/akvo/lumen"}
 
  :akvo.lumen.component.flow/api {:url "https://api.akvotest.org/flow"
-                                 :internal-url "https://api.akvotest.org/flow"}
+                                 :internal-url "https://api.akvotest.org/flow"
+                                 :internal-api-headers #ig/ref :akvo.lumen.component.flow/api-headers}
 
  :akvo.lumen.endpoint.env/env {:sentry-client-dsn "dev-sentry-client-dsn"
                                :piwik-site-id "165"}

--- a/backend/test/resources/test.edn
+++ b/backend/test/resources/test.edn
@@ -44,7 +44,8 @@
 
  :akvo.lumen.upload/data {:file-upload-path "/tmp/akvo/lumen"}
 
- :akvo.lumen.component.flow/api {:url "https://api.akvotest.org/flow"}
+ :akvo.lumen.component.flow/api {:url "https://api.akvotest.org/flow"
+                                 :internal-url "https://api.akvotest.org/flow"}
 
  :akvo.lumen.endpoint.env/env {:sentry-client-dsn "dev-sentry-client-dsn"
                                :piwik-site-id "165"}


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Relates #2228, implements https://github.com/akvo/akvo-lumen/issues/2228#issuecomment-521193513

Added integrant function `:akvo.lumen.component.flow/internal-api-headers` to inject different logic depending environment.
In `dev` and `test` envs we select api-_external_-headers logic so the jwt-token is passed from the frontend to the flow-api directly (though with a limited expired time)

We can increase the jwt-time-expiration in auth0 settings for akvo-auth0-`test` environment too so we could avoid time expiration problems related 