### PR TITLE
[#2537] Remove sampling in bubble/line/scatter v2 spec vizs and warn the user if results are greater than 2.5K 

### DIFF
--- a/backend/src/akvo/lumen/endpoint/aggregation.clj
+++ b/backend/src/akvo/lumen/endpoint/aggregation.clj
@@ -3,6 +3,7 @@
             [akvo.lumen.endpoint.commons.http :as http]
             [akvo.lumen.lib.aggregation :as aggregation]
             [cheshire.core :as json]
+            [clojure.tools.logging :as log]
             [clojure.spec.alpha :as s]
             [akvo.lumen.component.tenant-manager :as tenant-manager]
             [integrant.core :as ig])
@@ -23,7 +24,12 @@
                              visualisation-type
                              (json/parse-string query keyword))
           (catch JsonParseException e
-            (http/bad-request {:message (.getMessage e)})))
+            (log/error e)
+            (http/bad-request
+             {:message (format "JSON parse exception: %s" (.getMessage e))}))
+          (catch Exception e
+            (log/error e)
+            (http/internal-server-error {:message (.getMessage e)})))
         (http/bad-request {:message "No query supplied"})))))
 
 (defn routes [{:keys [tenant-manager] :as opts}]

--- a/backend/src/akvo/lumen/lib/aggregation.clj
+++ b/backend/src/akvo/lumen/lib/aggregation.clj
@@ -166,9 +166,11 @@
   (bar/query tenant-conn dataset query))
 
 (defmethod query* "scatter"
-  [tenant-conn dataset _ query]
+  [tenant-conn dataset v-type query]
   (scatter/query tenant-conn dataset query))
 
 (defmethod query* "bubble"
-  [tenant-conn dataset _ query]
+  [tenant-conn dataset v-type query]
   (bubble/query tenant-conn dataset query))
+
+

--- a/backend/src/akvo/lumen/lib/aggregation.clj
+++ b/backend/src/akvo/lumen/lib/aggregation.clj
@@ -166,11 +166,11 @@
   (bar/query tenant-conn dataset query))
 
 (defmethod query* "scatter"
-  [tenant-conn dataset v-type query]
+  [tenant-conn dataset _ query]
   (scatter/query tenant-conn dataset query))
 
 (defmethod query* "bubble"
-  [tenant-conn dataset v-type query]
+  [tenant-conn dataset _ query]
   (bubble/query tenant-conn dataset query))
 
 

--- a/backend/src/akvo/lumen/lib/aggregation/bubble.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/bubble.clj
@@ -13,8 +13,8 @@
       (format "count(%1$s%2$s)" (:columnName column) sql-type))
     (commons/sql-aggregation-subquery aggregation-method column)))
 
-(defn ^:deprecated query-v1
-  "version 1 works with sampling data, only current vizs without further modifications will use this version,
+(defn query-v1
+  "DEPRECATED: version 1 works with sampling data, only current vizs without further modifications will use this version,
    following modifications will use version 2 and user will be prompt to use aggregation facilities if sql results are
    higher than 2.5K rows"
   [tenant-conn {:keys [columns table-name]} query]

--- a/backend/src/akvo/lumen/lib/aggregation/bubble.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/bubble.clj
@@ -13,7 +13,10 @@
       (format "count(%1$s%2$s)" (:columnName column) sql-type))
     (commons/sql-aggregation-subquery aggregation-method column)))
 
-(defn query
+(defn ^:deprecated query-v1
+  "version 1 works with sampling data, only current vizs without further modifications will use this version,
+   following modifications will use version 2 and user will be prompt to use aggregation facilities if sql results are
+   higher than 2.5K rows"
   [tenant-conn {:keys [columns table-name]} query]
   (let [column-size  (find-column columns (:metricColumn query))
         column-bucket (find-column columns (:bucketColumn query))
@@ -37,3 +40,36 @@
                 :metadata {:type (:type column-size)}}]
       :common {:metadata {:sampled (= (count sql-response) max-points)}
                :data     (mapv (fn [[size-value label]] {:label label}) sql-response)}})))
+
+(defn query-v2
+  [tenant-conn {:keys [columns table-name]} query]
+  (let [column-size  (find-column columns (:metricColumn query))
+        column-bucket (find-column columns (:bucketColumn query))
+        max-points 2500
+        aggregation-method (if column-size (:metricAggregation query) "count")
+        subquery (format "(SELECT * FROM %1$s WHERE %2$s)z "
+                         table-name
+                         (sql-str columns (:filters query)))
+        sql-text (format "SELECT %1$s AS size, %2$s AS label 
+                          FROM %3$s 
+                          GROUP BY %2$s"
+                         (sql-aggregation-subquery aggregation-method (or column-size column-bucket))
+                         (:columnName column-bucket) ;; maybe we need to use => (or c-size c-bucket)
+                         subquery)
+        sql-response (run-query tenant-conn sql-text)]
+    (if (< (count sql-response) max-points)
+      (lib/ok
+       {:series [{:key      (:title column-size)
+                  :label    (:title column-size)
+                  :data     (mapv (fn [[size-value label]] {:value size-value}) sql-response)
+                  :metadata {:type (:type column-size)}}]
+        :common {:metadata {}
+                 :data     (mapv (fn [[size-value label]] {:label label}) sql-response)}})
+      (lib/bad-request
+       {:message (format "Results are more than %d. Please select another column or use a different aggregation."
+                         max-points)}))))
+
+(defn query [tenant-conn data query]
+  (if (= 1 (:version query))
+    (query-v1 tenant-conn data query)
+    (query-v2 tenant-conn data query)))

--- a/backend/src/akvo/lumen/lib/aggregation/line.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/line.clj
@@ -17,7 +17,10 @@
               "q3"                        "percentile_cont(0.75) WITHIN GROUP (ORDER BY %s)")
             (:columnName column-y))))
 
-(defn ^:deprecated query-v1
+(defn query-v1
+  "DEPRECATED: version 1 works with sampling data, only current vizs without further modifications will use this version,
+   following modifications will use version 2 and user will be prompt to use aggregation facilities if sql results are
+   higher than 2.5K rows"
   [tenant-conn {:keys [columns table-name]} query]
   (let [column-x      (find-column columns (:metricColumnX query))
         column-y      (find-column columns (:metricColumnY query))

--- a/backend/src/akvo/lumen/lib/aggregation/line.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/line.clj
@@ -17,7 +17,7 @@
               "q3"                        "percentile_cont(0.75) WITHIN GROUP (ORDER BY %s)")
             (:columnName column-y))))
 
-(defn query
+(defn ^:deprecated query-v1
   [tenant-conn {:keys [columns table-name]} query]
   (let [column-x      (find-column columns (:metricColumnX query))
         column-y      (find-column columns (:metricColumnY query))
@@ -47,3 +47,36 @@
                :data     (mapv (fn [[x-value y-value]]
                                  {:timestamp x-value})
                                sql-response)}})))
+
+(defn query-v2
+  [tenant-conn {:keys [columns table-name]} query]
+  (let [column-x      (find-column columns (:metricColumnX query))
+        column-y      (find-column columns (:metricColumnY query))
+        max-points    2500
+        aggregation (aggregation* (:metricAggregation query) column-y)
+        sql-text (format "SELECT %1$s AS x, %2$s AS y FROM %3$s WHERE %4$s %5$s ORDER BY x"
+                              (:columnName column-x)
+                              (or aggregation (:columnName column-y))
+                              table-name
+                              (sql-str columns (:filters query))
+                              (if aggregation (format  "GROUP BY %s" (:columnName column-x)) ""))
+        sql-response  (run-query tenant-conn sql-text)]
+    (if (< (count sql-response) max-points)
+      (lib/ok
+       {:series [{:key   (column-y :title)
+                  :label (column-y :title)
+                  :data  (mapv (fn [[x-value y-value]]
+                                 {:value y-value})
+                               sql-response)}]
+        :common {:metadata {:type    (:type column-x)}
+                 :data     (mapv (fn [[x-value y-value]]
+                                   {:timestamp x-value})
+                                 sql-response)}})
+      (lib/bad-request
+       {:message (format "Results are more than %d. Please select another column or use a different aggregation."
+                         max-points)}))))
+
+(defn query [tenant-conn data query]
+  (if (= 1 (:version query))
+    (query-v1 tenant-conn data query)
+    (query-v2 tenant-conn data query)))

--- a/backend/src/akvo/lumen/lib/aggregation/scatter.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/scatter.clj
@@ -16,8 +16,8 @@
      :data (serie-data :value sql-data index)
      :metadata {:type (:type column)}}))
 
-(defn ^:deprecated query-v1
-  "version 1 works with sampling data, only current vizs without further modifications will use this version,
+(defn query-v1
+  "DEPRECATED: version 1 works with sampling data, only current vizs without further modifications will use this version,
    following modifications will use version 2 and user will be prompt to use aggregation facilities if sql results are
    higher than 2.5K rows"
   [tenant-conn {:keys [columns table-name]} query]

--- a/backend/src/akvo/lumen/lib/aggregation/scatter.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/scatter.clj
@@ -16,7 +16,10 @@
      :data (serie-data :value sql-data index)
      :metadata {:type (:type column)}}))
 
-(defn query
+(defn ^:deprecated query-v1
+  "version 1 works with sampling data, only current vizs without further modifications will use this version,
+   following modifications will use version 2 and user will be prompt to use aggregation facilities if sql results are
+   higher than 2.5K rows"
   [tenant-conn {:keys [columns table-name]} query]
   (let [filter-sql (sql-str columns (:filters query))
         column-x (find-column columns (:metricColumnX query))
@@ -69,3 +72,59 @@
        :common {:metadata {:type (:type column-label)
                            :sampled (= (count sql-response) max-points)}
                 :data (serie-data :label sql-response 4)}})))
+
+(defn query-v2
+  [tenant-conn {:keys [columns table-name]} query]
+  (let [filter-sql (sql-str columns (:filters query))
+        column-x (find-column columns (:metricColumnX query))
+        column-y (find-column columns (:metricColumnY query))
+        column-size (find-column columns (:metricColumnSize query))
+        column-category (find-column columns (:bucketColumnCategory query))
+        column-label (find-column columns (:datapointLabelColumn query))
+        column-bucket (find-column columns (:bucketColumn query))
+        max-points 2500
+
+        aggregation (partial sql-aggregation-subquery (:metricAggregation query))
+
+        sql-text-with-aggregation
+        (format "SELECT %1$s AS x, %2$s AS y, %3$s AS size, %4$s AS category, %5$s AS label 
+                 FROM %6$s
+                 WHERE %7$s
+                 GROUP BY %5$s"
+                (aggregation column-x)
+                (aggregation column-y)
+                (aggregation column-size)
+                (aggregation column-category)
+                (:columnName column-bucket)
+                table-name
+                filter-sql)
+        sql-text-without-aggregation (format "SELECT %1$s AS x, %2$s AS y, %3$s AS size, %4$s AS category, %5$s AS label 
+                                              FROM %6$s 
+                                              WHERE %7$s
+                                              ORDER BY x"
+                         (:columnName column-x)
+                         (:columnName column-y)
+                         (:columnName column-size)
+                         (:columnName column-category)
+                         (:columnName column-label)
+                         table-name
+                         filter-sql)
+
+        sql-text (if column-bucket sql-text-with-aggregation sql-text-without-aggregation)
+        sql-response (run-query tenant-conn sql-text)]
+    (if (< (count sql-response) max-points)
+      (lib/ok
+       {:series (map-indexed
+                 (fn [idx column]
+                   (serie sql-response column idx))
+                 [column-x column-y column-size column-category])
+        :common {:metadata {:type (:type column-label)}
+                 :data (serie-data :label sql-response 4)}})
+      (lib/bad-request
+       {:message (format "Results are more than %d. Please select another column or use a different aggregation."
+                         max-points)}))))
+
+(defn query [tenant-conn data query]
+  (if (= 1 (:version query))
+    (query-v1 tenant-conn data query)
+    (query-v2 tenant-conn data query)))

--- a/client/src/components/visualisation/configMenu/BubbleConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/BubbleConfigMenu.jsx
@@ -71,15 +71,18 @@ const handleChangeSpec = (change, oldSpec, onChangeSpec, columnOptions) => {
   onChangeSpec(finalSpec);
 };
 
-function BarConfigMenu(props) {
+function BubbleConfigMenu(props) {
   const {
     visualisation,
-    onChangeSpec,
     columnOptions,
     aggregationOptions,
     intl,
   } = props;
   const spec = visualisation.spec;
+
+  const onChangeSpec = (data) => {
+    props.onChangeSpec({ ...data, version: 2 });
+  };
 
   return (
     <div>
@@ -265,7 +268,7 @@ function BarConfigMenu(props) {
   );
 }
 
-BarConfigMenu.propTypes = {
+BubbleConfigMenu.propTypes = {
   intl: intlShape,
   visualisation: PropTypes.object.isRequired,
   datasets: PropTypes.object.isRequired,
@@ -274,4 +277,4 @@ BarConfigMenu.propTypes = {
   aggregationOptions: PropTypes.array.isRequired,
 };
 
-export default injectIntl(BarConfigMenu);
+export default injectIntl(BubbleConfigMenu);

--- a/client/src/components/visualisation/configMenu/LineConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/LineConfigMenu.jsx
@@ -36,11 +36,14 @@ const getAxisLabel = (axis, spec, columnOptions) => {
 export default function LineConfigMenu(props) {
   const {
     visualisation,
-    onChangeSpec,
     columnOptions,
     aggregationOptions,
   } = props;
   const spec = visualisation.spec;
+
+  const onChangeSpec = (data) => {
+    props.onChangeSpec({ ...data, version: 2 });
+  };
 
   return (
     <div>

--- a/client/src/components/visualisation/configMenu/ScatterConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/ScatterConfigMenu.jsx
@@ -44,11 +44,15 @@ const getPopupLabelChoice = (spec) => {
 function ScatterConfigMenu(props) {
   const {
     visualisation,
-    onChangeSpec,
     columnOptions,
     aggregationOptions,
   } = props;
+
   const spec = visualisation.spec;
+
+  const onChangeSpec = (data) => {
+    props.onChangeSpec({ ...data, version: 2 });
+  };
 
   return (
     <div>


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

- add backward compatibility with v1 (the sampling one)
