### PR TITLE
[#1656] Reuse visualisation by dataset condition [client]

### DIFF
--- a/client/src/components/dashboard/DashboardEditor.jsx
+++ b/client/src/components/dashboard/DashboardEditor.jsx
@@ -10,6 +10,7 @@ import DashboardVisualisationList from './DashboardVisualisationList';
 import DashboardCanvasItem from './DashboardCanvasItem';
 import { groupIntoPages } from '../../utilities/dashboard';
 import { datasetsWithVisualizations } from '../../utilities/dataset';
+import { withDatasetRelated } from '../../utilities/visualisation';
 import { filterColumns } from '../../utilities/column';
 import { A4 } from '../../constants/print';
 import SelectMenu from '../common/SelectMenu';
@@ -344,6 +345,7 @@ class DashboardEditor extends Component {
     const finderFilterSelectOptions = v => columnFilterSelectAllOptions &&
     columnFilterSelectAllOptions.find(o => (v ? o.value === v.column : false));
     const dashboardEntitiesVisualisations = Object.values(dashboard.entities).filter(e => e.type === 'visualisation').map(e => this.props.visualisations[e.id]);
+    const datasetCondition = withDatasetRelated(filter.datasetId);
     return (
       <div
         className={`DashboardEditor ${exporting ? 'DashboardEditor--exporting' : ''}`}
@@ -411,7 +413,7 @@ class DashboardEditor extends Component {
                     <div>
                       <span title={intl.messages.visualisations_that_can_be_filtered}>
                         {dashboardEntitiesVisualisations.filter(v =>
-                          v.datasetId === filter.datasetId).length}/
+                          datasetCondition(v)).length}/
                         {dashboardEntitiesVisualisations.length} <FormattedMessage id="visualisations" />
                       </span>
                     </div>

--- a/client/src/components/dashboard/DashboardVisualisationList.jsx
+++ b/client/src/components/dashboard/DashboardVisualisationList.jsx
@@ -4,7 +4,8 @@ import { FormattedMessage } from 'react-intl';
 import moment from 'moment';
 import { getIconUrl, getModifiedTimestamp } from '../../domain/entity';
 import { specIsValidForApi } from '../../utilities/aggregation';
-import { datasetsWithVisualizations, mapDatasetLayers } from '../../utilities/dataset';
+import { datasetsWithVisualizations } from '../../utilities/dataset';
+import { withDatasetRelated } from '../../utilities/visualisation';
 import SelectMenu from '../common/SelectMenu';
 import { trackEvent } from '../../utilities/analytics';
 import { FILTER_VISUALISATIONS_BY_DATASET_IN_DASHBOARD } from '../../constants/analytics';
@@ -16,20 +17,11 @@ const filterVisualisations = (visualisations, filterText, filterByDataset, sorte
   // with something more serious before users start to have thousands of visualisations
   if (sortedBy) { visualisations.sort((a, b) => b[sortedBy] - a[sortedBy]); }
 
-  let datasetCondition = () => true;
-  if (filterByDataset) {
-    datasetCondition = (viz, datasetId) => {
-      if (viz.visualisationType === 'map') {
-        return Boolean(mapDatasetLayers(viz).find(layerDatasetId =>
-          layerDatasetId === filterByDataset));
-      }
-      return datasetId === filterByDataset;
-    };
-  }
+  const datasetCondition = withDatasetRelated(filterByDataset);
 
   if (!filterText) {
     return visualisations.filter(viz =>
-      specIsValidForApi(viz.spec, viz.visualisationType) && datasetCondition(viz, viz.datasetId)
+      specIsValidForApi(viz.spec, viz.visualisationType) && datasetCondition(viz)
     );
   }
   return visualisations.filter((visualisation) => {

--- a/client/src/utilities/visualisation.js
+++ b/client/src/utilities/visualisation.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import itsSet from 'its-set';
+import { mapDatasetLayers } from './dataset';
 
 import specMappings from '../constants/Visualisation/visualisationSpecMappings';
 
@@ -23,4 +24,18 @@ export const remapVisualisationDataColumnMappings = (visualisation, newVisualisa
       }
       return result;
     }, {});
+};
+
+
+export const withDatasetRelated = (datasetId) => {
+  if (datasetId) {
+    return (viz) => {
+      if (viz.visualisationType === 'map') {
+        return Boolean(mapDatasetLayers(viz).find(layerDatasetId =>
+          layerDatasetId === datasetId));
+      }
+      return viz.datasetId === datasetId;
+    };
+  }
+  return () => true;
 };


### PR DESCRIPTION
Fix "On filter editor “x/n Visualisations” (x not working)"

- [ ] **Update release notes if necessary**
