### PR TITLE
[#2127] Use map instead of vector to store column metadata

### DIFF
--- a/backend/specs/akvo/lumen/specs/import/values.clj
+++ b/backend/specs/akvo/lumen/specs/import/values.clj
@@ -37,7 +37,7 @@
                      string?
                      #(s/gen #{"c1" "c2" "c3"})))
 
-(s/def ::metadata (s/nilable vector?))
+(s/def ::metadata (s/nilable map?))
 
 (s/def ::title (s/with-gen
                         string?

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -94,7 +94,7 @@
                                      rqg (-> base-question
                                              (assoc :id (:id %2))
                                              (assoc :name (:name %2) )
-                                             (assoc :metadata (common/coerce question-type->lumen-type (:questions %2)))
+                                             (assoc :metadata {:columns (common/coerce question-type->lumen-type (:questions %2))})
                                              (assoc :type "RQG"))]
                                  [rqg])
                                (:questions %2))
@@ -147,7 +147,7 @@
        (let [rqg (first (filter #(= id (:id %)) questions))
              repeated-questions (mapv
                                  #(reduce (fn [x [k v]]
-                                            (assoc x (question-title-by-id k (:metadata rqg)) v)) {} %)
+                                            (assoc x (question-title-by-id k (-> rqg :metadata :columns)) v)) {} %)
                                      (get c id))]
          (assoc c id [{id repeated-questions}])))
      responses

--- a/backend/test/akvo/lumen/lib/import/flow_common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/flow_common_test.clj
@@ -83,7 +83,7 @@
         (is (= "RQG" (:type rqg)))
         (is (= rqg-name (:name rqg)))
         (is (= rqg-id (:id rqg)))
-        (is (= (:metadata rqg) (common/coerce flow-common/question-type->lumen-type rqs)))))
+        (is (= (-> rqg :metadata :columns) (common/coerce flow-common/question-type->lumen-type rqs)))))
 
     (testing "questions-responses-with-rqg-in-one-column"
       (let [questions (flow-common/questions-with-rqg-in-one-column form)


### PR DESCRIPTION
Being a map is more flexible to adapt to each column type needs

this PR is against `issue/2127-rqg-js`

- [ ] **Update release notes if necessary**
