### PR TITLE
[#2676] Calls `/api/env` after authentication

### DIFF
--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -115,6 +115,12 @@ function feedUserProfile(user, env, token) {
     }));
 }
 
+function dynamicEnv(res) {
+  return Promise.resolve(
+    get('/api/env').then(envresp => ({ profile: res.profile, env: Object.assign(res.env, envresp.body) }))
+  );
+}
+
 function dispatchOnMode() {
   const queryParams = queryString.parse(location.search);
   const accessToken = queryParams.access_token;
@@ -139,6 +145,7 @@ function dispatchOnMode() {
             return feedUserProfile(user, body);
           }
         })
+        .then(res => dynamicEnv(res))
         .then((res) => {
           if (res) {
             initAuthenticated(res.profile, res.env);


### PR DESCRIPTION
Call `/api/env` after getting the user profile, which means after knowing that we have the auth token.
The resulting `env` object contains the static configuration *plus* a _dynamic_ `environment` key.