### PR TITLE
[#2127] Add backend APIs to support groups

### DIFF
--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -53,10 +53,7 @@
                                auth-service :auth-service
                                {:keys [id]} :path-params}]
                            (if-let [res (dataset/fetch (p/connection tenant-manager tenant) id)]
-                             (let [ids (l.auth/ids ::dataset.s/dataset res)]
-                               (if (p/allow? auth-service ids)
-                                 (lib/ok res)
-                                 (lib/not-authorized ids)))
+                             (lib/ok res)
                              (lib/not-found {:error "Not found"})))}
           :put {:parameters {:body map?
                              :path-params {:id string?}}
@@ -75,18 +72,12 @@
                                   (dataset/fetch-groups-metadata (p/connection tenant-manager tenant) id))}}]
      ["/group"
       [["/:group-id" {:get {:parameters {:path-params {:id string?
-                                                        :group-id string?}}
-                             :handler (fn [{tenant :tenant
-
-                                            {:keys [id group-id]} :path-params}]
-                                        (if-let [res (dataset/fetch-group (p/connection tenant-manager tenant) id group-id)]
-                                          (lib/ok res)
-                                          ;; TODO implement auth
-                                          #_(let [ids (l.auth/ids ::dataset.s/dataset res)]
-                                              (if (p/allow? auth-service ids)
-                                                (lib/ok res)
-                                                (lib/not-authorized ids)))
-                                          (lib/not-found {:error "Not found"})))}}]]]
+                                                       :group-id string?}}
+                            :handler (fn [{tenant :tenant
+                                           {:keys [id group-id]} :path-params}]
+                                       (if-let [res (dataset/fetch-group (p/connection tenant-manager tenant) id group-id)]
+                                         (lib/ok res)
+                                         (lib/not-found {:error "Not found"})))}}]]]
      ["/sort"
       [["/:column-name/text" {:get {:parameters fetch-column-params
                                     :handler (fn [{tenant :tenant

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -68,6 +68,20 @@
                    :handler (fn [{tenant :tenant
                                   {:keys [id]} :path-params}]
                               (dataset/delete (p/connection tenant-manager tenant) id))}}]
+     ["/group"
+      [["/:group-id" {:get {:parameters {:path-params {:id string?
+                                                        :group-id string?}}
+                             :handler (fn [{tenant :tenant
+
+                                            {:keys [id group-id]} :path-params}]
+                                        (if-let [res (dataset/fetch-group (p/connection tenant-manager tenant) id group-id)]
+                                          (lib/ok res)
+                                          ;; TODO implement auth
+                                          #_(let [ids (l.auth/ids ::dataset.s/dataset res)]
+                                              (if (p/allow? auth-service ids)
+                                                (lib/ok res)
+                                                (lib/not-authorized ids)))
+                                          (lib/not-found {:error "Not found"})))}}]]]
      ["/sort"
       [["/:column-name/text" {:get {:parameters fetch-column-params
                                     :handler (fn [{tenant :tenant

--- a/backend/src/akvo/lumen/endpoint/dataset.clj
+++ b/backend/src/akvo/lumen/endpoint/dataset.clj
@@ -68,6 +68,11 @@
                    :handler (fn [{tenant :tenant
                                   {:keys [id]} :path-params}]
                               (dataset/delete (p/connection tenant-manager tenant) id))}}]
+     ;; get meta organised by groups
+     ["/groups" {:get {:parameters {:path-params {:id string?}}
+                       :handler (fn [{tenant :tenant
+                                      {:keys [id]} :path-params}]
+                                  (dataset/fetch-groups-metadata (p/connection tenant-manager tenant) id))}}]
      ["/group"
       [["/:group-id" {:get {:parameters {:path-params {:id string?
                                                         :group-id string?}}

--- a/backend/src/akvo/lumen/lib/auth.clj
+++ b/backend/src/akvo/lumen/lib/auth.clj
@@ -77,6 +77,7 @@
                  "/api/datasets/:id" {:methods #{:get :put :delete}}
                  "/api/datasets/:id/meta" {:methods #{:get}}
                  "/api/datasets/:id/update" {:methods #{:post}}
+                 "/api/datasets/:id/group/:group-id" {:methods #{:get}}
                  "/api/datasets/:id/sort/:column-name/text" {:methods #{:get}}
                  "/api/datasets/:id/sort/:column-name/number" {:methods #{:get}}
                  "/api/datasets" {:methods #{:get}}

--- a/backend/src/akvo/lumen/lib/auth.clj
+++ b/backend/src/akvo/lumen/lib/auth.clj
@@ -77,6 +77,7 @@
                  "/api/datasets/:id" {:methods #{:get :put :delete}}
                  "/api/datasets/:id/meta" {:methods #{:get}}
                  "/api/datasets/:id/update" {:methods #{:post}}
+                 "/api/datasets/:id/groups" {:methods #{:get}}
                  "/api/datasets/:id/group/:group-id" {:methods #{:get}}
                  "/api/datasets/:id/sort/:column-name/text" {:methods #{:get}}
                  "/api/datasets/:id/sort/:column-name/number" {:methods #{:get}}

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -135,7 +135,13 @@
                                  {:as-arrays? true}))]
       (-> (select-keys dataset [:updated :created :modified])
           remove-token
-          (assoc :rows data :columns columns :status "OK" :datasetId id :groupId group-id)))))
+          (assoc :rows data
+                 :columns (map (fn [col]
+                                 (cond-> col
+                                   true (assoc "groupId" group-id)
+                                   (contains? #{"main" "transformations" "metadata"} group-id)
+                                   (assoc "groupName" group-id))) columns)
+                 :status "OK" :datasetId id :groupId group-id)))))
 
 (defn sort-text
   [tenant-conn id column-name limit order]

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -1,18 +1,20 @@
 (ns akvo.lumen.lib.dataset
-  (:require [akvo.lumen.endpoint.job-execution :as job-execution]
-            [akvo.lumen.lib.import :as import]
-            [akvo.lumen.db.transformation :as db.transformation]
+  (:require [akvo.lumen.db.dataset :as db.dataset]
             [akvo.lumen.db.job-execution :as db.job-execution]
-            [akvo.lumen.db.dataset :as db.dataset]
+            [akvo.lumen.db.transformation :as db.transformation]
             [akvo.lumen.db.visualisation :as db.visualisation]
+            [akvo.lumen.endpoint.job-execution :as job-execution]
             [akvo.lumen.lib :as lib]
-            [akvo.lumen.protocols :as p]
+            [akvo.lumen.lib.import :as import]
+            [akvo.lumen.lib.import.flow-common :as flow-common]
             [akvo.lumen.lib.transformation.merge-datasets :as transformation.merge-datasets]
             [akvo.lumen.lib.update :as update]
-            [clojure.tools.logging :as log]
+            [akvo.lumen.protocols :as p]
             [clojure.java.jdbc :as jdbc]
+            [clojure.set :refer (rename-keys)]
             [clojure.string :as str]
-            [clojure.set :refer (rename-keys)]))
+            [clojure.tools.logging :as log]
+            [clojure.walk :as w]))
 
 (defn- remove-token [d]
   (update d :source dissoc "token"))
@@ -64,6 +66,42 @@
         :status "OK"
         :transformations (:transformations dataset)
         :columns columns}))
+    (lib/not-found {:error "Not found"})))
+
+(defn fetch-groups-metadata
+  "Fetch dataset groups metadata (everything apart from rows)
+
+  if dataset is CSV type then will contain a 'main' group containing all csv columns
+  else if FLOW type we'll return the columns inside each flow group besides a 'metadata' group
+
+  always we'll use 'transformations' groupId to include all generated transformations"
+  [tenant-conn id]
+  (if-let [dataset (w/keywordize-keys (db.dataset/dataset-by-id tenant-conn {:id id}))]
+    (let [columns (remove #(get % :hidden) (:columns dataset))
+          groups (if (= "AKVO_FLOW" (-> dataset :source :kind))
+                   (let [columns-by-group (group-by :groupId columns)
+                         groups (dissoc columns-by-group nil)
+                         nil-group (get columns-by-group nil)]
+                     (merge groups
+                            (reduce (fn [c col]
+                                      (let [k (if (contains? flow-common/metadata-keys (:columnName col))
+                                                :metadata :transformations)]
+                                        (update c k #(conj % (assoc col :groupId k :groupName k)))))
+                                    {:metadata [] :transformations []}  nil-group)))
+                   (reduce (fn [c col]
+                             (let [k (if (= \c  (first (:columnName col)))
+                                       :main :transformations)]
+                               (update c k #(conj % (assoc col :groupId k :groupName k)))))
+                           {:main [] :transformations []}  columns))]
+      (lib/ok
+       {:id id
+        :name (:title dataset)
+        :modified (:modified dataset)
+        :created (:created dataset)
+        :updated (:updated dataset)
+        :status "OK"
+        :transformations (:transformations dataset)
+        :groups groups}))
     (lib/not-found {:error "Not found"})))
 
 (defn fetch

--- a/backend/src/akvo/lumen/lib/import/csv.clj
+++ b/backend/src/akvo/lumen/lib/import/csv.clj
@@ -63,7 +63,7 @@
         column-types))
 
 (defn valid-column-name? [column-name]
-  (boolean (re-find #"^c\d+$" column-name)))
+  (boolean (re-matches #"c\d+$" column-name)))
 
 (defn data-records [column-spec rows]
   (for [row rows]

--- a/backend/src/akvo/lumen/lib/import/csv.clj
+++ b/backend/src/akvo/lumen/lib/import/csv.clj
@@ -62,6 +62,9 @@
         column-titles
         column-types))
 
+(defn valid-column-name? [column-name]
+  (boolean (re-find #"^c\d+$" column-name)))
+
 (defn data-records [column-spec rows]
   (for [row rows]
     (apply merge

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -171,6 +171,8 @@
        (map first)
        (apply merge)))
 
+(def metadata-keys #{"identifier" "instance_id" "display_name" "submitter" "submitted_at" "surveyal_time" "device_id"})
+
 (defn commons-columns [form]
   [(cond-> {:title "Identifier" :type "text" :id "identifier"}
      (:registration-form? form) (assoc :key true))

--- a/backend/src/akvo/lumen/lib/transformation/engine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/engine.clj
@@ -109,7 +109,7 @@
   (format "d%s" i))
 
 (defn is-derived? [column-name]
-  (boolean (re-find #"^d\d+$" column-name)))
+  (boolean (re-matches #"d\d+$" column-name)))
 
 (defn next-column-index [columns]
   (let [nums (->> columns

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -186,12 +186,9 @@
 
             (let [meta-group-dataset (-> (h (get* (api-url "/datasets" dataset-id "group" "main")))
                                    body-kw)]
-              (is (= {:id dataset-id
-                      :name title
-                      :status "OK"
-                      :transformations []
+              (is (= {:status "OK"
                       :columns (map #(assoc % :groupName "main" :groupId "main") commons/dataset-link-columns)}
-                     (select-keys meta-group-dataset [:id :name :status :transformations :columns])))))
+                     (select-keys meta-group-dataset [:status :columns])))))
 
           (testing "sort"
             (let [dataset-sort (-> (h (get* (api-url "/datasets" dataset-id "sort" "c6" "text") {"limit" "1"}))

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -172,7 +172,26 @@
                       :status "OK"
                       :transformations []
                       :columns commons/dataset-link-columns}
-                     (select-keys meta-dataset [:id :name :status :transformations :columns])))))
+                     (select-keys meta-dataset [:id :name :status :transformations :columns]))))
+
+            (let [meta-group-dataset (-> (h (get* (api-url "/datasets" dataset-id "groups")))
+                                   body-kw)]
+              (is (= {:id dataset-id
+                      :name title
+                      :status "OK"
+                      :transformations []
+                      :groups {:transformations []
+                               :main (map #(assoc % :groupName "main" :groupId "main") commons/dataset-link-columns)}}
+                     (select-keys meta-group-dataset [:id :name :status :transformations :groups]))))
+
+            (let [meta-group-dataset (-> (h (get* (api-url "/datasets" dataset-id "group" "main")))
+                                   body-kw)]
+              (is (= {:id dataset-id
+                      :name title
+                      :status "OK"
+                      :transformations []
+                      :columns (map #(assoc % :groupName "main" :groupId "main") commons/dataset-link-columns)}
+                     (select-keys meta-group-dataset [:id :name :status :transformations :columns])))))
 
           (testing "sort"
             (let [dataset-sort (-> (h (get* (api-url "/datasets" dataset-id "sort" "c6" "text") {"limit" "1"}))

--- a/backend/test/akvo/lumen/lib/import/csv_test.clj
+++ b/backend/test/akvo/lumen/lib/import/csv_test.clj
@@ -9,6 +9,7 @@
             [akvo.lumen.utils.logging-config :refer [with-no-logs]]
             [clojure.string :as string]
             [akvo.lumen.test-utils :as tu]
+            [akvo.lumen.lib.import.csv :as csv]
             [clojure.test :refer :all]
             [hugsql.core :as hugsql])
   (:import [java.util.concurrent ExecutionException]))
@@ -68,3 +69,10 @@
           trimmable? #(or (string/starts-with? " " %) (string/ends-with? " " %))]
       (is (every? trimmable? titles)))))
 
+
+(deftest valid-column-name
+  (testing "valid column name"
+    (is (not (csv/valid-column-name? "d123123")))
+    (is (not (csv/valid-column-name? "c")))
+    (is (not (csv/valid-column-name? "ca1")))
+    (is (csv/valid-column-name? "c123123"))))


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

- [x] `/dataset/<id>/group/metadata` to get metadata group 
- [x] `/dataset/<id>/group/transformations` to get transformations group 
- [x] `/dataset/<id>/group/main` to get main group (in the case of csv )
- [x] `/dataset/<id>/groups` to get meta with groups 
- [x] Tests!

Anyway these "static" groupIds will be returned by backend call `/dataset/<id>/groups` returning this kind of [data](https://github.com/akvo/akvo-lumen/issues/2127#issuecomment-644232253) 

so far both groups ^^ are calculated on client-side based on domain conditions such as column names


example json responses
`/dataset/<id>/groups` https://gist.github.com/tangrammer/046a954beba038d34c1f61cbe67cbd22#file-fetch-groups-json

`/dataset/<id>/group/metadata` https://gist.github.com/tangrammer/046a954beba038d34c1f61cbe67cbd22#file-fetch-metadata-group-json