### PR TITLE
[#2676] Use single value for feature flag

### DIFF
--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -111,7 +111,7 @@
 (defn questions
   "Get the list of questions from a form"
   [environment form]
-  (if (first (get environment "rqg"))
+  (if (get environment "rqg")
     (questions-with-rqg-in-one-column form)
     (questions-current-implementation form)))
 
@@ -154,7 +154,7 @@
      ids-to-adapt)))
 
 (defn- questions-responses-adapter [environment questions responses]
-  (if (first (get environment "rqg"))
+  (if (get environment "rqg")
     (questions-responses-with-rqg-in-one-column questions responses)
     responses))
 
@@ -167,7 +167,7 @@
   [environment questions responses]
   (->> responses
        (questions-responses-adapter environment questions)
-       vals 
+       vals
        (map first)
        (apply merge)))
 


### PR DESCRIPTION
When enabling `rqg` flag we can use a single value `true` for
enabling/disabling

The different code-path gets enabled by:

```
insert into environment(id, "value") VALUES('rqg', 'true'::jsonb);
```

- [ ] **Update release notes if necessary**
