### PR TITLE
Adapt cypress tests based on auth system

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -53,8 +53,8 @@ log Running Backend functional tests
 docker-compose -p akvo-lumen-ci -f docker-compose.yml -f docker-compose.ci.yml run --no-deps backend-functional-tests /app/import-and-run.sh functional-and-seed
 
 
-# log Running the end to end tests against local Docker Compose Environment
-# ./ci/e2e-test.sh akvolumenci http://t1.lumen.local/
+log Running the end to end tests against local Docker Compose Environment
+./ci/e2e-test.sh akvolumenci keycloak http://t1.lumen.local/
 
 log Done
 #docker-compose -p akvo-lumen-ci -f docker-compose.yml -f docker-compose.ci.yml down

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -71,8 +71,7 @@ else
     ./ci/helpers/wait-for-k8s-deployment-to-be-healthy.sh https://dark-lumencitest.akvotest.org/healthz
 
     log Running end to end tests against the Kubernetes TEST environment
-
-#    ./ci/e2e-test.sh akvolumenci https://dark-lumencitest.akvotest.org/ "$USERNAME" "$PASSWORD"
+    ./ci/e2e-test.sh akvolumenci auth0 https://dark-lumencitest.akvotest.org/ "$USERNAME" "$PASSWORD" "$AUTH_CLIENT" "$AUTH_PASSWORD"
 
     log Flipping TEST
     ./ci/auto-flip-test-blue-green-deployment.sh

--- a/ci/e2e-test.sh
+++ b/ci/e2e-test.sh
@@ -4,15 +4,18 @@ set -o errexit
 set -o nounset
 
 DOCKER_COMPOSE_PROJECT="${1:-akvolumen}"
-LUMEN_URL="${2:-http://t1.lumen.local:3030/}"
-LUMEN_USER="${3:-jerome}"
-LUMEN_PASSWORD="${4:-password}"
+LUMEN_AUTH="${2:-keycloak}"
+LUMEN_URL="${3:-http://t1.lumen.local:3030/}"
+LUMEN_USER="${4:-jerome@t1.akvolumen.org}"
+LUMEN_PASSWORD="${5:-password}"
+LUMEN_AUTH_CLIENT_ID="${6:-}"
+LUMEN_AUTH_CLIENT_PASSWORD="${7:-}"
 CYPRESS_RECORD_KEY="${CYPRESS_RECORD_KEY:-}"
 
 if [[ "${DOCKER_COMPOSE_PROJECT}" == "akvolumen" ]]; then
     docker-compose \
 	run --no-deps \
-        -e CYPRESS_LUMEN_AUTH="keycloak" \
+        -e CYPRESS_LUMEN_AUTH="${LUMEN_AUTH}" \
         -e CYPRESS_LUMEN_URL="${LUMEN_URL}" \
 	-e CYPRESS_LUMEN_USER="${LUMEN_USER}" \
 	-e CYPRESS_LUMEN_PASSWORD="${LUMEN_PASSWORD}" \
@@ -24,6 +27,9 @@ else
 	-f docker-compose.yml \
 	-f docker-compose.ci.yml \
 	run --no-deps \
+        -e CYPRESS_LUMEN_AUTH="${LUMEN_AUTH}" \
+	-e CYPRESS_LUMEN_AUTH_CLIENT_ID="${LUMEN_AUTH_CLIENT_ID}" \
+	-e CYPRESS_LUMEN_AUTH_CLIENT_PASSWORD="${LUMEN_AUTH_CLIENT_PASSWORD}" \
 	-e CYPRESS_LUMEN_URL="${LUMEN_URL}" \
 	-e CYPRESS_LUMEN_USER="${LUMEN_USER}" \
 	-e CYPRESS_LUMEN_PASSWORD="${LUMEN_PASSWORD}" \

--- a/ci/e2e-test.sh
+++ b/ci/e2e-test.sh
@@ -12,6 +12,7 @@ CYPRESS_RECORD_KEY="${CYPRESS_RECORD_KEY:-}"
 if [[ "${DOCKER_COMPOSE_PROJECT}" == "akvolumen" ]]; then
     docker-compose \
 	run --no-deps \
+        -e CYPRESS_LUMEN_AUTH="keycloak" \
         -e CYPRESS_LUMEN_URL="${LUMEN_URL}" \
 	-e CYPRESS_LUMEN_USER="${LUMEN_USER}" \
 	-e CYPRESS_LUMEN_PASSWORD="${LUMEN_PASSWORD}" \

--- a/client/e2e-test/cypress/integration/index.spec.js
+++ b/client/e2e-test/cypress/integration/index.spec.js
@@ -1,7 +1,9 @@
 /* global cy, before, context, Cypress, after, it */
 const baseUrl = Cypress.env('LUMEN_URL') || 'http://t1.lumen.local:3030/';
-const username = Cypress.env('LUMEN_USER') || 'jerome';
 const auth = Cypress.env('LUMEN_AUTH') || 'keycloak';
+const auth_client_id = Cypress.env('LUMEN_AUTH_CLIENT_ID');
+const auth_client_password = Cypress.env('LUMEN_AUTH_CLIENT_PASSWORD');
+const username = Cypress.env('LUMEN_USER') || 'jerome@t1.akvolumen.org';
 const password = Cypress.env('LUMEN_PASSWORD') || 'password';
 const DATASET_LINK = 'https://raw.githubusercontent.com/akvo/akvo-lumen/develop/client/e2e-test/sample-data-1.csv';
 const datasetName = `Dataset ${Date.now().toString()}`;
@@ -25,17 +27,45 @@ Cypress.on('fail', (error) => {
 });
 
 context('Akvo Lumen', ()  => {
-  // login
-  before(() => {
-      cy.visit(baseUrl);
-    cy.get('#username')
-      .type(username)
-      .should('have.value', username);
-    cy.get('#password')
-      .type(password)
-      .should('have.value', password);
-    cy.get('#kc-login').click();
-  });
+    // login
+    before(() => {
+	if(auth === "keycloak"){
+	    cy.visit(baseUrl);
+	    cy.get('#username')
+		.type(username)
+		.should('have.value', username);
+	    cy.get('#password')
+		.type(password)
+		.should('have.value', password);
+	    cy.get('#kc-login').click();
+	} else {
+	    Cypress.log({
+		name: 'loginViaAuth0',
+	    });
+	    const options = {
+		method: 'POST',
+		url: 'https://akvotest.eu.auth0.com/oauth/token',
+		body: {
+		    grant_type: 'password',
+		    username: username,
+		    password: password,
+		    audience: 'https://akvotest.eu.auth0.com/api/v2/',
+		    scope: 'openid profile email',
+		    client_id: auth_client_id,
+		    client_secret: auth_client_password
+		},
+	    };
+
+	    cy.request(options)
+		.then((resp) => {
+		    return resp.body;
+		})
+		.then((body) => {
+		    const { id_token } = body;
+		    cy.visit(baseUrl+"?access_token="+id_token+"&edit_user=false");
+		});
+	}
+    });
 
   // delete entities created during test
   after(() => {

--- a/client/e2e-test/cypress/integration/index.spec.js
+++ b/client/e2e-test/cypress/integration/index.spec.js
@@ -1,6 +1,7 @@
 /* global cy, before, context, Cypress, after, it */
 const baseUrl = Cypress.env('LUMEN_URL') || 'http://t1.lumen.local:3030/';
 const username = Cypress.env('LUMEN_USER') || 'jerome';
+const auth = Cypress.env('LUMEN_AUTH') || 'keycloak';
 const password = Cypress.env('LUMEN_PASSWORD') || 'password';
 const DATASET_LINK = 'https://raw.githubusercontent.com/akvo/akvo-lumen/develop/client/e2e-test/sample-data-1.csv';
 const datasetName = `Dataset ${Date.now().toString()}`;

--- a/client/src/containers/Main.jsx
+++ b/client/src/containers/Main.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { every } from 'lodash';
+import queryString from 'querystringify';
 import { FormattedMessage } from 'react-intl';
 import Modal from './Modal';
 import { showModal } from '../actions/activeModal';
@@ -16,12 +17,13 @@ require('fixed-data-table-2/dist/fixed-data-table.css');
 
 class Main extends Component {
   componentDidMount() {
+    const queryParams = queryString.parse(location.search);
+    const showEditUser = queryParams.edit_user === 'false';
     const {
       dispatch,
       profile: { firstName, lastName },
-      location: { pathname },
     } = this.props;
-    if ((pathname.split('/').pop() !== 'export')
+    if ((!showEditUser)
       && (!every([firstName, lastName], Boolean))) {
       dispatch(showModal('edit-user'));
     }

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -51,4 +51,4 @@ services:
    command: "true"
  fe-e2e-tests:
    environment:
-      - LUMEN_URL=http://t1.lumen.local/?auth=keycloak
+      - LUMEN_URL=http://t1.lumen.local/

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -7,8 +7,7 @@ services:
      - LUMEN_DB_URL=jdbc:postgresql://postgres/lumen?user=lumen&password=password&ssl=true
      - CI_BUILD=yes
      - LUMEN_FILE_UPLOAD_PATH=/tmp/akvo/lumen
-     - LUMEN_AUTH_URL=http://auth.lumen.local:8080/auth
-     - LUMEN_AUTH_ISSUER_SUFFIX_URL=/realms/akvo
+     - LUMEN_AUTH_URL=http://auth.lumen.local:8080/auth/realms/akvo
      - LUMEN_AUTH_PUBLIC_CLIENT_ID=akvo-lumen
      - LUMEN_AUTH_RSA_SUFFIX_URL=/protocol/openid-connect/certs
      - LUMEN_KEYCLOAK_URL=http://auth.lumen.local:8080/auth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,8 @@ services:
    volumes:
      - ./client/e2e-test:/app/e2e-test
    environment:
-      - LUMEN_URL=http://t1.lumen.local:3030/?auth=keycloak
       - LUMEN_USER=jerome
+      - LUMEN_URL=http://t1.lumen.local:3030/
       - LUMEN_PASSWORD=password
       - APP_DIR=/app/e2e-test
    links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,8 @@ services:
    volumes:
      - ./client/e2e-test:/app/e2e-test
    environment:
-      - LUMEN_USER=jerome
       - LUMEN_URL=http://t1.lumen.local:3030/
+      - LUMEN_USER=jerome@t1.akvolumen.org
       - LUMEN_PASSWORD=password
       - APP_DIR=/app/e2e-test
    links:

--- a/exporter/index.js
+++ b/exporter/index.js
@@ -105,7 +105,7 @@ const takeScreenshot = (req, runId) => new Promise((resolve, reject) => {
 
     const token = req.header('access_token');
     const locale = req.header('locale');
-    const dest = `${target}?access_token=${token}&locale=${locale}`;
+    const dest = `${target}?access_token=${token}&locale=${locale}&edit_user=false`;
     await page.goto(dest, { waitUntil: 'networkidle2', timeout: 0 });
 
     const selectors = (selector || '').split(',');


### PR DESCRIPTION
- [ ] **Update release notes if necessary**
Relates [#2378]

- Adds travis ci vars `AUTH_CLIENT` and `AUTH_PASSWORD` that contain the auth0 client-id and auth0 client-password