### PR TITLE
Optional slack notification script when promoting/flipping production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ npm-debug.log
 .DS_Store
 client/dist
 client/yarn.lock
+notify.slack.sh
 
 # docker-compose
 .env

--- a/ci/flip-blue-green-deployment.sh
+++ b/ci/flip-blue-green-deployment.sh
@@ -48,6 +48,8 @@ PROD_LIVE_VERSION=$VERSION
 read_version "$NEW_LIVE_COLOR"
 PROD_DARK_VERSION=$VERSION
 log "Diff between dark and live is https://github.com/akvo/akvo-lumen/compare/$PROD_LIVE_VERSION..$PROD_DARK_VERSION"
+log "Commits to be deployed:"
+git log --oneline $PROD_LIVE_VERSION..$PROD_DARK_VERSION | grep -v "Merge pull request" | grep -v "Merge branch"
 
 if [ "${CLUSTER}" == "production" ]; then
  read -r -e -p "Are you sure you want to flip production? [yn] " CONFIRM
@@ -62,6 +64,12 @@ if ! "${DIR}"/set-live-deployment.sh "${NEW_LIVE_COLOR}"; then
     log "PLEASE CHECK WHAT HAPPEN!!!!!!!!!!!!!"
     switch_back
     exit 5
+fi
+
+if [ "${CLUSTER}" == "production" ]; then
+  "${DIR}"/helpers/generate-slack-notification.sh "${PROD_LIVE_VERSION}" "${PROD_DARK_VERSION}" "Flipping *PROD!!!*" "warning"
+  log "Notifying the team about the changes deployed"
+  ./notify.slack.sh
 fi
 
 switch_back

--- a/ci/helpers/generate-slack-notification.sh
+++ b/ci/helpers/generate-slack-notification.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+OLDER_GIT_VERSION=$1
+NEWEST_GIT_VERSION=$2
+MSG=$3
+COLOR=$4
+
+cat << EOF > notify.slack.sh
+#!/usr/bin/env bash
+
+if [ -z "\${SLACK_CLI_TOKEN}" ]; then
+  echo "You need a env var SLACK_CLI_TOKEN with a Slack legacy token"
+  echo "Go to https://api.slack.com/custom-integrations/legacy-tokens to create one"
+  echo "Create the env variable and rerun this script (\$0)"
+  exit 1
+fi
+
+slack_txt=\$(git log --oneline $OLDER_GIT_VERSION..$NEWEST_GIT_VERSION | grep -v "Merge pull request" | grep -v "Merge branch" | cut -f 2- -d\  | sed 's/\[#\([0-9]*\)\]/<https:\/\/github.com\/akvo\/akvo-lumen\/issues\/\1|[#\1]>/')
+docker run --rm -e SLACK_CLI_TOKEN 512k/slack-cli \
+    chat send \
+    --channel='#lumen-dev' \
+    --pretext="$MSG. <https://github.com/akvo/akvo-lumen/compare/$OLDER_GIT_VERSION..$NEWEST_GIT_VERSION|Full diff>." \
+    --color $COLOR \
+    --text "\$slack_txt" > /dev/null
+EOF
+
+chmod u+x notify.slack.sh

--- a/ci/promote-test-to-prod.sh
+++ b/ci/promote-test-to-prod.sh
@@ -50,12 +50,39 @@ log "Deployed prod live version is $PROD_LIVE_VERSION"
 log "Diff between test and dark prod is https://github.com/akvo/akvo-lumen/compare/$PROD_DARK_VERSION..$TEST_LIVE_VERSION"
 log "Diff between test and live prod is https://github.com/akvo/akvo-lumen/compare/$PROD_LIVE_VERSION..$TEST_LIVE_VERSION"
 
+## Lets assume this git history:
+# v1 (prod-live)
+# v2
+# v3 (prod-dark)
+# v4
+# v5 (test)
+# When promoting a build, we want to report the new changes (v4, v5) that will show in dark.
+# But lets say that we have the previous history and we do a flip in production. We have:
+# v1 (prod-dark)
+# v2
+# v3 (prod-live)
+# v4
+# v5 (test)
+# So in this case we really want to report the changes between test and prod-live (still v4, v5)
+# In general terms, we want to see the diff between test and the last promotion.
+# Instead of looking at git tags, we just check which of the prod envs is older
+if git merge-base --is-ancestor $PROD_LIVE_VERSION $PROD_DARK_VERSION; then
+  NEWEST_VERSION_IN_PROD=$PROD_DARK_VERSION
+else
+  NEWEST_VERSION_IN_PROD=$PROD_LIVE_VERSION
+fi
+log "Commits to be deployed:"
+git log --oneline $NEWEST_VERSION_IN_PROD..$TEST_LIVE_VERSION | grep -v "Merge pull request" | grep -v "Merge branch"
+
+"${DIR}"/helpers/generate-slack-notification.sh "${NEWEST_VERSION_IN_PROD}" "${TEST_LIVE_VERSION}" "Promoting Lumen to dark prod cluster" "good"
+
 TAG_NAME="promote-$(date +"%Y%m%d-%H%M%S")"
 
 log "To deploy, run: "
 echo "----------------------------------------------"
 echo "git tag $TAG_NAME $TEST_LIVE_VERSION"
 echo "git push origin $TAG_NAME"
+echo "./notify.slack.sh"
 echo "----------------------------------------------"
 
 switch_back


### PR DESCRIPTION
Generate a script that when run will post to Slack the changes to be
promoted to dark production, or the changes after a production flip.

Script requires a Slack legacy token (https://api.slack.com/custom-integrations/legacy-tokens). 

Fixes #2427