### PR TITLE
[#2127] Using one text column to represent a flow RQG [skip ci]

### DIFF
--- a/backend/specs/akvo/lumen/specs/import/column.clj
+++ b/backend/specs/akvo/lumen/specs/import/column.clj
@@ -17,10 +17,12 @@
 (create-ns  'akvo.lumen.specs.import.column.date)
 (create-ns  'akvo.lumen.specs.import.column.geoshape)
 (create-ns  'akvo.lumen.specs.import.column.geopoint)
+(create-ns  'akvo.lumen.specs.import.column.rqg)
 (create-ns  'akvo.lumen.specs.import.column.multiple)
 (create-ns  'akvo.lumen.specs.import.column.multiple.caddisfly)
 (create-ns 'akvo.lumen.specs.import.column.multiple.geo-shape-features)
 
+(alias 'c.rqg 'akvo.lumen.specs.import.column.rqg)
 (alias 'c.text 'akvo.lumen.specs.import.column.text)
 (alias 'c.number 'akvo.lumen.specs.import.column.number)
 (alias 'c.date 'akvo.lumen.specs.import.column.date)
@@ -38,12 +40,16 @@
 (s/def ::c.geoshape/type #{"geoshape"})
 (s/def ::c.geopoint/type #{"geopoint"})
 (s/def ::c.multiple/type #{"multiple"})
+(s/def ::c.rqg/type #{"rqg"})
 
 (s/def ::column-header (s/keys :req-un [::v/title]
                                :opt-un [::v/id]))
 
 (s/def ::c.text/header* (s/keys :req-un [::c.text/type] :opt-un [::v/key]))
 (s/def ::c.text/header (s/merge ::column-header ::c.text/header*))
+
+(s/def ::c.rqg/header* (s/keys :req-un [::c.rqg/type] :opt-un [::v/key]))
+(s/def ::c.rqg/header (s/merge ::column-header ::c.rqg/header*))
 
 (s/def ::c.number/header* (s/keys :req-un [::c.number/type]))
 (s/def ::c.number/header (s/merge ::column-header ::c.number/header*))
@@ -77,6 +83,7 @@
 (s/def ::c.multiple/header (s/merge ::column-header ::c.multiple/header*))
 
 (defmulti column-header :type)
+(defmethod column-header "rqg" [_] ::c.rqg/header)
 (defmethod column-header "text" [_] ::c.text/header)
 (defmethod column-header "date" [_] ::c.date/header)
 (defmethod column-header "number" [_] ::c.number/header)
@@ -87,6 +94,8 @@
 (s/def ::header (s/multi-spec column-header :type))
 
 (s/def ::c.text/value string?)
+
+(s/def ::c.rqg/value any?)
 
 (s/def ::c.number/value double?)
 

--- a/backend/specs/akvo/lumen/specs/import/column.clj
+++ b/backend/specs/akvo/lumen/specs/import/column.clj
@@ -145,7 +145,7 @@
 (defmulti column-body (fn[{:keys [type] :as o}] type))
 
 (s/def ::c.text/body (s/keys :req-un [::c.text/type ::c.text/value]))
-(s/def ::c.text/body (s/keys :req-un [::c.rqg/type ::c.rqg/value]))
+(s/def ::c.rqg/body (s/keys :req-un [::c.rqg/type ::c.rqg/value]))
 (s/def ::c.number/body (s/keys :req-un [::c.number/type ::c.number/value]))
 (s/def ::c.date/body (s/keys :req-un [::c.date/type ::c.date/value]))
 (s/def ::c.multiple/body (s/keys :req-un [::c.multiple/type ::c.multiple/value]))

--- a/backend/specs/akvo/lumen/specs/import/column.clj
+++ b/backend/specs/akvo/lumen/specs/import/column.clj
@@ -145,6 +145,7 @@
 (defmulti column-body (fn[{:keys [type] :as o}] type))
 
 (s/def ::c.text/body (s/keys :req-un [::c.text/type ::c.text/value]))
+(s/def ::c.text/body (s/keys :req-un [::c.rqg/type ::c.rqg/value]))
 (s/def ::c.number/body (s/keys :req-un [::c.number/type ::c.number/value]))
 (s/def ::c.date/body (s/keys :req-un [::c.date/type ::c.date/value]))
 (s/def ::c.multiple/body (s/keys :req-un [::c.multiple/type ::c.multiple/value]))
@@ -152,6 +153,7 @@
 (s/def ::c.geopoint/body (s/keys :req-un [::c.geopoint/type ::c.geopoint/value]))
 
 (defmethod column-body "text" [_] ::c.text/body)
+(defmethod column-body "rqg" [_] ::c.rqg/body)
 (defmethod column-body "number" [_] ::c.number/body)
 (defmethod column-body "date" [_] ::c.date/body)
 (defmethod column-body "multiple" [_] ::c.multiple/body)
@@ -164,6 +166,8 @@
 
 (defmethod column "text" [_]
   (s/keys :req-un [::c.text/header ::c.text/body]))
+(defmethod column "rqg" [_]
+  (s/keys :req-un [::c.rqg/header ::c.text/body]))
 (defmethod column "number" [_]
   (s/keys :req-un [::c.number/header ::c.number/body]))
 (defmethod column "date" [_]

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -36,13 +36,14 @@
                                :table-name table-name
                                :imported-table-name imported-table-name
                                :version 1
-                               :columns (mapv (fn [{:keys [title id type key multipleType multipleId groupName groupId]}]
+                               :columns (mapv (fn [{:keys [metadata title id type key multipleType multipleId groupName groupId]}]
                                                 {:columnName id
                                                  :direction nil
                                                  :hidden false
                                                  :key (boolean key)
                                                  :multipleId multipleId
                                                  :multipleType multipleType
+                                                 :metadata metadata
                                                  :groupName groupName
                                                  :groupId groupId
                                                  :sort nil

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -8,6 +8,7 @@
             [akvo.lumen.db.transformation :as db.transformation]
             [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.import.csv]
+            [akvo.lumen.lib.env :as env]
             [akvo.lumen.lib.import.flow]
             [akvo.lumen.lib.import.csv]
             [akvo.lumen.lib.raster]
@@ -67,7 +68,8 @@
   (future
     (let [table-name (util/gen-table-name "ds")]
       (try
-        (with-open [importer (common/dataset-importer (get spec "source") import-config)]
+        (with-open [importer (common/dataset-importer (get spec "source")
+                                                      (assoc import-config :environment (env/all conn)))]
           (let [columns (p/columns importer)]
             (postgres/create-dataset-table conn table-name columns)
             (doseq [record (map postgres/coerce-to-sql (take common/rows-limit (p/records importer)))]

--- a/backend/src/akvo/lumen/lib/import/common.clj
+++ b/backend/src/akvo/lumen/lib/import/common.clj
@@ -38,6 +38,7 @@
             {:title (:name q)
              :type t
              :groupId (:groupId q)
+             :metadata (:metadata q)
              :groupName (:groupName q)
              :id (format "c%s" (:id q))}
             (when (= t "multiple")

--- a/backend/src/akvo/lumen/lib/import/flow.clj
+++ b/backend/src/akvo/lumen/lib/import/flow.clj
@@ -14,7 +14,7 @@
 
 (defmethod import/dataset-importer "AKVO_FLOW"
   [{:strs [instance surveyId formId token email version] :as spec}
-   {:keys [flow-api] :as config}]
+   {:keys [flow-api environment] :as config}]
   (let [version (if version version 1)
         headers-fn #((:internal-api-headers flow-api) {:email email :token token})
         survey (delay (flow-common/survey-definition (:internal-url flow-api)
@@ -28,8 +28,8 @@
       (columns [this]
         (try
           (cond
-            (<= version 2) (v2/dataset-columns (flow-common/form @survey formId))
-            (<= version 3) (v3/dataset-columns (flow-common/form @survey formId)))
+            (<= version 2) (v2/dataset-columns environment (flow-common/form @survey formId))
+            (<= version 3) (v3/dataset-columns environment (flow-common/form @survey formId)))
           (catch Throwable e
             (if-let [ex-d (ex-data e)]
               (do
@@ -42,8 +42,8 @@
       (records [this]
         (try
           (cond
-            (<= version 2) (v2/form-data headers-fn @survey formId)
-            (<= version 3) (v3/form-data headers-fn instance @survey formId))
+            (<= version 2) (v2/form-data environment headers-fn @survey formId)
+            (<= version 3) (v3/form-data environment headers-fn instance @survey formId))
           (catch Throwable e
             (if-let [ex-d (ex-data e)]
               (throw (ex-info (or (:cause e) (str "Null cause from instance: " instance))

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -91,16 +91,17 @@
                                       :repeatable repeatable
                                       ))
                              (if (:repeatable %2)
-                               (do
-                                 ;; we take the first repeatable question of this QG and adapt its props
-                                 [(-> (:questions %2)
-                                     first
-                                     (assoc :id (:id %2))
-                                     (assoc :name (str (:name %2) "_Q"))
-                                     (assoc :type "RQG"))])
-                                 (:questions %2)) (repeat [(:id %2)
-                                                        (str/trim (:name %2))
-                                                        (:repeatable %2)]))) [])))
+                               (let [rqg (-> (:questions %2) 
+                                             first ;; we take the first repeatable question of this QG and adapt its props
+                                             (assoc :id (:id %2))
+                                             (assoc :name (str (:name %2) "_Q"))
+                                             (assoc :metadata (common/coerce question-type->lumen-type (:questions %2)))
+                                             (assoc :type "RQG"))]
+                                 [rqg])
+                               (:questions %2))
+                             (repeat [(:id %2)
+                                      (str/trim (:name %2))
+                                      (:repeatable %2)]))) [])))
 
 (defn form
   "Get a form by id from a survey"

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -80,7 +80,8 @@
     "RQG" "rqg"
     "text"))
 
-(defn questions
+
+(defn questions-v2
   "Get the list of questions from a form"
   [form]
   (->> (:questionGroups form)
@@ -102,6 +103,19 @@
                              (repeat [(:id %2)
                                       (str/trim (:name %2))
                                       (:repeatable %2)]))) [])))
+
+(defn questions-v1 [form]
+  (->> (:questionGroups form)
+       (reduce #(into % (map (fn [q* [group-id group-name]]
+                               (assoc q* :groupId group-id :groupName group-name))
+                             (:questions %2) (repeat [(:id %2) (str/trim (:name %2))]))) [])))
+
+(defn questions
+  "Get the list of questions from a form"
+  [environment form]
+  (if (first (get environment "rqg"))
+    (questions-v2 form)
+    (questions-v1 form)))
 
 (defn form
   "Get a form by id from a survey"

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -70,9 +70,23 @@
   "Get the list of questions from a form"
   [form]
   (->> (:questionGroups form)
-       (reduce #(into % (map (fn [q* [group-id group-name]]
-                               (assoc q* :groupId group-id :groupName group-name))
-                             (:questions %2) (repeat [(:id %2) (str/trim (:name %2))]))) [])))
+       (reduce #(into % (map (fn [q* [group-id group-name repeatable]]
+                               (assoc q*
+                                      :groupId group-id
+                                      :groupName group-name
+                                      :repeatable repeatable
+                                      ))
+                             (if (:repeatable %2)
+                               (do
+                                 ;; we take the first repeatable question of this QG and adapt its props
+                                 [(-> (:questions %2)
+                                     first
+                                     (assoc :id (:id %2))
+                                     (assoc :name (str (:name %2) "_Q"))
+                                     (assoc :type "RQG"))])
+                                 (:questions %2)) (repeat [(:id %2)
+                                                        (str/trim (:name %2))
+                                                        (:repeatable %2)]))) [])))
 
 (defn form
   "Get a form by id from a survey"
@@ -90,10 +104,18 @@
 ;; {question-id -> first-response}
 (defn question-responses
   "Returns a map from question-id to the first response iteration"
-  [responses]
-  (->> (vals responses)
-       (map first)
-       (apply merge)))
+  [questions responses]
+  (let [ids-to-adapt (clojure.set/intersection
+                      (set (map :id (filter :repeatable questions)))
+                      (set (keys responses)))
+        adapted-responses (reduce
+                           (fn [c id]
+                             (assoc c id [{id (get c id)}]))
+                           responses
+                           ids-to-adapt)]
+    (->> (vals adapted-responses)
+         (map first)
+         (apply merge))))
 
 (defn commons-columns [form]
   [(cond-> {:title "Identifier" :type "text" :id "identifier"}

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -4,6 +4,7 @@
    [akvo.lumen.http.client :as http.client]
    [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.tools.logging :as log]
    [diehard.core :as dh])
@@ -105,7 +106,7 @@
 (defn question-responses
   "Returns a map from question-id to the first response iteration"
   [questions responses]
-  (let [ids-to-adapt (clojure.set/intersection
+  (let [ids-to-adapt (set/intersection
                       (set (map :id (filter :repeatable questions)))
                       (set (keys responses)))
         adapted-responses (reduce

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.import.flow-common
   (:require
    [akvo.commons.psql-util :as pg]
+   [akvo.lumen.lib.import.common :as common]
    [akvo.lumen.http.client :as http.client]
    [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
@@ -66,6 +67,18 @@
       (recur (into all-data-points (get response "dataPoints"))
              (data-points* headers-fn url))
       (into all-data-points (get response "dataPoints")))))
+
+(defn question-type->lumen-type
+  [question]
+  (condp = (:type question)
+    "NUMBER" "number"
+    "DATE" "date"
+    "GEO" "geopoint"
+    "GEOSHAPE" "geoshape"
+    "GEO-SHAPE-FEATURES" "multiple"
+    "CADDISFLY" "multiple"
+    "RQG" "rqg"
+    "text"))
 
 (defn questions
   "Get the list of questions from a form"

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -9,12 +9,12 @@
   (:import [java.time Instant]))
 
 (defn dataset-columns
-  [form]
+  [environment form]
   (into (flow-common/commons-columns form)
         (into
          [{:title "Latitude" :type "number" :id "latitude"}
           {:title "Longitude" :type "number" :id "longitude"}]
-         (common/coerce flow-common/question-type->lumen-type (flow-common/questions form)))))
+         (common/coerce flow-common/question-type->lumen-type (flow-common/questions environment form)))))
 
 (defmulti render-response
   (fn [type response]
@@ -82,8 +82,8 @@
   nil)
 
 (defn response-data
-  [form responses]
-  (let [questions (flow-common/questions form)
+  [environment form responses]
+  (let [questions (flow-common/questions environment form)
         responses (flow-common/question-responses questions responses)]
     (reduce (fn [response-data {:keys [type id]}]
               (if-let [response (get responses id)]
@@ -96,7 +96,7 @@
 
 (defn form-data
   "Returns a lazy sequence of form data, ready to be inserted as a lumen dataset"
-  [headers-fn survey form-id]
+  [_ headers-fn survey form-id]
   (let [form (flow-common/form survey form-id)
         data-points (util/index-by "id" (flow-common/data-points headers-fn survey))]
     (map (fn [form-instance]

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -96,13 +96,13 @@
 
 (defn form-data
   "Returns a lazy sequence of form data, ready to be inserted as a lumen dataset"
-  [_ headers-fn survey form-id]
+  [environment headers-fn survey form-id]
   (let [form (flow-common/form survey form-id)
         data-points (util/index-by "id" (flow-common/data-points headers-fn survey))]
     (map (fn [form-instance]
            (let [data-point-id (get form-instance "dataPointId")
                  data-point (get data-points data-point-id)]
-             (merge (response-data form (get form-instance "responses"))
+             (merge (response-data environment form (get form-instance "responses"))
                     (flow-common/common-records form-instance data-point)
                     {:latitude (get-in data-points [data-point-id "latitude"])
                      :longitude (get-in data-points [data-point-id "longitude"])})))

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -8,21 +8,13 @@
             [clojure.string :as str])
   (:import [java.time Instant]))
 
-
-(defn question-type->lumen-type
-  [question]
-  (condp = (:type question)
-    "NUMBER" "number"
-    "DATE" "date"
-    "text"))
-
 (defn dataset-columns
   [form]
   (into (flow-common/commons-columns form)
         (into
          [{:title "Latitude" :type "number" :id "latitude"}
           {:title "Longitude" :type "number" :id "longitude"}]
-         (common/coerce question-type->lumen-type (flow-common/questions form)))))
+         (common/coerce flow-common/question-type->lumen-type (flow-common/questions form)))))
 
 (defmulti render-response
   (fn [type response]

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -77,6 +77,10 @@
   [_ response]
   (json/generate-string response))
 
+(defmethod render-response "RQG"
+  [_ response]
+  response)
+
 (defmethod render-response "GEO-SHAPE-FEATURES"
   [_ response]
   (json/generate-string response))
@@ -87,7 +91,8 @@
 
 (defn response-data
   [form responses]
-  (let [responses (flow-common/question-responses responses)]
+  (let [questions (flow-common/questions form)
+        responses (flow-common/question-responses questions responses)]
     (reduce (fn [response-data {:keys [type id]}]
               (if-let [response (get responses id)]
                 (assoc response-data
@@ -95,7 +100,7 @@
                        (render-response type response))
                 response-data))
             {}
-            (flow-common/questions form))))
+            questions)))
 
 (defn form-data
   "Returns a lazy sequence of form data, ready to be inserted as a lumen dataset"

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -19,6 +19,7 @@
     "GEOSHAPE" "geoshape"
     "GEO-SHAPE-FEATURES" "multiple"
     "CADDISFLY" "multiple"
+    "RQG" "multiplejson"
     "text"))
 
 (defn flow-questions [form]
@@ -78,15 +79,18 @@
 
 (defn response-data
   [form responses]
-  (let [responses (flow-common/question-responses responses)]
-    (reduce (fn [response-data {:keys [type id derived-id derived-fn]}]
+  
+  (let [questions (flow-questions form)
+        responses (flow-common/question-responses questions responses)]
+    (reduce (fn [response-data {:keys [type id repeatable derived-id derived-fn]}]
               (if-let [response ((or derived-fn identity) (get responses (or derived-id id)))]
+                
                 (assoc response-data
                        (format "c%s" id)
                        (render-response type response))
                 response-data))
             {}
-            (flow-questions form))))
+            questions)))
 
 (defn form-data
   "First pulls all data-points belonging to the survey. Then map over all form

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -9,7 +9,7 @@
             [akvo.lumen.lib.import.flow-v2 :as v2])
   (:import [java.time Instant]))
 
-(defn flow-questions [form]
+(defn flow-questions [environment form]
   (reduce
    (fn [c  i]
      (if (= "GEOSHAPE" (:type i))
@@ -22,13 +22,13 @@
                                              (assoc :derived-fn (fn [x] (-> x (w/keywordize-keys) :features first :properties)))
                                              (update :name (fn [o] (str o " Features" )))
                                              (assoc :id id)))) [i] (range 1)))
-       (conj c i))) [] (flow-common/questions form)))
+       (conj c i))) [] (flow-common/questions environment form)))
 
 (defn dataset-columns
   "returns a vector of [{:title :type :id :key}]
   `:key` is optional"
-  [form]
-  (let [questions (flow-questions form)]
+  [environment form]
+  (let [questions (flow-questions environment form)]
     (into (flow-common/commons-columns form)
           (into [{:title "Device Id" :type "text" :id "device_id"}]
                 (common/coerce flow-common/question-type->lumen-type questions)))))
@@ -65,9 +65,9 @@
     (v2/render-response type response)))
 
 (defn response-data
-  [form responses]
+  [environment form responses]
   
-  (let [questions (flow-questions form)
+  (let [questions (flow-questions environment form)
         responses (flow-common/question-responses questions responses)]
     (reduce (fn [response-data {:keys [type id repeatable derived-id derived-fn]}]
               (if-let [response ((or derived-fn identity) (get responses (or derived-id id)))]

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -19,7 +19,7 @@
     "GEOSHAPE" "geoshape"
     "GEO-SHAPE-FEATURES" "multiple"
     "CADDISFLY" "multiple"
-    "RQG" "multiplejson"
+    "RQG" "rqg"
     "text"))
 
 (defn flow-questions [form]

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -82,14 +82,14 @@
 (defn form-data
   "First pulls all data-points belonging to the survey. Then map over all form
   instances and pulls additional data-point data using the forms data-point-id."
-  [headers-fn instance survey form-id]
+  [environment headers-fn instance survey form-id]
   (let [form (flow-common/form survey form-id)
         data-points (util/index-by
                      "id" (flow-common/data-points headers-fn survey))]
     (map (fn [form-instance]
            (let [data-point-id (get form-instance "dataPointId")]
              (if-let [data-point (get data-points data-point-id)]
-               (merge (response-data form (get form-instance "responses"))
+               (merge (response-data environment form (get form-instance "responses"))
                       (flow-common/common-records form-instance data-point)
                       {:device_id (get form-instance "deviceIdentifier")})
                (throw (ex-info "Flow form (dataPointId) referenced data point not in survey"

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -9,19 +9,6 @@
             [akvo.lumen.lib.import.flow-v2 :as v2])
   (:import [java.time Instant]))
 
-
-(defn question-type->lumen-type
-  [question]
-  (condp = (:type question)
-    "NUMBER" "number"
-    "DATE" "date"
-    "GEO" "geopoint"
-    "GEOSHAPE" "geoshape"
-    "GEO-SHAPE-FEATURES" "multiple"
-    "CADDISFLY" "multiple"
-    "RQG" "rqg"
-    "text"))
-
 (defn flow-questions [form]
   (reduce
    (fn [c  i]
@@ -44,7 +31,7 @@
   (let [questions (flow-questions form)]
     (into (flow-common/commons-columns form)
           (into [{:title "Device Id" :type "text" :id "device_id"}]
-                (common/coerce question-type->lumen-type questions)))))
+                (common/coerce flow-common/question-type->lumen-type questions)))))
 
 (defn render-response
   [type response]

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -3,6 +3,7 @@
             [akvo.lumen.lib.import.common :as import]
             [akvo.lumen.postgres :as postgres]
             [akvo.lumen.lib :as lib]
+            [akvo.lumen.lib.env :as env]
             [akvo.lumen.lib.transformation.engine :as engine]
             [akvo.lumen.util :as util]
             [clojure.java.jdbc :as jdbc]
@@ -115,7 +116,9 @@
 
 (defn- do-update [tenant-conn caddisfly import-config dataset-id data-source-id job-execution-id data-source-spec]
   (jdbc/with-db-transaction [conn tenant-conn]
-    (with-open [importer (import/dataset-importer (get data-source-spec "source") import-config)]
+    (with-open [importer (import/dataset-importer (get data-source-spec "source")
+                                                  (assoc import-config
+                                                         :environment (env/all conn)))]
       (let [initial-dataset-version  (db.transformation/initial-dataset-version-to-update-by-dataset-id conn {:dataset-id dataset-id})
             imported-dataset-columns (vec (:columns initial-dataset-version))
             importer-columns         (p/columns importer)

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -145,12 +145,13 @@
                               {}
                               {:transaction? false})
             (let [dataset-version  (db.transformation/latest-dataset-version-by-dataset-id conn {:dataset-id dataset-id})
-                  coerce-column-fn (fn [{:keys [title id type key multipleId multipleType groupName groupId] :as column}]
+                  coerce-column-fn (fn [{:keys [metadata title id type key multipleId multipleType groupName groupId] :as column}]
                                      (cond-> {"type" type
                                               "title" title
                                               "columnName" id
                                               "groupName" groupName
                                               "groupId" groupId
+                                              "metadata" metadata
                                               "sort" nil
                                               "direction" nil
                                               "hidden" false}

--- a/backend/src/akvo/lumen/postgres.clj
+++ b/backend/src/akvo/lumen/postgres.clj
@@ -2,7 +2,6 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [cheshire.core :as json]
             [akvo.lumen.protocols :as p])
   (:import [org.postgis Polygon MultiPolygon PGgeometry LineString MultiPoint]
            [org.postgresql.util PGobject]
@@ -24,11 +23,6 @@
     (.setValue (.toString v))))
 
 (extend-protocol jdbc/ISQLValue
-  PersistentVector
-  (sql-value [v]
-    (doto (PGobject.)
-      (.setType "json")
-      (.setValue (json/generate-string v))))
   org.postgis.Polygon
   (sql-value [v] (val->geometry-pgobj v))
   org.postgis.MultiPolygon
@@ -81,7 +75,7 @@
     "geoline" "geometry(LINE, 4326)"
     "geopoint" "geometry(POINT, 4326)"
     "multiple" "text"
-    "rqg" "jsonb"
+    "rqg" "text"
     "text" "text"))
 
 (defn- column-type-fn [{:keys [id type]}]

--- a/backend/src/akvo/lumen/postgres.clj
+++ b/backend/src/akvo/lumen/postgres.clj
@@ -81,7 +81,7 @@
     "geoline" "geometry(LINE, 4326)"
     "geopoint" "geometry(POINT, 4326)"
     "multiple" "text"
-    "multiplejson" "jsonb"
+    "rqg" "jsonb"
     "text" "text"))
 
 (defn- column-type-fn [{:keys [id type]}]

--- a/backend/src/akvo/lumen/postgres.clj
+++ b/backend/src/akvo/lumen/postgres.clj
@@ -4,8 +4,7 @@
             [clojure.tools.logging :as log]
             [akvo.lumen.protocols :as p])
   (:import [org.postgis Polygon MultiPolygon PGgeometry LineString MultiPoint]
-           [org.postgresql.util PGobject]
-           [clojure.lang PersistentVector]))
+           [org.postgresql.util PGobject]))
 
 (defn escape-string [s]
   (when-not (nil? s)
@@ -122,9 +121,6 @@
   java.time.Instant
   (coerce [value]
     (java.sql.Timestamp. (.toEpochMilli value)))
-  PersistentVector
-  (coerce [value]
-    value)
   Geoshape
   (coerce [value]
     (let [geom (PGgeometry/geomFromString (:wkt-string value))]

--- a/client/src/components/dataset/DatasetTable.jsx
+++ b/client/src/components/dataset/DatasetTable.jsx
@@ -20,6 +20,8 @@ function formatCellValue(type, value) {
       return value == null ? null : moment(value).format();
     case 'geoshape':
       return '<geoshape>';
+    case 'rqg':
+      return JSON.stringify(value);
     default:
       return value;
   }

--- a/client/src/components/dataset/DatasetTable.jsx
+++ b/client/src/components/dataset/DatasetTable.jsx
@@ -20,8 +20,6 @@ function formatCellValue(type, value) {
       return value == null ? null : moment(value).format();
     case 'geoshape':
       return '<geoshape>';
-    case 'rqg':
-      return JSON.stringify(value);
     default:
       return value;
   }

--- a/client/src/components/dataset/context-menus/ColumnContextMenu.jsx
+++ b/client/src/components/dataset/context-menus/ColumnContextMenu.jsx
@@ -134,6 +134,7 @@ const dataTypeOptions = ({
   date: [],
   geopoint: [],
   multiple: [],
+  rqg: [],
 });
 
 export default function ColumnContextMenu({

--- a/client/src/translations/en.json
+++ b/client/src/translations/en.json
@@ -249,6 +249,7 @@
   "prefix": "New column prefix",
   "previous": "Previous",
   "raster": "Raster",
+  "rqg": "Multiple",
   "remove_collection": "Remove from {title}",
   "remove_double_space": "Remove double space",
   "remove_leading_and_trailing_whitespace": "Remove leading and trailing whitespace",

--- a/client/src/translations/es.json
+++ b/client/src/translations/es.json
@@ -258,6 +258,7 @@
   "reverse_geocode": "Geocodificación inversa",
   "right": "Derecha",
   "role": "Rol",
+  "rqg": "Múltiple",
   "row_column": "Columna de fila",
   "row_column_title": "Título de columna de fila",
   "rows": "Filas",

--- a/client/src/translations/fr.json
+++ b/client/src/translations/fr.json
@@ -262,6 +262,7 @@
   "row_column": "colonne rangée",
   "row_column_title": "Titre de la colonne en rangée",
   "rows": "lignes",
+  "rqg": "Multiple",
   "satellite": "Satellite",
   "save": "Sauvegarder",
   "save_filter": "Enregistrer le filtre",


### PR DESCRIPTION
# TODO
- [x] review import process
tested against 
`uat1 > _1.10.1 and 2.8.3 UAT Folder > _1.10.1 and 2.8.3 MF Surveys > Registration form`
- [x] review update process
if there is currently a dataset already imported with 3 columns from a RQG 
which logic should happen to check consistency?
 - [x] check that we are not using these columns in any transformation
 - [x] [check that we are not using these columns in any visualisation](https://github.com/akvo/akvo-lumen/issues/2696)

- [x] backward compatibility
if we don't update older datasets we shouldn't have any problems
and having the work behind a feature flag will not allow real users to use the new import RQG functionality

- [x] [not introducing jsonb as postgres table type](https://github.com/akvo/akvo-lumen/pull/2685/commits/cecb59c8ab812b31ccf9907230a9909fa5b60b01) is "complex" ... affecting too much to derive-js transformations
we need to write a adapter value column-row here to get it working https://github.com/akvo/akvo-lumen/blob/issue-2127-import-one-json/backend/src/akvo/lumen/lib/transformation/derive.clj#L154

- [x] client render
- [x] review naming
choosing `rqg` instead of multiplejson as type backend name 
- [x] [add metadata](https://github.com/akvo/akvo-lumen/pull/2685/commits/bcbd81c1ce6c6a12fd06d9852226406a902afac2) to rqg column
- [x] [use feature flag](https://github.com/akvo/akvo-lumen/pull/2685/commits/bdadf0e7208a39ac607eac5c25d002a2927398c9)
we need to split the current logic based on feature flag
- [x] add tests

<img width="366" alt="Screenshot 2020-05-12 at 17 25 09" src="https://user-images.githubusercontent.com/731829/81713201-db53ad00-9475-11ea-8744-cab1787a4d7a.png">


- [ ] **Update release notes if necessary**
