### PR TITLE
[#2713] Use akvo/maps image instead of "build" a local one

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,11 +24,9 @@ services:
    ports:
       - "3030:3030"
  windshaft:
-   build: windshaft
-   environment:
-     - NODE_ENV=development
+   image: akvo/akvo-maps:beaf5cf8
    volumes:
-      - ./windshaft/config/dev:/config
+     - ./windshaft/config/dev:/config
  exporter:
    build: exporter
    ports:


### PR DESCRIPTION
As part of the local development setup we don't need the possibility
of refreshing the JS code via `nodemon`. We only need to use the
published container.

Use `image` instead of `build` and expose the config files as binding
mounts.