### PR TITLE
[#1656] Fix unfiltered icon on no filter value [backend] [client]

### DIFF
--- a/backend/src/akvo/lumen/lib/aggregation.clj
+++ b/backend/src/akvo/lumen/lib/aggregation.clj
@@ -100,27 +100,27 @@
                                  layers)]
     (cond
       (not (contains? map-datasets-ids (:datasetId filters)))
-      (assoc visualisation :unfiltered true)
+      (assoc visualisation :filterAffected false)
 
       :else
       (-> visualisation
-          (assoc :unfiltered false)
+          (assoc :filterAffected true)
           (a.maps/add-filters filters)))))
 
 (defmethod merge-dashboard-filters :default [visualisation filters]
   (cond
     (not (= (:datasetId visualisation) ;; Valid filter but no match on datasets
             (:datasetId filters)))
-    (assoc visualisation :unfiltered true)
+    (assoc visualisation :filterAffected false)
 
     :else ;; Valid filter and matching dataset
     (-> visualisation
         (update-in [:spec "filters"] #(concat % (filter :value (:columns filters))))
-        (assoc :unfiltered false))))
+        (assoc :filterAffected true))))
 
 (defn dashboard-filters [visualisation filters]
   (if (empty? (:columns filters)) ;; No valid filter
-    (assoc visualisation :unfiltered false)
+    (assoc visualisation :filterAffected false)
     (merge-dashboard-filters visualisation filters)))
 
 (defn visualisation-response-data [tenant-conn id windshaft-url filters]

--- a/client/src/components/dashboard/Dashboard.jsx
+++ b/client/src/components/dashboard/Dashboard.jsx
@@ -281,11 +281,17 @@ class Dashboard extends Component {
     }
   }
 
-  onFilterChange(filter) {
+  onFilterChange(filter, needToAggregate) {
     const dashboard = this.state.dashboard;
     dashboard.filter = filter;
     this.setState({ dashboard });
-    this.onSave();
+    if (needToAggregate && dashboard.entities
+      && Object.values(dashboard.entities).length > 0
+      && Object.values(dashboard.entities).find(e => e.filterAffected)) {
+      this.onApplyFilterValue(filter);
+    } else {
+      this.onSave();
+    }
     trackEvent(DASHBOARD_FILTER_CHANGE, window.location.href);
   }
 

--- a/client/src/components/dashboard/DashboardCanvasItem.jsx
+++ b/client/src/components/dashboard/DashboardCanvasItem.jsx
@@ -90,9 +90,10 @@ export default function DashboardCanvasItem(props) {
     titleEl.current.getBoundingClientRect().height :
     TITLE_HEIGHT;
 
-  const { intl, item, exporting, canvasLayout } = props;
-  const { unfiltered } = item;
+  const { intl, item, filter, exporting, canvasLayout } = props;
+  const { filterAffected } = item;
   let marginTop = 0;
+  const dashFiltered = filter.columns.find(c => c.value);
 
   if (exporting) {
     const layoutItem = canvasLayout.filter(({ i }) => i === item.id)[0];
@@ -107,14 +108,15 @@ export default function DashboardCanvasItem(props) {
       style={{ marginTop }}
     >
       {item.type === 'visualisation' && (
-        <div className={`itemContainerWrap ${!exporting && unfiltered ? 'unFiltered' : ''}`}>
+        <div className={`itemContainerWrap ${!exporting && !filterAffected && dashFiltered ? 'unFiltered' : ''}`}>
           <div
             className="itemTitle"
             ref={titleEl}
           >
             <span
               title={
-                (exporting || unfiltered) ? intl.messages.not_affected_by_applied_filters : null
+                (exporting ||
+                  !filterAffected) ? intl.messages.not_affected_by_applied_filters : null
               }
             >
               <h2>{getTitle(item.visualisation)}</h2>
@@ -174,6 +176,7 @@ DashboardCanvasItem.propTypes = {
   rowHeight: PropTypes.number.isRequired,
   datasets: PropTypes.object.isRequired,
   metadata: PropTypes.object,
+  filter: PropTypes.object,
   onEntityUpdate: PropTypes.func.isRequired,
   onDeleteClick: PropTypes.func.isRequired,
   onFocus: PropTypes.func.isRequired,

--- a/client/src/components/dashboard/DashboardEditor.jsx
+++ b/client/src/components/dashboard/DashboardEditor.jsx
@@ -325,7 +325,7 @@ class DashboardEditor extends Component {
           onClick={() => {
             filter.columns.splice(idx, 1);
             this.props.dispatch(fetchColumn(filter.datasetId, null));
-            onFilterChange(filter);
+            onFilterChange(filter, true);
           }}
         >
           <span />
@@ -392,7 +392,7 @@ class DashboardEditor extends Component {
                       if (filter.datasetId !== id) {
                         filter.datasetId = id;
                         filter.columns = [];
-                        onFilterChange(filter);
+                        onFilterChange(filter, true);
                         if (id) {
                           this.props.dispatch(fetchDataset(id, true));
                         }
@@ -484,6 +484,7 @@ class DashboardEditor extends Component {
                     onFocus={() => {
                       this.setState({ focusedItem: item.id });
                     }}
+                    filter={filter}
                     focused={this.state.focusedItem === item.id}
                     item={this.getItemFromLibrary(item)}
                     datasets={this.props.datasets}

--- a/client/src/components/dashboard/shared/DashboardViewer.jsx
+++ b/client/src/components/dashboard/shared/DashboardViewer.jsx
@@ -126,6 +126,7 @@ class DashboardViewer extends Component {
           {sortedDashboard.map(item =>
             <DashboardViewerItem
               key={item.id}
+              filter={dashboard.filter}
               item={this.getItemFromProps(item)}
               layout={layout[item.id]}
               canvasWidth={windowWidth}

--- a/client/src/components/dashboard/shared/DashboardViewerItem.jsx
+++ b/client/src/components/dashboard/shared/DashboardViewerItem.jsx
@@ -96,13 +96,15 @@ export default class DashboardViewerItem extends Component {
   }
 
   render() {
-    const { item } = this.props;
+    const { item, filter } = this.props;
     const isText = item.type === 'text';
     const isVisualisation = (item.type === 'visualisation' && item.visualisation);
     const style = this.getItemStyle();
     const titleHeight = this.titleEl ?
       this.titleEl.getBoundingClientRect().height :
       TITLE_HEIGHT;
+    const dashFiltered = filter.columns.find(c => c.value);
+
     return (
       <div
         className={`DashboardViewerItem DashboardCanvasItem ${item.type}`}
@@ -110,7 +112,7 @@ export default class DashboardViewerItem extends Component {
       >
         {isVisualisation &&
           <div
-            className={`itemContainer visualisation ${item.visualisation.unfiltered ? 'unFiltered' : ''}`}
+            className={`itemContainer visualisation ${!item.visualisation.filterAffected && dashFiltered ? 'unFiltered' : ''}`}
           >
             <div
               className="itemTitle"
@@ -149,6 +151,7 @@ DashboardViewerItem.propTypes = {
   canvasWidth: PropTypes.number.isRequired,
   viewportType: PropTypes.oneOf(['small', 'medium', 'large']),
   datasets: PropTypes.object,
+  filter: PropTypes.object,
   metadata: PropTypes.object,
 };
 


### PR DESCRIPTION
- Rename visualisation.unfiltered prop to filterAffected [backend]
[client]

- Pass filter to DashboardCanvasItem and DashboardViewerItem to
  internally decide if dash[hasBeen]Filtered [client]

- [ ] **Update release notes if necessary**
