### PR TITLE
Issue/2127 js transformation

### DIFF
--- a/backend/src/akvo/lumen/lib/transformation/derive/js_engine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive/js_engine.clj
@@ -63,7 +63,7 @@
 
 (defn- js-factory [] (NashornScriptEngineFactory.))
 
-(defn nashorn-depreciated? []
+(defn nashorn-deprecated? []
   (>= (-> (System/getProperty "java.version")
           (string/split #"\.")
           first
@@ -73,7 +73,7 @@
 (defn script-engine [factory]
   (if (nashorn-depreciated?)
     (.getScriptEngine factory
-                      (into-array String ["--no-deprecation-warning"])
+                      (into-array String ["--no-deprecation-warning" "--language=es6"])
                       nil class-filter)
     (.getScriptEngine factory class-filter)))
 
@@ -110,7 +110,7 @@
 (defn evaluable? [code]
   (and (not (str/includes? code "function"))
        (not (str/includes? code "=>"))
-       (let [try-code (column-function "try_js_sintax" code)]
+       (let [try-code (column-function "try_js_syntax" code)]
          (try
            (eval* (js-engine) try-code)
            true

--- a/backend/src/akvo/lumen/lib/transformation/derive/js_engine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive/js_engine.clj
@@ -71,7 +71,7 @@
       11))
 
 (defn script-engine [factory]
-  (if (nashorn-depreciated?)
+  (if (nashorn-deprecated?)
     (.getScriptEngine factory
                       (into-array String ["--no-deprecation-warning" "--language=es6"])
                       nil class-filter)

--- a/backend/src/akvo/lumen/lib/transformation/derive/js_engine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive/js_engine.clj
@@ -108,13 +108,11 @@
           res)))))
 
 (defn evaluable? [code]
-  (and (not (str/includes? code "function"))
-       (not (str/includes? code "=>"))
-       (let [try-code (column-function "try_js_syntax" code)]
-         (try
-           (eval* (js-engine) try-code)
-           true
-           ;; Catches syntax errors
-           (catch Exception e
-             (log/warn :not-valid-js try-code)
-             false)))))
+  (let [try-code (column-function "try_js_syntax" code)]
+    (try
+      (eval* (js-engine) try-code)
+      true
+      ;; Catches syntax errors
+      (catch Exception e
+        (log/warn :not-valid-js try-code)
+        false))))

--- a/backend/test/akvo/lumen/lib/transformation/derive/js_engine_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation/derive/js_engine_test.clj
@@ -17,4 +17,6 @@
   (is (true? (js-engine/evaluable? "row[\"age\"].reduce((a,b) => (a+b))")))
   (is (true? (js-engine/evaluable? "row[\"group\"][\"column\"].filter(a => a.prop === 1)")))
   (is (false? (js-engine/evaluable? "(function(){while(true);})()")))
-  (is (false? (js-engine/evaluable? "for(;;);"))))
+  (is (false? (js-engine/evaluable? "while(true);")))
+  (is (false? (js-engine/evaluable? "for(;;);")))
+  (is (false? (js-engine/evaluable? "(function(){for(;;);})()"))))

--- a/backend/test/akvo/lumen/lib/transformation/derive/js_engine_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation/derive/js_engine_test.clj
@@ -10,3 +10,11 @@
   (is (= (js-engine/eval* "1 + 1") 2))
   (is (= (js-engine/eval* "'akvo'.toUpperCase();") "AKVO"))
   (is (not (js-engine/eval* "NaN === NaN;"))))
+
+(deftest checking-valid-code
+  (is (true? (js-engine/evaluable? "true")))
+  (is (true? (js-engine/evaluable? "1+2")))
+  (is (true? (js-engine/evaluable? "row[\"age\"].reduce((a,b) => (a+b))")))
+  (is (true? (js-engine/evaluable? "row[\"group\"][\"column\"].filter(a => a.prop === 1)")))
+  (is (false? (js-engine/evaluable? "(function(){while(true);})()")))
+  (is (false? (js-engine/evaluable? "for(;;);"))))

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -113,7 +113,7 @@
         args (if (and kvs (not-empty kvs) (even? (count kvs)))
                (reduce #((if (vector? (first %2))  assoc-in assoc) % (first %2) (last %2)) args (partition 2 kvs))
                args)
-        
+
 ]
     (conform ::transformation.engine.s/op-spec (assoc s :op op-name :args args))
 
@@ -281,7 +281,7 @@
         years               (map (comp :value second) (:rows data))
         years-slash         (map (comp (partial timef/parse (timef/formatter "dd/MM/yyyy")) :value first next next) (:rows data))
         years-hiphen        (map (comp (partial timef/parse (timef/formatter "yyyy-MM-dd")) :value first next next next) (:rows data))
-        dataset-id          (import-file *tenant-conn* *error-tracker* 
+        dataset-id          (import-file *tenant-conn* *error-tracker*
                                          {:dataset-name "date-parsing-test-bis"
                                           :kind         "clj"
                                           :data         data})
@@ -460,7 +460,7 @@
                                                                   ::transformation.engine.s/onError "fail"})})]
         (is (= tag ::lib/ok))
         (is (every? number? (map :d5 (latest-data dataset-id))))))
-  
+
     (testing "Valid type check"
       (let [[tag _ status] (apply-transformation {:type :transformation
                                                   :transformation
@@ -506,26 +506,7 @@
                                            :transformation
                                            (gen-transformation "core/derive"
                                                                {::transformation.derive.s/newColumnTitle "Derived 8"
-                                                                ::transformation.derive.s/code "while(true) {}"
-                                                                ::transformation.derive.s/newColumnType "text"
-                                                                ::transformation.engine.s/onError "fail"})})]
-        (is (= tag ::lib/bad-request))))
-
-    (testing "Disallow anonymous functions"
-      (let [[tag _] (apply-transformation {:type :transformation
-                                           :transformation
-                                           (gen-transformation "core/derive"
-                                                               {::transformation.derive.s/newColumnTitle "Derived 8"
-                                                                ::transformation.derive.s/code "(function() {})()"
-                                                                ::transformation.derive.s/newColumnType "text"
-                                                                ::transformation.engine.s/onError "fail"})})]
-        (is (= tag ::lib/bad-request)))
-
-      (let [[tag _] (apply-transformation {:type :transformation
-                                           :transformation
-                                           (gen-transformation "core/derive"
-                                                               {::transformation.derive.s/newColumnTitle "Derived 8"
-                                                                ::transformation.derive.s/code "(() => 'foo')()"
+                                                                ::transformation.derive.s/code "for(;;);"
                                                                 ::transformation.derive.s/newColumnType "text"
                                                                 ::transformation.engine.s/onError "fail"})})]
         (is (= tag ::lib/bad-request))))))
@@ -666,7 +647,7 @@
                                 (assoc-in ["args" "columns"] (stringify-keys columns-payload)))})]
       (is (= ::lib/ok tag))
       (let [{:keys [columns transformations table-name]} (latest-dataset-version-by-dataset-id *tenant-conn* {:dataset-id dataset-id})]
-        
+
         (is (= (apply conj ["c1" "c2"] (mapv (fn [idx] (str "d" idx)) (range 1 (inc (inc (count new-columns))))))
                (map #(get % "columnName") columns)))
         (is (= ["https://akvoflow-uat1.s3.amazonaws.com/images/b1961e99-bc1c-477c-9309-ae5e8d2374e8.png"
@@ -793,7 +774,7 @@
 
 (deftest ^:functional merge-datasets-test
   (let [origin-data          (import.s/sample-imported-dataset [:text :date] 2)
-        target-data          (replace-column origin-data (import.s/sample-imported-dataset [:text :number :number :text] 2) 0) 
+        target-data          (replace-column origin-data (import.s/sample-imported-dataset [:text :number :number :text] 2) 0)
         origin-dataset-id    (import-file *tenant-conn* *error-tracker*
                                           {:dataset-name "origin-dataset"
                                            :kind         "clj"
@@ -909,5 +890,3 @@
       (is (= 4 (count columns)))
       (is (= "geopoint" (get (last columns) "type")))
       (is (= "d1" (get (last columns) "columnName"))))))
-
-

--- a/client/src/components/dataset/sidebars/DeriveColumnJavascript.jsx
+++ b/client/src/components/dataset/sidebars/DeriveColumnJavascript.jsx
@@ -41,15 +41,22 @@ const errorStrategies = [
 
 function isValidCode(code) {
   try {
-    const ast = esprima.parse(code);
+    const statements = [];
+    const ast = esprima.parse(code, {}, (node) => {
+      if (node.type.indexOf('Statement') !== -1) {
+        statements.push(node.type);
+      }
+    });
+
+    if (statements.length === 1 && statements[0] !== 'ExpressionStatement') {
+      return false;
+    }
+
     if (ast.body.length !== 1) {
       return false;
     }
     const expressionStatement = ast.body[0];
     if (expressionStatement.type !== 'ExpressionStatement') {
-      return false;
-    }
-    if (code.indexOf('function') !== -1 || code.indexOf('=>') !== -1) {
       return false;
     }
     return true;

--- a/client/src/translations/en.json
+++ b/client/src/translations/en.json
@@ -169,7 +169,7 @@
   "is_less_or_equal_to": "is less than or equal to",
   "is_greater_or_equal_to": "is greater than or equal to",
   "javascript_code": "Javascript code",
-  "js_helptext": "Derived columns are formulas written using a subset of Javascript where a single expression is allowed and columns are referenced as {columnSyntax} or alternatively if the title is a valid javascript identifier: {title}. Javascript code can't contain the word {funct} nor the sign {arrowFunct}",
+  "js_helptext": "Derived columns are formulas written using a subset of Javascript where a single expression is allowed and columns are referenced as {columnSyntax} or alternatively if the title is a valid javascript identifier: {title}.",
   "keep_rows_in_which": "keep rows in which",
   "label": "Label",
   "last_modified": "Last modified",

--- a/client/src/translations/es.json
+++ b/client/src/translations/es.json
@@ -164,7 +164,7 @@
   "is_less_or_equal_to": "es igual que o igual a",
   "is_lower_than": "es menor que",
   "javascript_code": "Código Javascript",
-  "js_helptext": "Las columnas derivadas son fórmulas escritas utilizando un subset de Javascript dónde se permite una sola expresión y las columnas son referenciadas como {columnSyntax} o alternativamente si el título es un identificador de Javascript válido: {title}. El código javascript no puede contener la palabra {funct} ni el signo {arrowFunct}",
+  "js_helptext": "Las columnas derivadas son fórmulas escritas utilizando un subset de Javascript dónde se permite una sola expresión y las columnas son referenciadas como {columnSyntax} o alternativamente si el título es un identificador de Javascript válido: {title}.",
   "keep_rows_in_which": "mantener las filas en las cuales",
   "label": "Etiqueta",
   "last_modified": "Ultima modificación",

--- a/client/src/translations/fr.json
+++ b/client/src/translations/fr.json
@@ -165,7 +165,7 @@
   "is_less_or_equal_to": "est inférieur ou égal à",
   "is_lower_than": "est plus inférieur à",
   "javascript_code": "Code javascript",
-  "js_helptext": "Les colonnes dérivées sont des formules écrites en utilisant un sous-ensemble de Javascript où une seule expression est autorisée et les colonnes sont référencées comme {columnSyntax} ou, en variante, si le titre est un identifiant de javascript valide: {title}. Le code Javascriot ne peut contenir ni le mot {funct} ni le signe {arrowFunct}",
+  "js_helptext": "Les colonnes dérivées sont des formules écrites en utilisant un sous-ensemble de Javascript où une seule expression est autorisée et les colonnes sont référencées comme {columnSyntax} ou, en variante, si le titre est un identifiant de javascript valide: {title}.",
   "keep_rows_in_which": "Garder les lignes dans lesquelles",
   "label": "Étiquette",
   "last_modified": "Modifié",


### PR DESCRIPTION
- Relax the restriction on using `function` and `=>` syntax
  - The idea is to support `.filter()` `.map()` and `.reduce()` in for a RGQ JSON blob
- We do checking of a single `ExpressionStatement` in the client and backend
- We don't allow `for()` and `while()` without parsing