### PR TITLE
[#2610] Dont abbreviate x-axis values

### DIFF
--- a/client/src/components/charts/LineChart.jsx
+++ b/client/src/components/charts/LineChart.jsx
@@ -242,9 +242,6 @@ export default class LineChart extends Component {
             const maxNodesForTooltip = 50;
             const showTooltip = numNodes <= maxNodesForTooltip;
             const abbreviateNumber = value => this.context.abbrNumber(value);
-
-            const xTickFormatConditional = series.metadata.type === 'number' ?
-              { tickFormat: abbreviateNumber } : {};
             const yTickFormat = (num) => {
               if (num >= 10000) {
                 return abbreviateNumber(num);
@@ -403,7 +400,6 @@ export default class LineChart extends Component {
                       transform: `rotate(45, ${xScale(val)}, 18)`,
                       fontSize: 10,
                     })}
-                    {...xTickFormatConditional}
                   />
                 </Svg>
               </div>


### PR DESCRIPTION
- [ ] **Update release notes if necessary**
Relates to #2610 
we (with @muloem ) agree on not abbreviate x-axis num values on this line chart viz type

Viz after changes:
<img width="990" alt="Screenshot 2020-03-16 at 16 31 17" src="https://user-images.githubusercontent.com/731829/76773985-9d067e00-67a3-11ea-9252-52922b301e0d.png">

