### PR TITLE
Issue 2606 wip

### DIFF
--- a/client/src/components/charts/MapVisualisation.jsx
+++ b/client/src/components/charts/MapVisualisation.jsx
@@ -371,8 +371,6 @@ export default class MapVisualisation extends Component {
     const layerGroupId = metadata.layerGroupId;
     const xCenter = [0, 0];
     const xZoom = 2;
-    document.getElementById('leafletMap').style.width = `${width}px`;
-    document.getElementById('leafletMap').style.height = `${height}px`;
 
     const node = this.leafletMapNode;
 
@@ -554,6 +552,10 @@ export default class MapVisualisation extends Component {
           }}
         >
           <div
+            style={{
+              height: mapHeight,
+              width: mapWidth,
+            }}
             className="leafletMap" id="leafletMap"
             ref={(ref) => { this.leafletMapNode = ref; }}
           />

--- a/client/src/components/charts/MapVisualisation.jsx
+++ b/client/src/components/charts/MapVisualisation.jsx
@@ -394,7 +394,9 @@ export default class MapVisualisation extends Component {
     const dimensionsChanged = Boolean(height !== this.oldHeight || width !== this.oldWidth);
 
     if (!haveDimensions || dimensionsChanged) {
-      this.map.invalidateSize();
+      setTimeout(() => {
+        map.invalidateSize(false);
+      }, 300);
       this.oldHeight = height;
       this.oldWidth = width;
     }

--- a/client/src/components/charts/MapVisualisation.jsx
+++ b/client/src/components/charts/MapVisualisation.jsx
@@ -553,8 +553,8 @@ export default class MapVisualisation extends Component {
         >
           <div
             style={{
-              height: mapHeight,
-              width: mapWidth,
+              height: `${height}px`,
+              width: `${width}px`,
             }}
             className="leafletMap" id="leafletMap"
             ref={(ref) => { this.leafletMapNode = ref; }}


### PR DESCRIPTION
Delay the call to `invalidateSize()` so the parent has the new dimension.

When we trigger the `renderLeafletMap` on `componentDidMount` and
`UNSAFE_componentWillReceiveProps` the dimensions of the parent container
element are the *old* ones.

Found it via:

    let parent = this.leafletMapNode.parentElement;
    console.log(parent.clientHeight, parentclientWidth);

More info:

    PaulLeCam/react-leaflet#40