### PR TITLE
[#2362] Disable Nashorn deprecation warnings

### DIFF
--- a/backend/project.clj
+++ b/backend/project.clj
@@ -52,6 +52,7 @@
                  [io.prometheus/simpleclient_hotspot "0.6.0"]
                  [io.prometheus/simpleclient_dropwizard "0.6.0"]
                  [org.clojure/test.check "0.10.0-alpha3"]]
+  :jvm-opts ["-Dnashorn.args=--no-deprecation-warning"]
   :source-paths   ["src" "specs"]
   :uberjar-name "akvo-lumen.jar"
   :repl-options {:timeout 120000}

--- a/backend/run-server.sh
+++ b/backend/run-server.sh
@@ -7,4 +7,4 @@ if [[ "${WAIT_FOR_DEPS:=false}" = "true" ]]; then
   /app/wait-for-dependencies.sh
 fi
 
-java -Xlog:gc=info -jar /app/akvo-lumen.jar
+java -Xlog:gc=info -Dnashorn.args="--no-deprecation-warning" -jar /app/akvo-lumen.jar


### PR DESCRIPTION
There are tons of warnings in the production logs

> Warning: Nashorn engine is planned to be removed from a future JDK release

JDK 11 is planned to be supported "at least Sept 2022"
Source: https://adoptopenjdk.net/support.html

- [ ] **Update release notes if necessary**
