### PR TITLE
Adapt to flow-api-auth0 url

### DIFF
--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -55,6 +55,7 @@
  :akvo.lumen.component.flow/internal-api-headers {}
 
  :akvo.lumen.component.flow/api {:url #duct/env "LUMEN_FLOW_API_URL"
+                                 :auth0-url #duct/env "LUMEN_FLOW_API_AUTH0_URL"
                                  :internal-url "http://flow-api-internal"
                                  :keycloak #ig/ref :akvo.lumen.component.keycloak/data
                                  :api-headers #ig/ref :akvo.lumen.component.flow/api-headers

--- a/backend/src/akvo/lumen/component/flow.clj
+++ b/backend/src/akvo/lumen/component/flow.clj
@@ -55,11 +55,12 @@
   opts)
 
 (s/def ::url string?)
+(s/def ::auth0-url string?)
 (s/def ::internal-url string?)
 (s/def ::keycloak :akvo.lumen.component.keycloak/data)
 (s/def ::api-headers fn?)
 (s/def ::internal-api-headers fn?)
-(s/def ::config (s/keys :req-un [::url ::internal-url ::keycloak ::api-headers ::internal-api-headers]))
+(s/def ::config (s/keys :req-un [::url ::auth0-url ::internal-url ::keycloak ::api-headers ::internal-api-headers]))
 
 (defmethod ig/pre-init-spec ::api [_]
   ::config)

--- a/backend/src/akvo/lumen/config.clj
+++ b/backend/src/akvo/lumen/config.clj
@@ -20,7 +20,8 @@
     (assert (:lumen-email-user env) (error-msg "LUMEN_EMAIL_USER"))
     (assert (:lumen-sentry-backend-dsn env) (error-msg "LUMEN_SENTRY_BACKEND_DSN"))
     (assert (:lumen-sentry-client-dsn env) (error-msg "LUMEN_SENTRY_CLIENT_DSN"))
-    (assert (:lumen-flow-api-url env) (error-msg "LUMEN_FLOW_API_URL"))))
+    (assert (:lumen-flow-api-url env) (error-msg "LUMEN_FLOW_API_URL"))
+    (assert (:lumen-flow-api-auth0-url env) (error-msg "LUMEN_FLOW_API_AUTH0_URL"))))
 
 (defn construct
   "Create a system definition."

--- a/backend/src/akvo/lumen/endpoint/env.clj
+++ b/backend/src/akvo/lumen/endpoint/env.clj
@@ -24,7 +24,9 @@
          (cond-> {"authClientId" auth-client-id
                   "authURL" auth-url
                   "authProvider" auth-type
-                  "flowApiUrl" (:url flow-api)
+                  "flowApiUrl" (condp = auth-type
+                                 "keycloak" (:url flow-api)
+                                 "auth0"    (:auth0-url flow-api))
                   "piwikSiteId" piwik-site-id
                   "tenant" (:tenant request)}
            (string? sentry-client-dsn)

--- a/backend/test/resources/test.edn
+++ b/backend/test/resources/test.edn
@@ -45,6 +45,7 @@
  :akvo.lumen.upload/data {:file-upload-path "/tmp/akvo/lumen"}
 
  :akvo.lumen.component.flow/api {:url "https://api.akvotest.org/flow"
+                                 :auth0-url "https://api-auth0.akvotest.org/flow"
                                  :internal-url "https://api.akvotest.org/flow"
                                  :internal-api-headers #ig/ref :akvo.lumen.component.flow/api-headers}
 

--- a/ci/k8s/deployment.yaml.template
+++ b/ci/k8s/deployment.yaml.template
@@ -124,6 +124,11 @@ spec:
             configMapKeyRef:
               name: akvo
               key: flow.api.root
+        - name: LUMEN_FLOW_API_AUTH0_URL
+          valueFrom:
+            configMapKeyRef:
+              name: akvo
+              key: flow.api.auth0.root
         - name: LUMEN_SENTRY_BACKEND_DSN
           valueFrom:
             secretKeyRef:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -15,6 +15,7 @@ services:
      - LUMEN_EMAIL_USER=admin@akvo.org
      - LUMEN_EMAIL_PASSWORD=password
      - LUMEN_FLOW_API_URL=flow-url
+     - LUMEN_FLOW_API_AUTH0_URL=flow-auth0-url
      - LUMEN_PIWIK_SITE_ID=165
  client:
    image: "eu.gcr.io/${PROJECT_NAME}/lumen-client:${TRAVIS_COMMIT}"


### PR DESCRIPTION
Currently client is rejected when it tries to connect to flow-api using auth0 thus the flow-api url used validates the token against keycloak as auth system

With these changes, client side will target proper flow-api url value

Relates to
#2228, https://github.com/akvo/akvo-platform/pull/162, https://github.com/akvo/akvo-platform/issues/163

- [ ] **Update release notes if necessary**
