### PR TITLE
Duplicated questions and long column names

### DIFF
--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -69,7 +69,18 @@
 (defn questions
   "Get the list of questions from a form"
   [form]
-  (mapcat :questions (:questionGroups form)))
+  (let [duplicates (->> (:questionGroups form)
+                        (map :questions)
+                        (reduce #(into % (map :name %2)) [])
+                        frequencies
+                        (filter (fn [[m v]] (> v 1)))
+                        (map first)
+                        set)]
+    (->> (:questionGroups form)
+         (reduce #(into % (map (fn [q group-name]
+                                 (if (contains? duplicates (:name q))
+                                   (update q :name (fn [x] (format "%s (%s)" x group-name)))
+                                   q)) (:questions %2) (repeat (str/trim (:name %2))))) []))))
 
 (defn form
   "Get a form by id from a survey"

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -17,12 +17,12 @@
     "text"))
 
 (defn dataset-columns
-  [form]
+  [form questions]
   (into (flow-common/commons-columns form)
         (into
          [{:title "Latitude" :type "number" :id "latitude"}
           {:title "Longitude" :type "number" :id "longitude"}]
-         (common/coerce question-type->lumen-type (flow-common/questions form)))))
+         (common/coerce question-type->lumen-type questions))))
 
 (defmulti render-response
   (fn [type response]
@@ -86,7 +86,7 @@
   nil)
 
 (defn response-data
-  [form responses]
+  [questions responses]
   (let [responses (flow-common/question-responses responses)]
     (reduce (fn [response-data {:keys [type id]}]
               (if-let [response (get responses id)]
@@ -95,17 +95,16 @@
                        (render-response type response))
                 response-data))
             {}
-            (flow-common/questions form))))
+            questions)))
 
 (defn form-data
   "Returns a lazy sequence of form data, ready to be inserted as a lumen dataset"
-  [headers-fn survey form-id]
-  (let [form (flow-common/form survey form-id)
-        data-points (util/index-by "id" (flow-common/data-points headers-fn survey))]
+  [headers-fn survey form questions form-id]
+  (let [data-points (util/index-by "id" (flow-common/data-points headers-fn survey))]
     (map (fn [form-instance]
            (let [data-point-id (get form-instance "dataPointId")
                  data-point (get data-points data-point-id)]
-             (merge (response-data form (get form-instance "responses"))
+             (merge (response-data questions (get form-instance "responses"))
                     (flow-common/common-records form-instance data-point)
                     {:latitude (get-in data-points [data-point-id "latitude"])
                      :longitude (get-in data-points [data-point-id "longitude"])})))

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -32,7 +32,7 @@
                                              (assoc :multipleId (:id i))
                                              (assoc :derived-id (:id i))
                                              (assoc :derived-fn (fn [x] (-> x (w/keywordize-keys) :features first :properties)))
-                                             (update :name (fn [o] (str o " Features" )))
+                                             (update :name (fn [o] (format "%s Features" o)))
                                              (assoc :id id)))) [i] (range 1)))
        (conj c i))) [] (flow-common/questions form)))
 

--- a/backend/test/akvo/lumen/lib/import/flow_common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/flow_common_test.clj
@@ -1,0 +1,60 @@
+(ns akvo.lumen.lib.import.flow-common-test
+  (:require [akvo.lumen.lib.import.flow-common :as flow-common]
+            [clojure.test :refer [deftest testing is]]))
+
+(def demo-form {:id "166189116",
+                :name "Demo form",
+                :questionGroups
+                [{:id "166199115",
+                  :name "Basic information",
+                  :repeatable false,
+                  :questions
+                  [{:id "169799115",
+                    :name "What is your name?",
+                    :type "FREE_TEXT",
+                    :order 1,
+                    :variableName nil,
+                    :createdAt "2017-07-21T12:14:12.388Z",
+                    :modifiedAt "2017-07-21T12:25:14.494Z"}
+                   {:id "166669142",
+                    :name "How old are you",
+                    :type "NUMBER",
+                    :order 2,
+                    :variableName nil,
+                    :createdAt "2017-07-21T12:23:26.623Z",
+                    :modifiedAt "2017-07-21T12:23:43.693Z"}
+                   {:id "169679190",
+                    :name
+                    "How likely are you going to recommend Akvo Flow to a colleague or a friend? ",
+                    :type "OPTION",
+                    :order 3,
+                    :variableName nil,
+                    :createdAt "2017-07-21T12:18:41.989Z",
+                    :modifiedAt "2017-07-21T12:25:14.951Z"}],
+                  :createdAt "2017-07-21T12:14:01.596Z",
+                  :modifiedAt "2017-07-21T12:14:14.435Z"}
+                 {:id "581219119",
+                  :name "Other Group",
+                  :repeatable true,
+                  :questions
+                  [{:id "523129121",
+                    :name "What is your name?",
+                    :type "FREE_TEXT",
+                    :order 1,
+                    :variableName nil,
+                    :createdAt "2019-11-19T10:15:12.915Z",
+                    :modifiedAt "2019-11-19T10:15:24.755Z"}],
+                  :createdAt "2019-11-19T10:15:01.380Z",
+                  :modifiedAt "2019-11-19T15:35:11.927Z"}],
+                :createdAt "2017-07-21T12:13:54.716Z",
+                :modifiedAt "2019-11-19T10:39:49.567Z",
+                :formInstancesUrl
+                "https://api-auth0.akvotest.org/flow/orgs/uat1/form_instances?survey_id=169539266&form_id=166189116",
+                :registration-form? false})
+
+(deftest flow-common-questions
+  (testing "duplicated questions suffix"
+    (is (= (flow-common/questions demo-form)
+           (-> (vec (mapcat :questions (:questionGroups demo-form)))
+               (update-in [0 :name] #(format "%s (%s)" % (:name (first (:questionGroups demo-form)))))
+               (update-in [3 :name] #(format "%s (%s)" % (:name (last (:questionGroups demo-form))))))))))

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7005,12 +7005,45 @@
       }
     },
     "fixed-data-table-2": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/fixed-data-table-2/-/fixed-data-table-2-0.7.17.tgz",
-      "integrity": "sha1-Mn0XL4ZfcXFchtSXn9vzx37PfZo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fixed-data-table-2/-/fixed-data-table-2-1.0.1.tgz",
+      "integrity": "sha512-sKjQsTfWxY9FMXlGMylwv054QG2u9ZqsSTYggz/S67g6O8DHnbCP0MOjKib+YQsLscxFHE/XLPZGxI/nr0bTcg==",
       "requires": {
-        "create-react-class": "^15.5.2",
-        "prop-types": "^15.5.8"
+        "lodash": "^4.17.4",
+        "prop-types": "15.7.2",
+        "redux": "4.0.1",
+        "reselect": "4.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.12.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+        },
+        "redux": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+          "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "symbol-observable": "^1.2.0"
+          }
+        }
       }
     },
     "flat-cache": {
@@ -14487,6 +14520,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -67,7 +67,7 @@
     "extract-text-webpack-plugin": "3.0.1",
     "file-loader": "0.11.2",
     "file-saver": "^1.3.8",
-    "fixed-data-table-2": "^0.7.17",
+    "fixed-data-table-2": "^1.0.1",
     "history": "^4.7.2",
     "html-webpack-plugin": "2.29.0",
     "http-proxy-middleware": "^0.17.4",

--- a/client/src/components/dataset/ColumnGroupHeader.jsx
+++ b/client/src/components/dataset/ColumnGroupHeader.jsx
@@ -1,0 +1,85 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Immutable from 'immutable';
+
+require('./ColumnGroupHeader.scss');
+
+export default class ColumnGroupHeader extends Component {
+
+  constructor() {
+    super();
+    this.handleColumnMenuClick = this.handleColumnMenuClick.bind(this);
+    this.handleRemoveSort = this.handleRemoveSort.bind(this);
+  }
+
+  handleColumnMenuClick() {
+    const el = this.columnHeaderContainer;
+    const rect = el.getBoundingClientRect();
+    const verticalOffset = rect.top + el.offsetHeight;
+    const horizontalOffset = rect.left;
+    const width = el.offsetWidth;
+
+    const dimensions = {
+      left: horizontalOffset,
+      top: verticalOffset,
+      width,
+    };
+    this.props.onToggleColumnContextMenu({
+      dimensions,
+      column: this.props.column,
+    });
+  }
+
+  handleRemoveSort(event, column) {
+    event.stopPropagation();
+    this.props.onRemoveSort(Immutable.fromJS({
+      op: 'core/remove-sort',
+      args: { columnName: column.get('columnName') },
+      onError: 'fail',
+    }));
+  }
+
+  render() {
+    const { column, disabled } = this.props;
+
+    return (
+      <div
+        className={`ColumnGroupHeader ${disabled ? '' : 'clickable'}
+          ${this.props.columnMenuActive ? 'columnMenuActive' : ''}`}
+        ref={(ref) => { this.columnHeaderContainer = ref; }}
+        onClick={this.handleColumnMenuClick}
+      >
+        {column.get('sort') != null ?
+          <div
+            className="sortLabel"
+          >
+            Sort: {column.get('direction') === 'ASC' ? 'Ascending' : 'Descending'}
+            <span
+              className="cancelSort"
+              onClick={event => this.handleRemoveSort(event, column)}
+            >
+              ✕
+            </span>
+          </div>
+          : null
+        }
+        <span
+          className="columnTitleText"
+          title={column.get('title')}
+          data-test-id={column.get('title')}
+        >
+          {column.get('title')}
+        </span>
+      </div>
+    );
+  }
+}
+
+ColumnGroupHeader.propTypes = {
+  column: PropTypes.object.isRequired,
+  onToggleDataTypeContextMenu: PropTypes.func.isRequired,
+  onToggleColumnContextMenu: PropTypes.func.isRequired,
+  onRemoveSort: PropTypes.func.isRequired,
+  columnMenuActive: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
+};

--- a/client/src/components/dataset/ColumnGroupHeader.scss
+++ b/client/src/components/dataset/ColumnGroupHeader.scss
@@ -1,35 +1,8 @@
 @import "../../styles/modules/importAll";
 
-/*
-fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_even fixedDataTableLayout_header public_fixedDataTable_header
-
-fixedDataTableRowLayout_main public_fixedDataTableRow_main fixedDataTableLayout_header public_fixedDataTable_header
-
-*/
-.fixedDataTableRowLayout_main {
-    border-width: 0px;
-    border-style: none;
-
-}
-
-
-.HOLA {
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
-    border-color: #d3d3d3;
-}
-
-// fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_highlighted public_fixedDataTableRow_odd HOLA public_fixedDataTable_bodyRow fixedDataTableLayout_hasBottomBorder 
-
-.public_fixedDataTable_hasBottomBorder{
-   // border-top-width: 1px;
-   //  border-top-style: solid;    
-}
-
-
-.ColumnHeader {
+.ColumnGroupHeader {
     vertical-align: top;
-    margin-top: 3px;
+
     * {
         vertical-align: top;
     }
@@ -58,7 +31,7 @@ fixedDataTableRowLayout_main public_fixedDataTableRow_main fixedDataTableLayout_
     }
 
     * {
-    //    line-height: 60px;
+        line-height: 60px;
     }
 
     .columnKey {
@@ -83,5 +56,27 @@ fixedDataTableRowLayout_main public_fixedDataTableRow_main fixedDataTableLayout_
         text-overflow: ellipsis;
         white-space: nowrap;
         display: inline-block;
+    }
+
+    .sortLabel {
+        display: block;
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 0rem;
+        line-height: 0.7rem;
+        padding: 0.125rem 0.5rem 0.18rem 0.5rem;
+        background-color: rgba(0, 0, 0, 0.25);
+        color: $black;
+        text-align: left;
+
+        * {
+            line-height: 0.7rem;
+        }
+
+        .cancelSort {
+            float: right;
+            margin-right: -0.25rem;
+        }
     }
 }

--- a/client/src/components/dataset/ColumnHeader.jsx
+++ b/client/src/components/dataset/ColumnHeader.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Immutable from 'immutable';
 import { FormattedMessage } from 'react-intl';
 
 require('./ColumnHeader.scss');
@@ -10,8 +9,6 @@ export default class ColumnHeader extends Component {
   constructor() {
     super();
     this.handleDataTypeMenuClick = this.handleDataTypeMenuClick.bind(this);
-    this.handleColumnMenuClick = this.handleColumnMenuClick.bind(this);
-    this.handleRemoveSort = this.handleRemoveSort.bind(this);
   }
 
   handleDataTypeMenuClick(event) {
@@ -33,61 +30,16 @@ export default class ColumnHeader extends Component {
     });
   }
 
-  handleColumnMenuClick() {
-    const el = this.columnHeaderContainer;
-    const rect = el.getBoundingClientRect();
-    const verticalOffset = rect.top + el.offsetHeight;
-    const horizontalOffset = rect.left;
-    const width = el.offsetWidth;
-
-    const dimensions = {
-      left: horizontalOffset,
-      top: verticalOffset,
-      width,
-    };
-    this.props.onToggleColumnContextMenu({
-      dimensions,
-      column: this.props.column,
-    });
-  }
-
-  handleRemoveSort(event, column) {
-    event.stopPropagation();
-    this.props.onRemoveSort(Immutable.fromJS({
-      op: 'core/remove-sort',
-      args: { columnName: column.get('columnName') },
-      onError: 'fail',
-    }));
-  }
 
   render() {
-    const { column, disabled } = this.props;
+    const { column } = this.props;
 
     return (
       <div
-        className={`ColumnHeader ${disabled ? '' : 'clickable'}
-          ${this.props.columnMenuActive ? 'columnMenuActive' : ''}`}
-        ref={(ref) => { this.columnHeaderContainer = ref; }}
-        onClick={this.handleColumnMenuClick}
+        className="ColumnHeader"
       >
-        {column.get('sort') != null ?
-          <div
-            className="sortLabel"
-          >
-            Sort: {column.get('direction') === 'ASC' ? 'Ascending' : 'Descending'}
-            <span
-              className="cancelSort"
-              onClick={event => this.handleRemoveSort(event, column)}
-            >
-              ✕
-            </span>
-          </div>
-          : null
-        }
         <span
           className="columnTitleText"
-          title={column.get('title')}
-          data-test-id={column.get('title')}
         >
           {column.get('key') ?
             <span className="columnKey">
@@ -105,7 +57,6 @@ export default class ColumnHeader extends Component {
               </span>
             </span>
           }
-          {column.get('title')}
         </span>
       </div>
     );

--- a/client/src/components/dataset/DatasetTable.jsx
+++ b/client/src/components/dataset/DatasetTable.jsx
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Table, Column, Cell } from 'fixed-data-table-2';
+import { Table, Column, Cell, ColumnGroup } from 'fixed-data-table-2';
 import moment from 'moment';
 import { withRouter } from 'react-router';
 import ColumnHeader from './ColumnHeader';
+import ColumnGroupHeader from './ColumnGroupHeader';
 import DataTableSidebar from './DataTableSidebar';
 import DatasetControls from './DatasetControls';
 import DataTypeContextMenu from './context-menus/DataTypeContextMenu';
@@ -411,9 +412,21 @@ class DatasetTable extends Component {
     } = this.state;
 
     const cols = columns.map((column, index) => {
+      const columnGroupHeader = (
+          <ColumnGroupHeader
+            key={`group-header${index}`}
+            column={column}
+            onToggleDataTypeContextMenu={this.handleToggleDataTypeContextMenu}
+            onToggleColumnContextMenu={this.handleToggleColumnContextMenu}
+            disabled={isLockedFromTransformations}
+            columnMenuActive={activeColumnContextMenu != null && !isLockedFromTransformations &&
+              activeColumnContextMenu.column.get('title') === column.get('title')}
+            onRemoveSort={transformation => this.props.onTransform(transformation)}
+          />
+      );
       const columnHeader = (
         <ColumnHeader
-          key={index}
+          key={`header${index}`}
           column={column}
           onToggleDataTypeContextMenu={this.handleToggleDataTypeContextMenu}
           onToggleColumnContextMenu={this.handleToggleColumnContextMenu}
@@ -422,7 +435,8 @@ class DatasetTable extends Component {
             activeColumnContextMenu.column.get('title') === column.get('title')}
           onRemoveSort={transformation => this.props.onTransform(transformation)}
         />
-      );
+    );
+
       const formatCell = (props) => {
         const formattedCellValue =
           formatCellValue(column.get('type'), rows.getIn([props.rowIndex, index]));
@@ -439,13 +453,19 @@ class DatasetTable extends Component {
       };
 
       return (
-        <Column
-          cellClassName={this.getCellClassName(column.get('title'))}
+        <ColumnGroup
+          header={columnGroupHeader}
           key={index}
-          header={columnHeader}
-          cell={formatCell}
-          width={200}
-        />
+        >
+          <Column
+            cellClassName={this.getCellClassName(column.get('title'))}
+            key={index}
+            header={columnHeader}
+            cell={formatCell}
+            width={200}
+          />
+        </ColumnGroup>
+
       );
     });
     return (
@@ -496,9 +516,12 @@ class DatasetTable extends Component {
                 left={columns.last().get('title') === activeColumnContextMenu.column.get('title')}
               />
             )}
+            
             <Table
-              headerHeight={60}
+              groupHeaderHeight={60}
+              headerHeight={30}
               rowHeight={30}
+              rowClassNameGetter={() => 'HOLA'}
               rowsCount={rows.size}
               width={width}
               height={height}


### PR DESCRIPTION
# WIP
- [ ] **Update release notes if necessary**

relates #862 #2437 

how about using column groups https://schrodinger.github.io/fixed-data-table-2/example-column-groups.html

then, instead of changing the column name if we have duplicates we could just "adjust" the js "problematic" code

also we could use column-groups just to split current functionality
eg: column title and functions in "first" row, column type in second row 🤔 

![Screen Shot 2019-11-22 at 19 44 34](https://user-images.githubusercontent.com/731829/69451825-98373d80-0d60-11ea-8e24-6a3a8132d46d.png)



