### PR TITLE
[#2534] Increase timeout in page.waitFor [exporter]

### DIFF
--- a/exporter/index.js
+++ b/exporter/index.js
@@ -113,7 +113,7 @@ const takeScreenshot = (req, runId) => new Promise((resolve, reject) => {
     if (selectors.length) {
       await Promise.all(selectors.map(async (s) => {
         try {
-          await page.waitFor(s);
+            await page.waitFor(s, {timeout: 60000});
         } catch (error) {
           captureException(error);
           reject(error);


### PR DESCRIPTION
Following k8s logs, by default is 30000ms

Exception captured for run ID: - { TimeoutError: waiting for selector ".render-completed-5e393b63-7144-453a-be41-76d2b2fff4d9" failed: timeout 30000ms exceeded at new WaitTask (/node_modules/puppeteer/lib/DOMWorld.js:561:28) at DOMWorld._waitForSelectorOrXPath (/node_modules/puppeteer/lib/DOMWorld.js:490:22) at DOMWorld.waitForSelector (/node_modules/puppeteer/lib/DOMWorld.js:444:17) at Frame.waitForSelector (/node_modules/puppeteer/lib/FrameManager.js:628:47) at Frame.<anonymous> (/node_modules/puppeteer/lib/helper.js:111:23) at Frame.waitFor (/node_modules/puppeteer/lib/FrameManager.js:613:19) at Page.waitFor (/node_modules/puppeteer/lib/Page.js:1037:29) at Promise.all.selectors.map (/usr/src/app/index.js:116:22) at Array.map (<anonymous>) at configureScope (/usr/src/app/index.js:114:35)

- [ ] **Update release notes if necessary**
