### PR TITLE
[#2127] Add column metadata

### DIFF
--- a/backend/specs/akvo/lumen/specs/import/column.clj
+++ b/backend/specs/akvo/lumen/specs/import/column.clj
@@ -40,7 +40,8 @@
 (s/def ::c.multiple/type #{"multiple"})
 
 (s/def ::column-header (s/keys :req-un [::v/title]
-                               :opt-un [::v/id]))
+                               :opt-un [::v/id
+                                        ::v/metadata]))
 
 (s/def ::c.text/header* (s/keys :req-un [::c.text/type] :opt-un [::v/key]))
 (s/def ::c.text/header (s/merge ::column-header ::c.text/header*))

--- a/backend/specs/akvo/lumen/specs/import/values.clj
+++ b/backend/specs/akvo/lumen/specs/import/values.clj
@@ -37,6 +37,8 @@
                      string?
                      #(s/gen #{"c1" "c2" "c3"})))
 
+(s/def ::metadata (s/nilable map?))
+
 (s/def ::title (s/with-gen
                         string?
                         #(s/gen #{"Column 1" "Column 2" "Column 3"})))

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -36,13 +36,14 @@
                                :table-name table-name
                                :imported-table-name imported-table-name
                                :version 1
-                               :columns (mapv (fn [{:keys [title id type key multipleType multipleId groupName groupId]}]
+                               :columns (mapv (fn [{:keys [metadata title id type key multipleType multipleId groupName groupId]}]
                                                 {:columnName id
                                                  :direction nil
                                                  :hidden false
                                                  :key (boolean key)
                                                  :multipleId multipleId
                                                  :multipleType multipleType
+                                                 :metadata metadata
                                                  :groupName groupName
                                                  :groupId groupId
                                                  :sort nil

--- a/backend/src/akvo/lumen/lib/import/common.clj
+++ b/backend/src/akvo/lumen/lib/import/common.clj
@@ -38,6 +38,7 @@
             {:title (:name q)
              :type t
              :groupId (:groupId q)
+             :metadata (:metadata q)
              :groupName (:groupName q)
              :id (format "c%s" (:id q))}
             (when (= t "multiple")

--- a/backend/src/akvo/lumen/lib/import/csv.clj
+++ b/backend/src/akvo/lumen/lib/import/csv.clj
@@ -56,6 +56,7 @@
   (mapv (fn [idx title type]
           {:id (str "c" (inc idx))
            :title title
+           :metadata nil
            :type type})
         (range)
         column-titles

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -145,12 +145,13 @@
                               {}
                               {:transaction? false})
             (let [dataset-version  (db.transformation/latest-dataset-version-by-dataset-id conn {:dataset-id dataset-id})
-                  coerce-column-fn (fn [{:keys [title id type key multipleId multipleType groupName groupId] :as column}]
+                  coerce-column-fn (fn [{:keys [metadata title id type key multipleId multipleType groupName groupId] :as column}]
                                      (cond-> {"type" type
                                               "title" title
                                               "columnName" id
                                               "groupName" groupName
                                               "groupId" groupId
+                                              "metadata" metadata
                                               "sort" nil
                                               "direction" nil
                                               "hidden" false}

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -388,27 +388,29 @@
                             body-kw)]
             (is (= {:transformations []
                     :columns [{:key false,
-	                       :type "text",
-	                       :title "one",
-	                       :multipleId nil,
-	                       :hidden false,
-	                       :multipleType nil,
-	                       :columnName "c1",
+                               :type "text",
+                               :title "one",
+                               :multipleId nil,
+                               :hidden false,
+                               :multipleType nil,
+                               :columnName "c1",
+                               :metadata nil,
                                :groupId nil
                                :groupName nil
-	                       :direction nil,
-	                       :sort nil}
-	                      {:key false,
-	                       :type "text",
-	                       :title "two",
-	                       :multipleId nil,
-	                       :hidden false,
+                               :direction nil,
+                               :sort nil}
+                              {:key false,
+                               :type "text",
+                               :title "two",
+                               :multipleId nil,
+                               :hidden false,
                                :groupId nil
                                :groupName nil
-	                       :multipleType nil,
-	                       :columnName "c2",
-	                       :direction nil,
-	                       :sort nil}]
+                               :multipleType nil,
+                               :columnName "c2",
+                               :metadata nil,
+                               :direction nil,
+                               :sort nil}]
                     :name title
                     ;;:author nil,
                     :rows

--- a/backend/test/akvo/lumen/endpoints_test/commons.clj
+++ b/backend/test/akvo/lumen/endpoints_test/commons.clj
@@ -13,6 +13,7 @@
                             :hidden false,
                             :multipleType nil,
                             :columnName "c1",
+                            :metadata nil,
                             :groupId nil
                             :groupName nil
                             :direction nil,
@@ -26,6 +27,7 @@
                             :groupId nil
                             :groupName nil
                             :columnName "c2",
+                            :metadata nil,
                             :direction nil,
                             :sort nil}
                            {:key false,
@@ -37,6 +39,7 @@
                             :groupId nil
                             :groupName nil
                             :columnName "c3",
+                            :metadata nil,
                             :direction nil,
                             :sort nil}
                            {:key false,
@@ -48,6 +51,7 @@
                             :groupName nil
                             :multipleType nil,
                             :columnName "c4",
+                            :metadata nil,
                             :direction nil,
                             :sort nil}
                            {:key false,
@@ -57,6 +61,7 @@
                             :hidden false,
                             :multipleType nil,
                             :columnName "c5",
+                            :metadata nil,
                             :groupId nil
                             :groupName nil
                             :direction nil,
@@ -70,6 +75,7 @@
                             :groupName nil
                             :multipleType nil,
                             :columnName "c6",
+                            :metadata nil,
                             :direction nil,
                             :sort nil}])
 

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
@@ -36,25 +36,27 @@
       (is (= (map keys (:columns dataset)) '(("groupId"
                                               "key"
                                               "groupName"
-	                                      "sort"
-	                                      "direction"
-	                                      "title"
-	                                      "type"
-	                                      "multipleType"
-	                                      "hidden"
-	                                      "multipleId"
-	                                      "columnName")
+                                              "sort"
+                                              "direction"
+                                              "metadata"
+                                              "title"
+                                              "type"
+                                              "multipleType"
+                                              "hidden"
+                                              "multipleId"
+                                              "columnName")
                                              ("groupId"
                                               "key"
                                               "groupName"
-	                                      "sort"
-	                                      "direction"
-	                                      "title"
-	                                      "type"
-	                                      "multipleType"
-	                                      "hidden"
-	                                      "multipleId"
-	                                      "columnName"))))
+                                              "sort"
+                                              "direction"
+                                              "metadata"
+                                              "title"
+                                              "type"
+                                              "multipleType"
+                                              "hidden"
+                                              "multipleId"
+                                              "columnName"))))
 
       (is (= (map #(select-keys % ["type" "columnName"]) (:columns dataset))
              '({"type" "text", "columnName" "c1"}


### PR DESCRIPTION
- [ ] **Update release notes if necessary**
Metadata will be used so far to store RQG columns metadata

the future api response with rqg metadata will be more or less like ...

<img width="631" alt="Screenshot 2020-05-13 at 13 51 47" src="https://user-images.githubusercontent.com/731829/81915566-10294680-95d3-11ea-946a-9ad5d77bccb3.png">
