### PR TITLE
[#2676] Adds support for exposing environment config to `/env` endpoint

### DIFF
--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -88,7 +88,8 @@
                                :piwik-site-id #duct/env "LUMEN_PIWIK_SITE_ID"
                                :lumen-deployment-color #duct/env "LUMEN_DEPLOYMENT_COLOR"
                                :lumen-deployment-environment #duct/env "LUMEN_DEPLOYMENT_ENVIRONMENT"
-                               :lumen-deployment-version #duct/env "LUMEN_DEPLOYMENT_VERSION"}
+                               :lumen-deployment-version #duct/env "LUMEN_DEPLOYMENT_VERSION"
+                               :tenant-manager #ig/ref :akvo.lumen.component.tenant-manager/tenant-manager}
 
  :akvo.lumen.endpoint.export/export {:exporter-api-url #duct/env [ "EXPORTER_API_URL" :or "http://localhost:3001" ]}
 
@@ -193,7 +194,7 @@
  :akvo.lumen.component.caddisfly/prod {:schema-uri #duct/env [ "LUMEN_CADDISFLY_SCHEMA_URI" :or "https://s3-eu-west-1.amazonaws.com/akvoflow-public/caddisfly-tests-v2.json"]}
 
  :akvo.lumen.component.authentication/public-client {:url #duct/env ["LUMEN_AUTH_URL" :or "https://akvofoundation.eu.auth0.com/"]
-                                                     :rsa-suffix-url  #duct/env ["LUMEN_AUTH_RSA_SUFFIX_URL" :or ".well-known/jwks.json"] 
+                                                     :rsa-suffix-url  #duct/env ["LUMEN_AUTH_RSA_SUFFIX_URL" :or ".well-known/jwks.json"]
                                                      :client-id #duct/env [ "LUMEN_AUTH_PUBLIC_CLIENT_ID" :or "7Ze0JP6Jjf7zItGy3ekyuTvwGyik4Lay"]
                                                      :end-session-endpoint-suffix #duct/env [ "LUMEN_AUTH_END_SESSION_ENDPOINT_SUFFIX" :or "v2/logout"]}
 

--- a/backend/resources/akvo/lumen/config.edn
+++ b/backend/resources/akvo/lumen/config.edn
@@ -160,7 +160,8 @@
                                                      #ig/ref :akvo.lumen.endpoint.share/share
                                                      #ig/ref :akvo.lumen.endpoint.transformation/transformation
                                                      #ig/ref :akvo.lumen.endpoint.user/user
-                                                     #ig/ref :akvo.lumen.endpoint.visualisation/visualisation]}
+                                                     #ig/ref :akvo.lumen.endpoint.visualisation/visualisation
+                                                     #ig/ref :akvo.lumen.endpoint.env/env]}
 
  :akvo.lumen.component.handler/handler-verify {:path "/verify"
                                                :middleware [#ig/ref :akvo.lumen.component.tenant-manager/wrap-label-tenant

--- a/backend/resources/akvo/lumen/migrations/tenants/022-environment.down.sql
+++ b/backend/resources/akvo/lumen/migrations/tenants/022-environment.down.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER IF EXISTS environment_history ON environment CASCADE;
+DROP TABLE IF EXISTS environment;
+
+DROP TABLE IF EXISTS history.environment;

--- a/backend/resources/akvo/lumen/migrations/tenants/022-environment.up.sql
+++ b/backend/resources/akvo/lumen/migrations/tenants/022-environment.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE environment (
+    id text PRIMARY KEY,
+    "value" jsonb NOT NULL,
+    created timestamptz NOT NULL DEFAULT now(),
+    modified timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+    PERFORM tardis('environment');
+    PERFORM install_update_modified('environment');
+END$$;
+--;;

--- a/backend/src/akvo/lumen/db/env.clj
+++ b/backend/src/akvo/lumen/db/env.clj
@@ -1,0 +1,4 @@
+(ns akvo.lumen.db.env
+  (:require [hugsql.core :as hugsql]))
+
+(hugsql/def-db-fns "akvo/lumen/lib/env.sql")

--- a/backend/src/akvo/lumen/endpoint/env.clj
+++ b/backend/src/akvo/lumen/endpoint/env.clj
@@ -1,9 +1,11 @@
 (ns akvo.lumen.endpoint.env
   (:require [akvo.lumen.component.authentication]
             [akvo.lumen.component.keycloak]
+            [akvo.lumen.lib.env :as env]
             [clojure.spec.alpha :as s]
             [clojure.tools.logging :as log]
             [integrant.core :as ig]
+            [akvo.lumen.protocols :as p]
             [akvo.lumen.specs :as lumen.s]
             [ring.util.response :as response]))
 
@@ -13,7 +15,8 @@
 
 (defn handler
   [{:keys [public-client flow-api lumen-deployment-color lumen-deployment-environment
-           lumen-deployment-version piwik-site-id sentry-client-dsn]}]
+           lumen-deployment-version piwik-site-id sentry-client-dsn
+           tenant-manager]}]
   (fn [{tenant :tenant
         :as request}]
     (let [{:keys [url client-id end-session-endpoint-suffix open-id-config]} public-client]
@@ -31,7 +34,8 @@
                 "lumenDeploymentEnvironment" lumen-deployment-environment
                 "lumenDeploymentVersion" lumen-deployment-version
                 "piwikSiteId" piwik-site-id
-                "tenant" (:tenant request)}
+                "tenant" (:tenant request)
+                "environment" (env/all (p/connection tenant-manager (:tenant request)))}
          (string? sentry-client-dsn)
          (assoc "sentryDSN" sentry-client-dsn))))))
 

--- a/backend/src/akvo/lumen/endpoint/env.clj
+++ b/backend/src/akvo/lumen/endpoint/env.clj
@@ -21,23 +21,24 @@
         :as request}]
     (let [{:keys [url client-id end-session-endpoint-suffix open-id-config]} public-client]
       (response/response
-       (cond-> {"auth" {"clientId" client-id
-                        "url" url
-                        "domain" (:issuer open-id-config)
-                        "endpoints" {"issuer" (:issuer open-id-config)
-                                     "authorization" (:authorization_endpoint open-id-config)
-                                     "userinfo" (:userinfo_endpoint open-id-config)
-                                     "endSession" (:end_session_endpoint open-id-config (str (:issuer open-id-config) end-session-endpoint-suffix))
-                                     "jwksUri" (:jwks_uri open-id-config)}}
-                "flowApiUrl" (:url flow-api)
-                "lumenDeploymentColor" lumen-deployment-color
-                "lumenDeploymentEnvironment" lumen-deployment-environment
-                "lumenDeploymentVersion" lumen-deployment-version
-                "piwikSiteId" piwik-site-id
-                "tenant" (:tenant request)
-                "environment" (env/all (p/connection tenant-manager (:tenant request)))}
-         (string? sentry-client-dsn)
-         (assoc "sentryDSN" sentry-client-dsn))))))
+       (if (get-in request [:jwt-claims "sub"])
+         {"environment" (env/all (p/connection tenant-manager (:tenant request)))}
+         (cond-> {"auth" {"clientId" client-id
+                          "url" url
+                          "domain" (:issuer open-id-config)
+                          "endpoints" {"issuer" (:issuer open-id-config)
+                                       "authorization" (:authorization_endpoint open-id-config)
+                                       "userinfo" (:userinfo_endpoint open-id-config)
+                                       "endSession" (:end_session_endpoint open-id-config (str (:issuer open-id-config) end-session-endpoint-suffix))
+                                       "jwksUri" (:jwks_uri open-id-config)}}
+                  "flowApiUrl" (:url flow-api)
+                  "lumenDeploymentColor" lumen-deployment-color
+                  "lumenDeploymentEnvironment" lumen-deployment-environment
+                  "lumenDeploymentVersion" lumen-deployment-version
+                  "piwikSiteId" piwik-site-id
+                  "tenant" (:tenant request)}
+           (string? sentry-client-dsn)
+           (assoc "sentryDSN" sentry-client-dsn)))))))
 
 (defn routes [{:keys [routes-opts] :as opts}]
   ["/env" (merge {:get {:handler (handler opts)}}

--- a/backend/src/akvo/lumen/lib/env.clj
+++ b/backend/src/akvo/lumen/lib/env.clj
@@ -1,0 +1,9 @@
+(ns akvo.lumen.lib.env
+  (:require [akvo.lumen.db.env :as db.env]))
+
+(defn all
+  [tenant-conn]
+  (let [config (db.env/all-values tenant-conn)]
+    (reduce (fn [acc {:keys [id value]}]
+              (assoc acc id value))
+            {} config)))

--- a/backend/src/akvo/lumen/lib/env.sql
+++ b/backend/src/akvo/lumen/lib/env.sql
@@ -1,0 +1,3 @@
+-- :name all-values
+-- :doc All values defined in `environment` table
+SELECT id, "value" FROM environment


### PR DESCRIPTION
The new `environment` table is a "id => value" type of setup where the
`id` is any string and `value` is any JSON value. Since a JSON value
can be Boolean|Number|Null|Array|Object we can (ab)use it as we want.

Simple boolean value for feature flag:

The `environemnt` table is empty

```
$ curl http://t1.lumen.local:3030/env | jq -M .
{
  "auth": {
    "clientId": "akvo-lumen",
    "url": "http://auth.lumen.local:8080/auth/realms/akvo",
    "domain": "http://auth.lumen.local:8080/auth/realms/akvo",
    "endpoints": {
      "issuer": "http://auth.lumen.local:8080/auth/realms/akvo",
      "authorization": "http://auth.lumen.local:8080/auth/realms/akvo/protocol/openid-connect/auth",
      "userinfo": "http://auth.lumen.local:8080/auth/realms/akvo/protocol/openid-connect/userinfo",
      "endSession": "http://auth.lumen.local:8080/auth/realms/akvo/protocol/openid-connect/logout",
      "jwksUri": "http://auth.lumen.local:8080/auth/realms/akvo/protocol/openid-connect/certs"
    }
  },
  "piwikSiteId": "165",
  "lumenDeploymentColor": "Local dev",
  "flowApiUrl": "https://api.akvotest.org/flow",
  "environment": {},
  "tenant": "t1",
  "sentryDSN": "dev-sentry-client-dsn",
  "lumenDeploymentVersion": "The evaled code",
  "lumenDeploymentEnvironment": "docker-compose"
}
```

Insert a new environment property with key `rqg` and value `true`

```
$ psql -U lumen -d lumen_tenant_1 -h localhost \
  -c "INSERT INTO environment(id, \"value\") VALUES ('rqg', 'true'::jsonb)"
Password for user lumen:
INSERT 0 1
```

A new request to `/env`, See the value added to the `environment` key:

```
$ curl http://t1.lumen.local:3030/env | jq -M .
{
  "auth": {
    "clientId": "akvo-lumen",
    "url": "http://auth.lumen.local:8080/auth/realms/akvo",
    "domain": "http://auth.lumen.local:8080/auth/realms/akvo",
    "endpoints": {
      "issuer": "http://auth.lumen.local:8080/auth/realms/akvo",
      "authorization": "http://auth.lumen.local:8080/auth/realms/akvo/protocol/openid-connect/auth",
      "userinfo": "http://auth.lumen.local:8080/auth/realms/akvo/protocol/openid-connect/userinfo",
      "endSession": "http://auth.lumen.local:8080/auth/realms/akvo/protocol/openid-connect/logout",
      "jwksUri": "http://auth.lumen.local:8080/auth/realms/akvo/protocol/openid-connect/certs"
    }
  },
  "piwikSiteId": "165",
  "lumenDeploymentColor": "Local dev",
  "flowApiUrl": "https://api.akvotest.org/flow",
  "environment": {
    "rqg": true
  },
  "tenant": "t1",
  "sentryDSN": "dev-sentry-client-dsn",
  "lumenDeploymentVersion": "The evaled code",
  "lumenDeploymentEnvironment": "docker-compose"
}
```
