### PR TITLE
Issue/2127 rqg js

### DIFF
--- a/backend/specs/akvo/lumen/specs/import/values.clj
+++ b/backend/specs/akvo/lumen/specs/import/values.clj
@@ -37,7 +37,7 @@
                      string?
                      #(s/gen #{"c1" "c2" "c3"})))
 
-(s/def ::metadata (s/nilable map?))
+(s/def ::metadata (s/nilable vector?))
 
 (s/def ::title (s/with-gen
                         string?

--- a/backend/src/akvo/lumen/lib/transformation/derive.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive.clj
@@ -111,7 +111,7 @@
   (let [{:keys [::code
                 ::column-title
                 ::column-type]} (args op-spec)]
-    (and (string? column-title) 
+    (and (string? column-title)
          (util/valid-type? column-type)
          (#{"fail" "leave-empty" "delete-row"} (engine/error-strategy op-spec))
          (js-engine/evaluable? code))))
@@ -164,7 +164,8 @@
                         ::column-type]} (args op-spec)
                 new-column-name         (engine/next-column-name columns)
                 columns-groups*         (columns-groups (walk/keywordize-keys columns))
-                adapter                 (js-engine/column-name->column-title columns)
+                adapter                 (comp (js-engine/rqg columns)
+                                              (js-engine/column-name->column-title columns))
                 row-fn                  (js-engine/row-transform-fn {:adapter     adapter
                                                                      :code        code
                                                                      :column-type column-type})
@@ -185,7 +186,7 @@
                                            :column-type             (lumen->pg-type column-type)
                                            :new-column-name         new-column-name})
             (set-cells-values! conn base-opts (js-execution>sql-params js-execution-seq :set-value!))
-            (delete-rows! conn base-opts (js-execution>sql-params js-execution-seq :delete-row!))      
+            (delete-rows! conn base-opts (js-execution>sql-params js-execution-seq :delete-row!))
             {:success?      true
              :execution-log [(format "Derived columns using '%s'" code)]
              :columns       (conj columns {"title"      column-title


### PR DESCRIPTION
- Fixes spec definition (metadata is a `vector` not a `map`)
  - An error in this problematic spec was hidden behind a `(catch Exception _)` . The function instrumentation was complaining and reporting a misleading error :cry: 

- The main change is to help a user write less code when by converting `rqg` columns to a JS object automatically, __before__ executing the user's code. We do it by enhancing the _adapter_ that was converting column names -> column title and adding a key `__rgq__` to the `row` object.  This key has an array of all columns of type `rqg`. The transformation function loops that array (if present) and calls `JSON.parse()` on those column's values.

- The `row` object passed to the JS context was previously a Clojure immutable datastructure, because we're mutating those `rqg` keys, we convert that object in to a mutable `HashMap` before passing it to the JS code.