### PR TITLE
[#2244] Don't allow the word "function" nor the sign "=>" [client]

### DIFF
--- a/client/src/components/dataset/sidebars/DeriveColumnJavascript.jsx
+++ b/client/src/components/dataset/sidebars/DeriveColumnJavascript.jsx
@@ -49,6 +49,9 @@ function isValidCode(code) {
     if (expressionStatement.type !== 'ExpressionStatement') {
       return false;
     }
+    if (code.indexOf('function') !== -1 || code.indexOf('=>') !== -1) {
+      return false;
+    }
     return true;
   } catch (e) {
     return false;
@@ -73,6 +76,8 @@ function HelpText() {
       <FormattedMessage
         id="js_helptext"
         values={{
+          arrowFunct: <Code>{'=>'}</Code>,
+          funct: <Code>function</Code>,
           columnSyntax: <Code>{'row["Column Title"]'}</Code>,
           title: <Code>row.title</Code>,
         }}

--- a/client/src/translations/en.json
+++ b/client/src/translations/en.json
@@ -161,7 +161,7 @@
   "is_less_or_equal_to": "is less than or equal to",
   "is_greater_or_equal_to": "is greater than or equal to",
   "javascript_code": "Javascript code",
-  "js_helptext": "Derived columns are formulas written using a subset of Javascript where a single expression is allowed and columns are referenced as {columnSyntax} or alternatively if the title is a valid javascript identifier: {title}.",
+  "js_helptext": "Derived columns are formulas written using a subset of Javascript where a single expression is allowed and columns are referenced as {columnSyntax} or alternatively if the title is a valid javascript identifier: {title}. Javascript code can't contain the word {funct} nor the sign {arrowFunct}",
   "keep_rows_in_which": "keep rows in which",
   "label": "Label",
   "last_modified": "Last modified",

--- a/client/src/translations/es.json
+++ b/client/src/translations/es.json
@@ -156,7 +156,7 @@
   "is_less_or_equal_to": "es igual que o igual a",
   "is_lower_than": "es menor que",
   "javascript_code": "Código Javascript",
-  "js_helptext": "Las columnas derivadas son fórmulas escritas utilizando un subset de Javascript dónde se permite una sola expresión y las columnas son referenciadas como {columnSyntax} o alternativamente si el título es un identificador de Javascript válido: {title}.",
+  "js_helptext": "Las columnas derivadas son fórmulas escritas utilizando un subset de Javascript dónde se permite una sola expresión y las columnas son referenciadas como {columnSyntax} o alternativamente si el título es un identificador de Javascript válido: {title}. El código javascript no puede contener la palabra {funct} ni el signo {arrowFunct}",
   "keep_rows_in_which": "mantener las filas en las cuales",
   "label": "Etiqueta",
   "last_modified": "Ultima modificación",

--- a/client/src/translations/fr.json
+++ b/client/src/translations/fr.json
@@ -157,7 +157,7 @@
   "is_less_or_equal_to": "est inférieur ou égal à",
   "is_lower_than": "est plus inférieur à",
   "javascript_code": "Code javascript",
-  "js_helptext": "Les colonnes dérivées sont des formules écrites en utilisant un sous-ensemble de Javascript où une seule expression est autorisée et les colonnes sont référencées comme {columnSyntax} ou, en variante, si le titre est un identifiant de javascript valide: {title}. Javascript code can't contain the word {funct} nor the sign {arrowFunct}",
+  "js_helptext": "Les colonnes dérivées sont des formules écrites en utilisant un sous-ensemble de Javascript où une seule expression est autorisée et les colonnes sont référencées comme {columnSyntax} ou, en variante, si le titre est un identifiant de javascript valide: {title}. Le code Javascriot ne peut contenir ni le mot {funct} ni le signe {arrowFunct}",
   "keep_rows_in_which": "Garder les lignes dans lesquelles",
   "label": "Étiquette",
   "last_modified": "Modifié",

--- a/client/src/translations/fr.json
+++ b/client/src/translations/fr.json
@@ -157,7 +157,7 @@
   "is_less_or_equal_to": "est inférieur ou égal à",
   "is_lower_than": "est plus inférieur à",
   "javascript_code": "Code javascript",
-  "js_helptext": "Les colonnes dérivées sont des formules écrites en utilisant un sous-ensemble de Javascript où une seule expression est autorisée et les colonnes sont référencées comme {columnSyntax} ou, en variante, si le titre est un identifiant de javascript valide: {title}.",
+  "js_helptext": "Les colonnes dérivées sont des formules écrites en utilisant un sous-ensemble de Javascript où une seule expression est autorisée et les colonnes sont référencées comme {columnSyntax} ou, en variante, si le titre est un identifiant de javascript valide: {title}. Javascript code can't contain the word {funct} nor the sign {arrowFunct}",
   "keep_rows_in_which": "Garder les lignes dans lesquelles",
   "label": "Étiquette",
   "last_modified": "Modifié",


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

# Todo:
- [x] review `en` translation
- [x] adapt `fr` translation


<img width="290" alt="Screen Shot 2019-11-18 at 20 24 53" src="https://user-images.githubusercontent.com/731829/69083060-aa07a080-0a41-11ea-9174-c1948fdec66d.png">
