### PR TITLE
[#2127] Normalise import data (processing  multiple responses)

### DIFF
--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -72,7 +72,7 @@
           (let [columns (p/columns importer)]
             (postgres/create-dataset-table conn table-name columns)
             (doseq [record (take common/rows-limit (p/records importer))]
-              (doseq [i (range (count (last (first record))))]
+              (doseq [i (range (common/responses-count record))]
                   (jdbc/insert! conn table-name (postgres/coerce-to-sql (common/extract-question-response record i)))))
             (successful-execution conn job-execution-id  data-source-id table-name columns {:spec-name (get spec "name")
                                                                                             :spec-description (get spec "description" "")} claims)))

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -60,13 +60,6 @@
                                      :reason [reason]})
   (db.transformation/drop-table conn {:table-name table-name}))
 
-
-(defn take-pos [r idx]
-  (reduce (fn [c [k v]]
-            (assoc c k (nth v idx))
-            ) {} (seq r)))
-
-
 (defn- execute
   "Import runs within a future and since this is not taking part of ring
   request / response cycle we need to make sure to capture errors."
@@ -80,7 +73,7 @@
             (postgres/create-dataset-table conn table-name columns)
             (doseq [record (take common/rows-limit (p/records importer))]
               (doseq [i (range (count (last (first record))))]
-                  (jdbc/insert! conn table-name (postgres/coerce-to-sql (take-pos record i)))))
+                  (jdbc/insert! conn table-name (postgres/coerce-to-sql (common/extract-question-response record i)))))
             (successful-execution conn job-execution-id  data-source-id table-name columns {:spec-name (get spec "name")
                                                                                             :spec-description (get spec "description" "")} claims)))
         (catch Throwable e

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -60,6 +60,13 @@
                                      :reason [reason]})
   (db.transformation/drop-table conn {:table-name table-name}))
 
+
+(defn take-pos [r idx]
+  (reduce (fn [c [k v]]
+            (assoc c k (nth v idx))
+            ) {} (seq r)))
+
+
 (defn- execute
   "Import runs within a future and since this is not taking part of ring
   request / response cycle we need to make sure to capture errors."
@@ -71,8 +78,9 @@
                                                       (assoc import-config :environment (env/all conn)))]
           (let [columns (p/columns importer)]
             (postgres/create-dataset-table conn table-name columns)
-            (doseq [record (map postgres/coerce-to-sql (take common/rows-limit (p/records importer)))]
-              (jdbc/insert! conn table-name record))
+            (doseq [record (take common/rows-limit (p/records importer))]
+              (doseq [i (range (count (last (first record))))]
+                  (jdbc/insert! conn table-name (postgres/coerce-to-sql (take-pos record i)))))
             (successful-execution conn job-execution-id  data-source-id table-name columns {:spec-name (get spec "name")
                                                                                             :spec-description (get spec "description" "")} claims)))
         (catch Throwable e

--- a/backend/src/akvo/lumen/lib/import/common.clj
+++ b/backend/src/akvo/lumen/lib/import/common.clj
@@ -48,3 +48,9 @@
                 {:multipleType (:multipleType q)
                  :multipleId (:multipleId q)})))))
        questions))
+
+(defn extract-question-response
+  "based on position"
+  [r idx]
+  (reduce (fn [c [k v]]
+            (assoc c k (nth v idx))) {} (seq r)))

--- a/backend/src/akvo/lumen/lib/import/common.clj
+++ b/backend/src/akvo/lumen/lib/import/common.clj
@@ -50,7 +50,15 @@
        questions))
 
 (defn extract-question-response
-  "based on position"
-  [r idx]
-  (reduce (fn [c [k v]]
-            (assoc c k (nth v idx))) {} (seq r)))
+  "`record` is a map with collection values
+  e.g: {:a [\"1\" \"2\"] :b [\"3\" \"4\"]}
+  depending on idx return same map structure but with one value per key
+  e.g: using idx=0: {:a \"1\" :b \"3\"}"
+  [record idx]
+  (reduce (fn [c [k v]] (assoc c k (nth v idx))) {} (seq record)))
+
+
+(defn responses-count
+  "e.g: `record` {:a [\"1\" \"2\"] :b [\"3\" \"4\"]} will return 2"
+  [record]
+  (count (first (vals record))))

--- a/backend/src/akvo/lumen/lib/import/csv.clj
+++ b/backend/src/akvo/lumen/lib/import/csv.clj
@@ -68,7 +68,7 @@
   (for [row rows]
     (apply merge
            (map (fn [{:keys [id type]} value]
-                  {id (transform-value value type)})
+                  {id [(transform-value value type)]})
                 column-spec
                 row))))
 

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -98,14 +98,13 @@
     (assoc form
            :registration-form? (= form-id (:registrationFormId survey)))))
 
-(defn adapt [r]
-  (reduce (fn [c [k v]]
-            (assoc c k [(first (mapv last v))])
-            ;; TODO: use this impl when we could process all responses
-            ;; (assoc c k (mapv last v))
-            )
-          {}
-          (group-by first (reduce into [] (map seq r)))))
+(defn- adapt-response-values [response]
+  (->> (group-by first (reduce into [] (map seq response)))
+       (reduce (fn [c [k v]]
+             (assoc c k [(first (mapv last v))])
+             ;; TODO: use this impl when we could process all responses
+             ;; (assoc c k (mapv last v))
+             ) {})))
 
 ;; Transforms the structure
 ;; {question-group-id -> [{question-id -> response}]
@@ -116,7 +115,7 @@
   [questions responses]
   (->> responses
        vals
-       (map adapt)
+       (map adapt-response-values)
        (apply merge)))
 
 (def metadata-keys #{"identifier" "instance_id" "display_name" "submitter" "submitted_at" "surveyal_time" "device_id"})

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -98,16 +98,22 @@
     (assoc form
            :registration-form? (= form-id (:registrationFormId survey)))))
 
+(defn adapt [r]
+  (reduce (fn [c [k v]]
+            (assoc c k (mapv last v)))
+          {}
+          (group-by first (reduce into [] (map seq r)))))
+
 ;; Transforms the structure
 ;; {question-group-id -> [{question-id -> response}]
 ;; to
-;; {question-id -> first-response}
+;; {question-id -> [response-1 response2 response3]}
 (defn question-responses
   "Returns a map from question-id to the first response iteration"
   [questions responses]
   (->> responses
        vals
-       (map first)
+       (map adapt)
        (apply merge)))
 
 (def metadata-keys #{"identifier" "instance_id" "display_name" "submitter" "submitted_at" "surveyal_time" "device_id"})
@@ -122,9 +128,9 @@
    {:title "Surveyal time" :type "number" :id "surveyal_time"}])
 
 (defn common-records [form-instance data-point]
-  {:instance_id   (get form-instance "id")
-   :display_name  (get data-point "displayName")
-   :identifier    (get data-point "identifier")
-   :submitter     (get form-instance "submitter")
-   :submitted_at  (some-> (get form-instance "submissionDate") Instant/parse)
-   :surveyal_time (get form-instance "surveyalTime")})
+  {:instance_id   [(get form-instance "id")]
+   :display_name  [(get data-point "displayName")]
+   :identifier    [(get data-point "identifier")]
+   :submitter     [(get form-instance "submitter")]
+   :submitted_at  [(some-> (get form-instance "submissionDate") Instant/parse)]
+   :surveyal_time [(get form-instance "surveyalTime")]})

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -100,7 +100,10 @@
 
 (defn adapt [r]
   (reduce (fn [c [k v]]
-            (assoc c k (mapv last v)))
+            (assoc c k [(first (mapv last v))])
+            ;; TODO: use this impl when we could process all responses
+            ;; (assoc c k (mapv last v))
+            )
           {}
           (group-by first (reduce into [] (map seq r)))))
 

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -89,7 +89,7 @@
               (if-let [response (get responses id)]
                 (assoc response-data
                        (format "c%s" id)
-                       (render-response type response))
+                       (map (partial render-response type) response))
                 response-data))
             {}
             questions)))

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -37,33 +37,34 @@
 (defn render-response
   [type response]
   (condp = type
-    "GEO" (let [{:strs [long lat]} response]
-            (when (and long lat)
-              (postgres/->Geopoint
-               (format "POINT (%s %s)" long lat))))
-    "GEOSHAPE" (let [feature (-> (w/keywordize-keys response) :features first)
-                     geom-type (-> feature :geometry :type)
-                     points (-> feature :geometry :coordinates)]
-                 (log/debug :geom-type geom-type :points points )
-                 (if points
-                   (condp = geom-type
-                     "LineString" (when (> (count points) 1)
-                                    (postgres/->Geoline
-                                     (format "LINESTRING (%s)" (->> points
-                                                                    (map (partial string/join " " ))
-                                                                    (string/join ", " )))))
-                     "Polygon"    (let [points (->> (first points)
-                                                    (map (partial string/join " " )))]
-                                    (when (> (count points) 3)
-                                      (postgres/->Geoshape
-                                       (format "POLYGON ((%s))" (->> points                                                                                                           (string/join ", " ))))))
-                     "MultiPoint" (postgres/->Multipoint
-                                   (format "MULTIPOINT (%s)" (->> points
-                                                                  (map (partial string/join " " ))
-                                                                  (string/join ", " ))))
-                     
-                     (log/warn :unmapped-geoshape! geom-type))))
-    (v2/render-response type response)))
+    "GEO" (->> response
+               (map #(let [{:strs [long lat]} %]
+                       (when (and long lat)
+                         (postgres/->Geopoint
+                          (format "POINT (%s %s)" long lat))))))
+    "GEOSHAPE" (->> response
+                    (map #(let [feature (-> (w/keywordize-keys %) :features first)
+                                geom-type (-> feature :geometry :type)
+                                points (-> feature :geometry :coordinates)]
+                            (log/debug :geom-type geom-type :points points )
+                            (if points
+                              (condp = geom-type
+                                "LineString" (when (> (count points) 1)
+                                               (postgres/->Geoline
+                                                (format "LINESTRING (%s)" (->> points
+                                                                               (map (partial string/join " " ))
+                                                                               (string/join ", " )))))
+                                "Polygon"    (let [points (->> (first points)
+                                                               (map (partial string/join " " )))]
+                                               (when (> (count points) 3)
+                                                 (postgres/->Geoshape
+                                                  (format "POLYGON ((%s))" (->> points                                                                                                           (string/join ", " ))))))
+                                "MultiPoint" (postgres/->Multipoint
+                                              (format "MULTIPOINT (%s)" (->> points
+                                                                             (map (partial string/join " " ))
+                                                                             (string/join ", " ))))
+                                (log/warn :unmapped-geoshape! geom-type))))))
+    (map (partial v2/render-response type) response)))
 
 (defn response-data
   [form responses]
@@ -90,7 +91,7 @@
              (if-let [data-point (get data-points data-point-id)]
                (merge (response-data form (get form-instance "responses"))
                       (flow-common/common-records form-instance data-point)
-                      {:device_id (get form-instance "deviceIdentifier")})
+                      {:device_id [(get form-instance "deviceIdentifier")]})
                (throw (ex-info "Flow form (dataPointId) referenced data point not in survey"
                                {:form-instance-id (get form-instance "id")
                                 :data-point-id data-point-id

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -140,7 +140,7 @@
                 imported-table-name (util/gen-table-name "imported")]
             (postgres/create-dataset-table conn table-name importer-columns)
             (doseq [record (p/records importer)]
-              (doseq [i (range (count (last (first record))))]
+              (doseq [i (range (import/responses-count record))]
                (jdbc/insert! conn table-name (postgres/coerce-to-sql (import/extract-question-response record i)))))
             (db.job-execution/clone-data-table conn {:from-table table-name
                                     :to-table   imported-table-name}

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -139,8 +139,9 @@
           (let [table-name          (util/gen-table-name "ds")
                 imported-table-name (util/gen-table-name "imported")]
             (postgres/create-dataset-table conn table-name importer-columns)
-            (doseq [record (map postgres/coerce-to-sql (p/records importer))]
-              (jdbc/insert! conn table-name record))
+            (doseq [record (p/records importer)]
+              (doseq [i (range (count (last (first record))))]
+               (jdbc/insert! conn table-name (postgres/coerce-to-sql (import/extract-question-response record i)))))
             (db.job-execution/clone-data-table conn {:from-table table-name
                                     :to-table   imported-table-name}
                               {}

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer.clj
@@ -10,7 +10,7 @@
   (for [row rows]
     (apply merge
            (map (fn [{:keys [id type]} {:keys [value]}]
-                  {id value})
+                  {id [value]})
                 columns
                 row))))
 

--- a/backend/test/akvo/lumen/lib/import/common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/common_test.clj
@@ -1,0 +1,18 @@
+(ns akvo.lumen.lib.import.common-test
+  (:require [akvo.lumen.lib.import.common :as common]
+            [clojure.test :refer :all]
+            [clojure.data :as d]
+            [clojure.string :as str]))
+
+(deftest take-pos-test
+  (testing "extract question response based on pos"
+    (let [record {:id ["c1" "c2"], :kind ["number" "text"]}
+]
+      (is (= (common/extract-question-response record 0)
+             {:id "c1", :kind "number"}))
+      (is (= (common/extract-question-response record 1)
+             {:id "c2", :kind "text"})))
+))
+
+
+

--- a/backend/test/akvo/lumen/lib/import/common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/common_test.clj
@@ -1,18 +1,18 @@
 (ns akvo.lumen.lib.import.common-test
   (:require [akvo.lumen.lib.import.common :as common]
-            [clojure.test :refer :all]
-            [clojure.data :as d]
-            [clojure.string :as str]))
+            [clojure.test :refer :all]))
 
 (deftest take-pos-test
+  (testing "extract responses count"
+    (let [record {:id ["c1" "c2"], :kind ["number" "text"]}]
+      (is (= (common/responses-count record)
+             2))))
   (testing "extract question response based on pos"
-    (let [record {:id ["c1" "c2"], :kind ["number" "text"]}
-]
+    (let [record {:id ["c1" "c2"], :kind ["number" "text"]}]
       (is (= (common/extract-question-response record 0)
              {:id "c1", :kind "number"}))
       (is (= (common/extract-question-response record 1)
-             {:id "c2", :kind "text"})))
-))
+             {:id "c2", :kind "text"})))))
 
 
 

--- a/backend/test/akvo/lumen/lib/import/flow_common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/flow_common_test.clj
@@ -2,48 +2,40 @@
   (:require [akvo.lumen.lib.import.flow-common :as flow-common]
             [clojure.test :refer :all]))
 
-(def form-submission {:surveyalTime 88,
-                      :dataPointId "598359137",
-                      :deviceIdentifier "s7",
-                      :displayName "Ivan",
-                      :createdAt "2020-06-25T13:28:51.099Z",
-                      :formId "633209136",
-                      :submissionDate "2020-06-25T13:28:45Z",
-                      :id "602269126",
-                      :responses
-                      {:619429141
-                       [{:600019131 "Ivan",
-                         :619419129 41,
-                         :629229127
-                         [{:name "France"}
-                          {:name "Île-de-France"}
-                          {:name "Paris"}
-                          {:name "Paris, 16e arrondissement"}
-                          {:name "Paris, 16e arrondissement"}
-                          {:name "Paris, 16e arrondissement"}]}
-                        {:619419129 3}
-                        {:600019131 "Foo", :619419129 15}
-                        {:629229127
-                         [{:name "France"}
-                          {:name "Île-de-France"}
-                          {:name "Paris"}
-                          {:name "Paris, 18e arrondissement"}
-                          {:name "Paris, 18e arrondissement"}
-                          {:name "Paris, 18e arrondissement"}]}]},
-                      :identifier "fkrw-tcaf-8mt0",
-                      :modifiedAt "2020-06-25T13:28:54.697Z",
-                      :submitter "iperdomo"})
-
-
-(let [data (-> form-submission :responses vals)
-      responses-count (count (first data))]
-
-  
-  )
-
 (deftest take-pos-test
   (testing "extract responses count"
-    (let [vals-responses (-> form-submission :responses vals)]
+    (let [form-submission {:surveyalTime 88,
+                           :dataPointId "598359137",
+                           :deviceIdentifier "s7",
+                           :displayName "Ivan",
+                           :createdAt "2020-06-25T13:28:51.099Z",
+                           :formId "633209136",
+                           :submissionDate "2020-06-25T13:28:45Z",
+                           :id "602269126",
+                           :responses
+                           {:619429141
+                            [{:600019131 "Ivan",
+                              :619419129 41,
+                              :629229127
+                              [{:name "France"}
+                               {:name "Île-de-France"}
+                               {:name "Paris"}
+                               {:name "Paris, 16e arrondissement"}
+                               {:name "Paris, 16e arrondissement"}
+                               {:name "Paris, 16e arrondissement"}]}
+                             {:619419129 3}
+                             {:600019131 "Foo", :619419129 15}
+                             {:629229127
+                              [{:name "France"}
+                               {:name "Île-de-France"}
+                               {:name "Paris"}
+                               {:name "Paris, 18e arrondissement"}
+                               {:name "Paris, 18e arrondissement"}
+                               {:name "Paris, 18e arrondissement"}]}]},
+                           :identifier "fkrw-tcaf-8mt0",
+                           :modifiedAt "2020-06-25T13:28:54.697Z",
+                           :submitter "iperdomo"}
+          vals-responses (-> form-submission :responses vals)]
       (is (= (flow-common/adapt-response-values false (first vals-responses))
              {:600019131 ["Ivan"],          
               :619419129 [41],

--- a/backend/test/akvo/lumen/lib/import/flow_common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/flow_common_test.clj
@@ -1,0 +1,170 @@
+(ns akvo.lumen.lib.import.flow-common-test
+  (:require [akvo.lumen.lib.import.flow-common :as flow-common]
+            [clojure.test :refer :all]))
+
+(def form-submission {:surveyalTime 88,
+                      :dataPointId "598359137",
+                      :deviceIdentifier "s7",
+                      :displayName "Ivan",
+                      :createdAt "2020-06-25T13:28:51.099Z",
+                      :formId "633209136",
+                      :submissionDate "2020-06-25T13:28:45Z",
+                      :id "602269126",
+                      :responses
+                      {:619429141
+                       [{:600019131 "Ivan",
+                         :619419129 41,
+                         :629229127
+                         [{:name "France"}
+                          {:name "Île-de-France"}
+                          {:name "Paris"}
+                          {:name "Paris, 16e arrondissement"}
+                          {:name "Paris, 16e arrondissement"}
+                          {:name "Paris, 16e arrondissement"}]}
+                        {:619419129 3}
+                        {:600019131 "Foo", :619419129 15}
+                        {:629229127
+                         [{:name "France"}
+                          {:name "Île-de-France"}
+                          {:name "Paris"}
+                          {:name "Paris, 18e arrondissement"}
+                          {:name "Paris, 18e arrondissement"}
+                          {:name "Paris, 18e arrondissement"}]}]},
+                      :identifier "fkrw-tcaf-8mt0",
+                      :modifiedAt "2020-06-25T13:28:54.697Z",
+                      :submitter "iperdomo"})
+
+
+(let [data (-> form-submission :responses vals)
+      responses-count (count (first data))]
+
+  
+  )
+
+(deftest take-pos-test
+  (testing "extract responses count"
+    (let [vals-responses (-> form-submission :responses vals)]
+      (is (= (flow-common/adapt-response-values false (first vals-responses))
+             {:600019131 ["Ivan"],          
+              :619419129 [41],
+              :629229127
+              [[{:name "France"}
+                {:name "Île-de-France"}
+                {:name "Paris"}
+                {:name "Paris, 16e arrondissement"}
+                {:name "Paris, 16e arrondissement"}
+                {:name "Paris, 16e arrondissement"}]]}))
+      (is (= (flow-common/adapt-response-values true (first vals-responses))
+             {:600019131 ["Ivan" "Foo"],
+              :619419129 [41 3 15],
+              :629229127
+              [[{:name "France"}
+                {:name "Île-de-France"}
+                {:name "Paris"}
+                {:name "Paris, 16e arrondissement"}
+                {:name "Paris, 16e arrondissement"}
+                {:name "Paris, 16e arrondissement"}]
+               [{:name "France"}
+                {:name "Île-de-France"}
+                {:name "Paris"}
+                {:name "Paris, 18e arrondissement"}
+                {:name "Paris, 18e arrondissement"}
+                {:name "Paris, 18e arrondissement"}]]})))))
+
+
+(deftest ensure-all-questions-exist
+  (testing "flow only send values for questions that are filled"
+    (let [questions [{:groupId "597899156",
+                      :name "Name",
+                      :groupName "Repeated",
+                      :createdAt "2020-06-09T13:47:32.786Z",
+                      :type "FREE_TEXT",
+                      :personalData false,
+                      :variableName nil,
+                      :id "583119147",
+                      :order 1,
+                      :modifiedAt "2020-06-09T13:47:53.534Z"}
+                     {:groupId "597899156",
+                      :name "Age",
+                      :groupName "Repeated",
+                      :createdAt "2020-06-09T13:47:34.083Z",
+                      :type "NUMBER",
+                      :personalData false,
+                      :variableName nil,
+                      :id "594979148",
+                      :order 2,
+                      :modifiedAt "2020-06-09T13:48:07.215Z"}
+                     {:groupId "597899156",
+                      :name "Likes Pizza",
+                      :groupName "Repeated",
+                      :createdAt "2020-06-09T13:47:35.352Z",
+                      :type "OPTION",
+                      :personalData false,
+                      :variableName nil,
+                      :id "609479145",
+                      :order 3,
+                      :modifiedAt "2020-06-09T13:48:57.306Z"}
+                     {:groupId "617319144",
+                      :name "Family name",
+                      :groupName "Non repeatable",
+                      :createdAt "2020-06-09T13:46:35.817Z",
+                      :type "FREE_TEXT",
+                      :personalData false,
+                      :variableName nil,
+                      :id "617309149",
+                      :order 1,
+                      :modifiedAt "2020-06-09T13:47:25.423Z"}
+                     {:groupId "617319144",
+                      :name "Location",
+                      :groupName "Non repeatable",
+                      :createdAt "2020-06-09T13:47:05.152Z",
+                      :type "FREE_TEXT",
+                      :personalData false,
+                      :variableName nil,
+                      :id "588869155",
+                      :order 2,
+                      :modifiedAt "2020-06-09T13:47:20.516Z"}]]
+      (let [responses {"597899156" [{"583119147" "Mary",
+                                     "609479145" [{"text" "yes", "code" "1"}],
+                                     "594979148" 36.0}
+                                    {"583119147" "Pol",
+                                     "609479145" [{"text" "no", "code" "2"}],
+                                     "594979148" 12.0}],
+                       "617319144" [{"588869155" "Sevilla",
+                                     "617309149" "Poppins"}]}]
+        (is (= responses
+               (flow-common/ensure-response-value questions responses ::missing))))
+      (let [responses {"597899156" [{"609479145" [{"text" "yes", "code" "1"}],
+                                     "594979148" 36.0}
+                                    {"583119147" "Pol",
+                                     "609479145" [{"text" "no", "code" "2"}],
+                                     "594979148" 12.0}],
+                       "617319144" [{"588869155" "Sevilla",
+                                     "617309149" "Poppins"}]}]
+        (is (= (assoc-in responses ["597899156" 0 "583119147"] ::missing)
+               (flow-common/ensure-response-value questions responses ::missing))))
+      (let [responses {"597899156" [{"609479145" [{"text" "yes", "code" "1"}],
+                                     "594979148" 36.0}
+                                    {"583119147" "Pol",
+                                     "594979148" 12.0}],
+                       "617319144" [{"588869155" "Sevilla",
+                                     "617309149" "Poppins"}]}]
+        (is (= (-> responses
+                   (assoc-in  ["597899156" 0 "583119147"] ::missing)
+                   (assoc-in  ["597899156" 1 "609479145"] ::missing))
+               (flow-common/ensure-response-value questions responses ::missing))))
+      (let [responses {"597899156" [{}
+                                    {}],
+                       "617319144" [{"617309149" "Poppins"}]}]
+        (is (= {"617319144" [{"588869155" ::yikes
+                              "617309149" "Poppins"}],
+                "597899156" [{"583119147" ::yikes,
+                              "594979148" ::yikes,
+                              "609479145" ::yikes}
+                             {"583119147" ::yikes,
+                              "594979148" ::yikes,
+                              "609479145" ::yikes}]}
+               (flow-common/ensure-response-value questions responses ::yikes)))))))
+
+
+


### PR DESCRIPTION
```
FROM
;; {question-id -> response1 }

TO
;; {question-id -> [response1]}


Being a record a collection of questions-responses
{
question1 -> [response1-1],
question2 -> [response2-1],

}

```

This change is one step towards processing multiple responses in one question
```
;; {question-id -> [response1, response2]}
```


- [ ] **Update release notes if necessary**
