### PR TITLE
[#2378] Disconnect lumenci e2e test

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -53,7 +53,7 @@ log Running Backend functional tests
 docker-compose -p akvo-lumen-ci -f docker-compose.yml -f docker-compose.ci.yml run --no-deps backend-functional-tests /app/import-and-run.sh functional-and-seed
 
 log Running the end to end tests against local Docker Compose Environment
-./ci/e2e-test.sh akvolumenci http://t1.lumen.local/?auth=keycloak
+#./ci/e2e-test.sh akvolumenci http://t1.lumen.local/?auth=keycloak
 
 log Done
 #docker-compose -p akvo-lumen-ci -f docker-compose.yml -f docker-compose.ci.yml down


### PR DESCRIPTION
- [ ] **Update release notes if necessary**
until we had an alternative cypress test that uses the auth0 [recommended approach](https://auth0.com/blog/end-to-end-testing-with-cypress-and-auth0/), that is, to make a POST call to get the token instead of hitting the UI login page