### PR TITLE
Improve error message on flow update errors

### DIFF
--- a/backend/src/akvo/lumen/lib/transformation/derive.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive.clj
@@ -154,8 +154,9 @@
     (reduce (fn [c r]
               (conj c (if-let [column-name (:column-name r)]
                         column-name
-                        (throw (ex-info "ups, no column name here!" {:transformation applied-transformation
-                                                                     :columns columns
-                                                                     :computed computed
-                                                                     :reference r}))))
+                        (throw (ex-info (format "Column '%s' doesn't exist." (last (last (parse-row-object-references(:pattern r)))))
+                                        {:transformation applied-transformation
+                                         :columns columns
+                                         :computed computed
+                                         :reference r}))))
               ) [] (walk/keywordize-keys (get computed "references")))))

--- a/client/src/actions/dataset.js
+++ b/client/src/actions/dataset.js
@@ -468,7 +468,7 @@ function pollDatasetUpdateStatus(updateId, datasetId, title) {
           );
         } else if (status === 'FAILED') {
           dispatch(updateDatasetTogglePending(datasetId));
-          dispatch(showNotification('error', `Failed to update dataset "${title}": ${reason}`));
+          dispatch(showNotification('error', `Failed to update "${title}". ${reason}`));
         } else if (status === 'OK') {
           dispatch(fetchDataset(datasetId)).then(() =>
             dispatch(showNotification('info', `Successfully updated dataset "${title}"`, true))


### PR DESCRIPTION
Relates [#1361] 

Add transformation index
Specify js columns not found references

- [ ] **Update release notes if necessary**

Example of improved message:
<img width="652" alt="Screen Shot 2019-11-15 at 11 09 05" src="https://user-images.githubusercontent.com/731829/68935137-60e0f380-0798-11ea-86ec-c6ae71e745ea.png">


To test it locally, you need to edit your local.edn with these settings:

```clojure
{

    :akvo.lumen.component.flow/api {:url "https://api-auth0.akvotest.org/flow"
				    :internal-url "https://api-auth0.akvotest.org/flow"
				    :internal-api-headers #ig/ref :akvo.lumen.component.flow/api-headers}
    :akvo.lumen.component.authentication/public-client    
    {:url "https://akvotest.eu.auth0.com/"
     :client-id "PIcm0mTZLfzufij7mlGP1v72VPwXDGfw"
     :rsa-suffix-url ".well-known/jwks.json"
    }
}
```
Then import a flow dataset, define a new js trasnformation that points to a non existent column, then click on update
