### PR TITLE
[#2591] Increase timeoutSec to 100s using beta.cloud.google.com/backend-config service.yaml definition

### DIFF
--- a/ci/k8s/blue-green-gateway.yaml.template
+++ b/ci/k8s/blue-green-gateway.yaml.template
@@ -88,7 +88,6 @@ data:
                 proxy_set_header    X-Forwarded-Proto $http_x_forwarded_proto;
                 proxy_set_header    X-Blue-Green-State 'live';
                 proxy_pass          http://lumen-live;
-                proxy_read_timeout  120s;
             }
 
         }
@@ -106,7 +105,6 @@ data:
                 proxy_set_header    X-Blue-Green-State 'dark';
                 proxy_set_header    X-Forwarded-Proto $http_x_forwarded_proto;
                 proxy_pass          http://lumen-dark;
-                proxy_read_timeout  120s;
             }
         }
 kind: ConfigMap

--- a/ci/k8s/service.yaml
+++ b/ci/k8s/service.yaml
@@ -1,9 +1,17 @@
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: lumen-backendconfig
+spec:
+  timeoutSec: 100
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: lumen-live
   annotations:
       flipDate: ${UTCDATE}
+      beta.cloud.google.com/backend-config: '{"ports": {"80":"lumen-backendconfig}}'
       flipBy: ${ACCOUNT}
 spec:
   type: NodePort
@@ -22,6 +30,7 @@ metadata:
   name: lumen-dark
   annotations:
     flipDate: ${UTCDATE}
+    beta.cloud.google.com/backend-config: '{"ports": {"80":"lumen-backendconfig}}'
     flipBy: ${ACCOUNT}
 spec:
   type: NodePort
@@ -38,6 +47,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: lumen-blue-green-gateway
+  annotations:
+    beta.cloud.google.com/backend-config: '{"ports": {"80":"lumen-backendconfig}}'
 spec:
   type: NodePort
   ports:


### PR DESCRIPTION
lumen exporter service needs more than the 30s timeout default value

- [ ] **Update release notes if necessary**
