### PR TITLE
[#2322] Squeeze the createDataset modal height

### DIFF
--- a/client/src/components/modals/CreateDataset.scss
+++ b/client/src/components/modals/CreateDataset.scss
@@ -2,7 +2,7 @@
 
 .CreateDataset {
     .tabMenu {
-        padding: 3rem 0;
+        padding: 1rem 0;
     }
 
     .tab {

--- a/client/src/components/modals/CreateDataset.scss
+++ b/client/src/components/modals/CreateDataset.scss
@@ -90,7 +90,7 @@
             display: inline-block;
             text-align: left;
             padding: 1rem;
-            padding-bottom: 3.25rem;
+            padding-bottom: 1rem;
 
             &.progressActive {
                 padding-bottom: 1rem;

--- a/client/src/containers/Modal.jsx
+++ b/client/src/containers/Modal.jsx
@@ -20,7 +20,7 @@ const getWidth = (modal) => {
 
 const getHeight = (modal) => {
   switch (modal) {
-    case 'create-dataset': return 500;
+    case 'create-dataset': return 450;
     default: return 250;
   }
 };

--- a/client/src/containers/Modal.jsx
+++ b/client/src/containers/Modal.jsx
@@ -20,7 +20,7 @@ const getWidth = (modal) => {
 
 const getHeight = (modal) => {
   switch (modal) {
-    case 'create-dataset': return 600;
+    case 'create-dataset': return 500;
     default: return 250;
   }
 };


### PR DESCRIPTION
An attempt to squeeze the height of the modal to make users with tiny screens see the action buttons. Hopefully this is enough, otherwise, I think more drastic redesigns of the options in the panels of the steps in the modal is needed.