### PR TITLE
[#2127] Add groupId and groupName to column [backend][db]

### DIFF
--- a/backend/specs/akvo/lumen/specs/db/dataset_version.clj
+++ b/backend/specs/akvo/lumen/specs/db/dataset_version.clj
@@ -32,7 +32,8 @@
 (s/def ::version int?)
 
 (s/def ::column* (s/keys :req-un [::db.dsv.column/hidden ::db.dsv.column/direction
-                                  ::db.dsv.column/sort ::db.dsv.column/columnName]))
+                                  ::db.dsv.column/sort ::db.dsv.column/columnName]
+                         :opt-un [::db.dsv.column/groupName ::db.dsv.column/groupId]))
 
 (s/def ::column (s/merge ::import.column.s/header ::column*))
 

--- a/backend/specs/akvo/lumen/specs/db/dataset_version/column.clj
+++ b/backend/specs/akvo/lumen/specs/db/dataset_version/column.clj
@@ -11,6 +11,10 @@
 
 (s/def ::direction (s/nilable string?))
 
+(s/def ::groupName string?)
+
+(s/def ::groupId string?)
+
 (def ^:dynamic *columnName?* string?)
 
 (s/def ::columnName? #'*columnName?*)

--- a/backend/specs/akvo/lumen/specs/import/column.clj
+++ b/backend/specs/akvo/lumen/specs/import/column.clj
@@ -41,7 +41,8 @@
 
 (s/def ::column-header (s/keys :req-un [::v/title]
                                :opt-un [::v/id
-                                        ::v/metadata]))
+                                        ::v/groupId
+                                        ::v/groupName]))
 
 (s/def ::c.text/header* (s/keys :req-un [::c.text/type] :opt-un [::v/key]))
 (s/def ::c.text/header (s/merge ::column-header ::c.text/header*))

--- a/backend/specs/akvo/lumen/specs/import/values.clj
+++ b/backend/specs/akvo/lumen/specs/import/values.clj
@@ -37,11 +37,13 @@
                      string?
                      #(s/gen #{"c1" "c2" "c3"})))
 
-(s/def ::metadata (s/nilable map?))
-
 (s/def ::title (s/with-gen
                         string?
                         #(s/gen #{"Column 1" "Column 2" "Column 3"})))
+
+(s/def ::groupId string?)
+
+(s/def ::groupName string?)
 
 (s/def ::key boolean?)
 

--- a/backend/src/akvo/lumen/lib/import/csv.clj
+++ b/backend/src/akvo/lumen/lib/import/csv.clj
@@ -56,6 +56,8 @@
   (mapv (fn [idx title type]
           {:id (str "c" (inc idx))
            :title title
+           :groupId "main"
+           :groupName "main"
            :type type})
         (range)
         column-titles

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -12,8 +12,9 @@
   [form]
   (into (flow-common/commons-columns form)
         (into
-         [{:title "Latitude" :type "number" :id "latitude"}
-          {:title "Longitude" :type "number" :id "longitude"}]
+         (->> [{:title "Latitude" :type "number" :id "latitude"}
+               {:title "Longitude" :type "number" :id "longitude"}]
+              (mapv #(assoc % :groupName "metadata" :groupId "metadata")))
          (common/coerce flow-common/question-type->lumen-type (flow-common/questions form)))))
 
 (defmulti render-response

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -18,7 +18,6 @@
                                              (assoc :type "GEO-SHAPE-FEATURES")
                                              (assoc :multipleType "geo-shape-features")
                                              (assoc :multipleId (:id i))
-                                             (assoc :ns (:ns i))
                                              (assoc :derived-id (:id i))
                                              (assoc :derived-fn (fn [x] (-> x (w/keywordize-keys) :features first :properties)))
                                              (update :name (fn [o] (str o " Features" )))
@@ -26,12 +25,12 @@
        (conj c i))) [] (flow-common/questions form)))
 
 (defn dataset-columns
-  "returns a vector of [{:title :type :id :key}]
+  "returns a vector of [{:title :type :id :key :groupName :groupId}]
   `:key` is optional"
   [form]
   (let [questions (flow-questions form)]
     (into (flow-common/commons-columns form)
-          (into [{:title "Device Id" :type "text" :id "device_id"}]
+          (into [{:title "Device Id" :type "text" :id "device_id" :groupName "metadata" :groupId "metadata"}]
                 (common/coerce flow-common/question-type->lumen-type questions)))))
 
 (defn render-response

--- a/backend/src/akvo/lumen/lib/transformation/combine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/combine.clj
@@ -41,8 +41,8 @@
                                  "sort" nil
                                  "hidden" false
                                  "direction" nil
-                                 "groupName" "transformations"
-                                 "groupId" "transformations"
+                                 "groupName" "main"
+                                 "groupId" "main"
                                  "columnName" new-column-name})}))))
 
 (defmethod engine/columns-used "core/combine"

--- a/backend/src/akvo/lumen/lib/transformation/combine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/combine.clj
@@ -41,6 +41,8 @@
                                  "sort" nil
                                  "hidden" false
                                  "direction" nil
+                                 "groupName" "transformations"
+                                 "groupId" "transformations"
                                  "columnName" new-column-name})}))))
 
 (defmethod engine/columns-used "core/combine"

--- a/backend/src/akvo/lumen/lib/transformation/derive.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive.clj
@@ -193,6 +193,8 @@
                                            "type"       column-type
                                            "sort"       nil
                                            "hidden"     false
+                                           "groupName" "transformations"
+                                           "groupId" "transformations"
                                            "direction"  nil
                                            "columnName" new-column-name})})))))
 

--- a/backend/src/akvo/lumen/lib/transformation/derive.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive.clj
@@ -193,8 +193,8 @@
                                            "type"       column-type
                                            "sort"       nil
                                            "hidden"     false
-                                           "groupName" "transformations"
-                                           "groupId" "transformations"
+                                           "groupName" "main"
+                                           "groupId" "main"
                                            "direction"  nil
                                            "columnName" new-column-name})})))))
 

--- a/backend/src/akvo/lumen/lib/transformation/derive_category.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive_category.clj
@@ -84,8 +84,8 @@
                                          "type"       "text"
                                          "sort"       nil
                                          "hidden"     false
-                                         "groupName" "transformations"
-                                         "groupId" "transformations"
+                                         "groupName" "main"
+                                         "groupId" "main"
                                          "direction"  nil
                                          "columnName" new-column-name})})))))
 

--- a/backend/src/akvo/lumen/lib/transformation/derive_category.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive_category.clj
@@ -84,6 +84,8 @@
                                          "type"       "text"
                                          "sort"       nil
                                          "hidden"     false
+                                         "groupName" "transformations"
+                                         "groupId" "transformations"
                                          "direction"  nil
                                          "columnName" new-column-name})})))))
 

--- a/backend/src/akvo/lumen/lib/transformation/geo.clj
+++ b/backend/src/akvo/lumen/lib/transformation/geo.clj
@@ -47,6 +47,8 @@
                                     "sort" nil
                                     "hidden" false
                                     "direction" nil
+                                    "groupName" "transformations"
+                                    "groupId" "transformations"
                                     "columnName" column-name-geo})})
          (catch Exception e
            (log/debug e)

--- a/backend/src/akvo/lumen/lib/transformation/geo.clj
+++ b/backend/src/akvo/lumen/lib/transformation/geo.clj
@@ -47,8 +47,8 @@
                                     "sort" nil
                                     "hidden" false
                                     "direction" nil
-                                    "groupName" "transformations"
-                                    "groupId" "transformations"
+                                    "groupName" "main"
+                                    "groupId" "main"
                                     "columnName" column-name-geo})})
          (catch Exception e
            (log/debug e)

--- a/backend/src/akvo/lumen/lib/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/lib/transformation/merge_datasets.clj
@@ -146,8 +146,11 @@
                                                        source-dataset)
         column-names-translation (merge-column-names-map columns
                                                          source-merge-columns)
-        target-merge-columns (get-target-merge-columns source-merge-columns
-                                                       column-names-translation)
+        target-merge-columns (->> (get-target-merge-columns source-merge-columns
+                                                            column-names-translation)
+                                  (map #(assoc %
+                                               "groupName" "transformations"
+                                               "groupId" "transformations")))
         data (fetch-data conn
                          source-table-name
                          target-merge-columns

--- a/backend/src/akvo/lumen/lib/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/lib/transformation/merge_datasets.clj
@@ -149,8 +149,8 @@
         target-merge-columns (->> (get-target-merge-columns source-merge-columns
                                                             column-names-translation)
                                   (map #(assoc %
-                                               "groupName" "transformations"
-                                               "groupId" "transformations")))
+                                               "groupName" "main"
+                                               "groupId" "main")))
         data (fetch-data conn
                          source-table-name
                          target-merge-columns

--- a/backend/src/akvo/lumen/lib/transformation/multiple_column/caddisfly.clj
+++ b/backend/src/akvo/lumen/lib/transformation/multiple_column/caddisfly.clj
@@ -77,5 +77,5 @@
          {:success?      true
           :execution-log [(format "Extract caddisfly column %s" (:columnName selected-column))]
           :columns       (into current-columns (vec (map #(assoc %
-                                                                 "groupName" "transformations"
-                                                                 "groupId" "transformations") new-columns)))})))))
+                                                                 "groupName" "main"
+                                                                 "groupId" "main") new-columns)))})))))

--- a/backend/src/akvo/lumen/lib/transformation/multiple_column/caddisfly.clj
+++ b/backend/src/akvo/lumen/lib/transformation/multiple_column/caddisfly.clj
@@ -76,4 +76,6 @@
          (log/debug :db-txs selected-column add-db-columns update-db-columns)
          {:success?      true
           :execution-log [(format "Extract caddisfly column %s" (:columnName selected-column))]
-          :columns       (into current-columns (vec new-columns))})))))
+          :columns       (into current-columns (vec (map #(assoc %
+                                                                 "groupName" "transformations"
+                                                                 "groupId" "transformations") new-columns)))})))))

--- a/backend/src/akvo/lumen/lib/transformation/multiple_column/geo_shape_features.clj
+++ b/backend/src/akvo/lumen/lib/transformation/multiple_column/geo_shape_features.clj
@@ -65,5 +65,5 @@
           {:success?      true
            :execution-log [(format "Extract caddisfly column %s" (:columnName selected-column))]
            :columns       (into current-columns (vec (map #(assoc %
-                                                                  "groupName" "transformations"
-                                                                  "groupId" "transformations") new-columns)))})))))
+                                                                  "groupName" "main"
+                                                                  "groupId" "main") new-columns)))})))))

--- a/backend/src/akvo/lumen/lib/transformation/multiple_column/geo_shape_features.clj
+++ b/backend/src/akvo/lumen/lib/transformation/multiple_column/geo_shape_features.clj
@@ -64,4 +64,6 @@
           (log/debug :db-txs selected-column add-db-columns update-db-columns)
           {:success?      true
            :execution-log [(format "Extract caddisfly column %s" (:columnName selected-column))]
-           :columns       (into current-columns (vec new-columns))})))))
+           :columns       (into current-columns (vec (map #(assoc %
+                                                                  "groupName" "transformations"
+                                                                  "groupId" "transformations") new-columns)))})))))

--- a/backend/src/akvo/lumen/lib/transformation/reverse_geocode.clj
+++ b/backend/src/akvo/lumen/lib/transformation/reverse_geocode.clj
@@ -49,6 +49,8 @@
                          "sort" nil
                          "hidden" false
                          "direction" nil
+                         "groupName" "transformations"
+                         "groupId" "transformations"
                          "columnName" column-name})}))))
 
 (defmethod engine/columns-used "core/reverse-geocode"

--- a/backend/src/akvo/lumen/lib/transformation/reverse_geocode.clj
+++ b/backend/src/akvo/lumen/lib/transformation/reverse_geocode.clj
@@ -49,8 +49,8 @@
                          "sort" nil
                          "hidden" false
                          "direction" nil
-                         "groupName" "transformations"
-                         "groupId" "transformations"
+                         "groupName" "main"
+                         "groupId" "main"
                          "columnName" column-name})}))))
 
 (defmethod engine/columns-used "core/reverse-geocode"

--- a/backend/src/akvo/lumen/lib/transformation/split_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/split_column.clj
@@ -105,7 +105,9 @@
                                    (update-row tenant-conn table-name (:rnum row))))]
           {:success?      true
            :execution-log [(format "Splitted column %s with pattern %s" column-name pattern)]
-           :columns       (into columns (walk/stringify-keys (vec new-columns)))})
+           :columns       (into columns (walk/stringify-keys (vec (map #(assoc %
+                                                                               "groupName" "transformations"
+                                                                               "groupId" "transformations") new-columns))))})
         {:success? false
          :message  (format "No results trying to split column '%s' with pattern '%s'"
                            (:title (selected-column args)) (pattern* args))}))))

--- a/backend/src/akvo/lumen/lib/transformation/split_column.clj
+++ b/backend/src/akvo/lumen/lib/transformation/split_column.clj
@@ -106,8 +106,8 @@
           {:success?      true
            :execution-log [(format "Splitted column %s with pattern %s" column-name pattern)]
            :columns       (into columns (walk/stringify-keys (vec (map #(assoc %
-                                                                               "groupName" "transformations"
-                                                                               "groupId" "transformations") new-columns))))})
+                                                                               "groupName" "main"
+                                                                               "groupId" "main") new-columns))))})
         {:success? false
          :message  (format "No results trying to split column '%s' with pattern '%s'"
                            (:title (selected-column args)) (pattern* args))}))))

--- a/backend/src/akvo/lumen/protocols.clj
+++ b/backend/src/akvo/lumen/protocols.clj
@@ -69,9 +69,9 @@
 
     DatasetImporter
     (columns [this]
-      [{:id :a :type \"text\" :title \"A\"}
-       {:id :b :type \"number\" :title \"B\"}
-       {:id :c :type \"date\" :title \"C\"}])
+      [{:id :a :type \"text\" :title \"A\" :groupId \"main\" :groupName \"main\"}
+       {:id :b :type \"number\" :title \"B\" :groupId \"main\" :groupName \"main\"}
+       {:id :c :type \"date\" :title \"C\" :groupId \"main\" :groupName \"main\"}])
     (records [this]
       [{:a \"foo\"
         :b 42
@@ -90,6 +90,8 @@
        :title - The title of the column
        :id - The internal id of the column (as a keyword). The id must be
              lowercase alphanumeric ([a-z][a-z0-9]*)
+       :groupId - String value that represent a group id, e.g. \"main\"
+       :groupName - String value that represent a group name, e.g. \"main\"
 
      Optional:
        :key - True if this column is required to be non-null and unique")

--- a/backend/test/akvo/lumen/endpoint/share_test.clj
+++ b/backend/test/akvo/lumen/endpoint/share_test.clj
@@ -67,9 +67,9 @@
                           "i" "text-2"}}}))
 
 (defn seed* [conn vis-spec]
-  (let [data {:columns [{:id "c1", :title "A", :type "text"}
-                        {:id "c2", :title "B", :type "number"}
-                        {:id "c3", :title "C", :type "date"}]
+  (let [data {:columns [{:id "c1", :title "A", :type "text" :groupId "main" :groupName "main"}
+                        {:id "c2", :title "B", :type "number" :groupId "main" :groupName "main"}
+                        {:id "c3", :title "C", :type "date" :groupId "main" :groupName "main"}]
               :rows    [[{:value "a"} {:value 1} {:value (tu/instant-date "01/02/2019")}]
                         [{:value "b"} {:value 2} {:value (tu/instant-date "02/02/2019")}]
                         [{:value "c"} {:value 3} {:value (tu/instant-date "03/02/2019")}]

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -410,8 +410,8 @@
                                :hidden false,
                                :multipleType nil,
                                :columnName "c1",
-                               :groupId nil
-                               :groupName nil
+                               :groupId "main",
+                               :groupName "main",
                                :direction nil,
                                :sort nil}
                               {:key false,
@@ -419,8 +419,8 @@
                                :title "two",
                                :multipleId nil,
                                :hidden false,
-                               :groupId nil
-                               :groupName nil
+                               :groupId "main"
+                               :groupName "main"
                                :multipleType nil,
                                :columnName "c2",
                                :direction nil,

--- a/backend/test/akvo/lumen/endpoints_test/commons.clj
+++ b/backend/test/akvo/lumen/endpoints_test/commons.clj
@@ -6,68 +6,68 @@
             [clojure.java.io :as io])
   (:import [java.io ByteArrayInputStream]))
 
-(def dataset-link-columns [{:key false,
+(def dataset-link-columns [{:groupId "main",
+                            :key false,
+                            :groupName "main",
                             :type "text",
                             :title "Name",
                             :multipleId nil,
                             :hidden false,
                             :multipleType nil,
                             :columnName "c1",
-                            :groupId nil
-                            :groupName nil
                             :direction nil,
                             :sort nil}
-                           {:key false,
+                           {:groupId "main",
+                            :key false,
+                            :groupName "main",
                             :type "number",
                             :title "Age",
                             :multipleId nil,
                             :hidden false,
                             :multipleType nil,
-                            :groupId nil
-                            :groupName nil
                             :columnName "c2",
                             :direction nil,
                             :sort nil}
-                           {:key false,
+                           {:groupId "main",
+                            :key false,
+                            :groupName "main",
                             :type "number",
                             :title "Score",
                             :multipleId nil,
                             :hidden false,
                             :multipleType nil,
-                            :groupId nil
-                            :groupName nil
                             :columnName "c3",
                             :direction nil,
                             :sort nil}
-                           {:key false,
+                           {:groupId "main",
+                            :key false,
+                            :groupName "main",
                             :type "number",
                             :title "Temperature",
                             :multipleId nil,
                             :hidden false,
-                            :groupId nil
-                            :groupName nil
                             :multipleType nil,
                             :columnName "c4",
                             :direction nil,
                             :sort nil}
-                           {:key false,
+                           {:groupId "main",
+                            :key false,
+                            :groupName "main",
                             :type "number",
                             :title "Humidity",
                             :multipleId nil,
                             :hidden false,
                             :multipleType nil,
                             :columnName "c5",
-                            :groupId nil
-                            :groupName nil
                             :direction nil,
                             :sort nil}
-                           {:key false,
+                           {:groupId "main",
+                            :key false,
+                            :groupName "main",
                             :type "text",
                             :title "Cat",
                             :multipleId nil,
                             :hidden false,
-                            :groupId nil
-                            :groupName nil
                             :multipleType nil,
                             :columnName "c6",
                             :direction nil,

--- a/backend/test/akvo/lumen/lib/aggregation_test.clj
+++ b/backend/test/akvo/lumen/lib/aggregation_test.clj
@@ -25,9 +25,9 @@
       res)))
 
 (deftest pivot-tests
-  (let [columns [{:id "c1", :title "A", :type "text"}
-                 {:id "c2", :title "B", :type "text"}
-                 {:id "c3", :title "C", :type "number"}]
+  (let [columns [{:id "c1", :title "A", :type "text" :groupName "main" :groupId "main"}
+                 {:id "c2", :title "B", :type "text" :groupName "main" :groupId "main"}
+                 {:id "c3", :title "C", :type "number" :groupName "main" :groupId "main"}]
         rows [[{:value "a1"} {:value "b1"} {:value 10}]
               [{:value "a1"} {:value "b1"} {:value 11}]
               [{:value "a1"} {:value "b2"} {:value 9}]
@@ -139,8 +139,8 @@
 
 (deftest pie-tests
   (let [data {:columns
-              [{:id "c1", :title "A", :type "text"}
-               {:id "c2", :title "B", :type "text"}],
+              [{:id "c1", :title "A", :type "text" :groupName "main" :groupId "main"}
+               {:id "c2", :title "B", :type "text" :groupName "main" :groupId "main"}],
               :rows
               [[{:value "a1"} {:value "b1"}]
                [{:value "a1"} {:value "b1"}]
@@ -170,11 +170,11 @@
                  :metadata {:type "text"}}}))))))
 
 (deftest bar-tests
-  (let [data       {:columns [{:id "c1", :title "A", :type "text"}
-                              {:id "c2", :title "B", :type "number"}
-                              {:id "c3", :title "C", :type "number"}
-                              {:id "c4", :title "D", :type "number"}
-                              {:id "c5", :title "E", :type "number"}]
+  (let [data       {:columns [{:id "c1", :title "A", :type "text" :groupName "main" :groupId "main"}
+                              {:id "c2", :title "B", :type "number" :groupName "main" :groupId "main"}
+                              {:id "c3", :title "C", :type "number" :groupName "main" :groupId "main"}
+                              {:id "c4", :title "D", :type "number" :groupName "main" :groupId "main"}
+                              {:id "c5", :title "E", :type "number" :groupName "main" :groupId "main"}]
                     :rows    [[{:value "a"} {:value 1} {:value 1} {:value 10} {:value 100}]
                               [{:value "b"} {:value 1} {:value 2} {:value 20} {:value 200}]
                               [{:value "c"} {:value 1} {:value 3} {:value 30} {:value 300}]
@@ -270,9 +270,9 @@
                   {:label "c", :key "c"}]}}))))))
 
 (deftest line-tests
-  (let [data {:columns [{:id "c1", :title "A", :type "text"}
-                        {:id "c2", :title "B", :type "number"}
-                        {:id "c3", :title "C", :type "date"}]
+  (let [data {:columns [{:id "c1", :title "A", :type "text" :groupName "main" :groupId "main"}
+                        {:id "c2", :title "B", :type "number" :groupName "main" :groupId "main"}
+                        {:id "c3", :title "C", :type "date" :groupName "main" :groupId "main"}]
               :rows    [[{:value "a"} {:value 1} {:value (tu/instant-date "01/02/2019")}]
                         [{:value "b"} {:value 2} {:value (tu/instant-date "02/02/2019")}]
                         [{:value "c"} {:value 3} {:value (tu/instant-date "03/02/2019")}]
@@ -314,9 +314,9 @@
                     {:timestamp 1549238400000}]}})))))))
 
 (deftest scatter-tests
-  (let [data {:columns [{:id "c1", :title "A", :type "text"}
-                        {:id "c2", :title "B", :type "number"}
-                        {:id "c3", :title "C", :type "date"}]
+  (let [data {:columns [{:id "c1", :title "A", :type "text" :groupName "main" :groupId "main"}
+                        {:id "c2", :title "B", :type "number" :groupName "main" :groupId "main"}
+                        {:id "c3", :title "C", :type "date" :groupName "main" :groupId "main"}]
               :rows    [[{:value "a"} {:value 1} {:value (tu/instant-date "01/02/2019")}]
                         [{:value "b"} {:value 2} {:value (tu/instant-date "02/02/2019")}]
                         [{:value "c"} {:value 3} {:value (tu/instant-date "03/02/2019")}]
@@ -351,9 +351,9 @@
                  :data [{:label nil} {:label nil} {:label nil} {:label nil}]}}))))))
 
 (deftest bubble-tests
-  (let [data {:columns [{:id "c1", :title "A", :type "text"}
-                        {:id "c2", :title "B", :type "number"}
-                        {:id "c3", :title "C", :type "number"}]
+  (let [data {:columns [{:id "c1", :title "A", :type "text" :groupName "main" :groupId "main"}
+                        {:id "c2", :title "B", :type "number" :groupName "main" :groupId "main"}
+                        {:id "c3", :title "C", :type "number" :groupName "main" :groupId "main"}]
               :rows    [[{:value "a"} {:value 1} {:value 1}]
                         [{:value "b"} {:value 2} {:value 2}]
                         [{:value "c"} {:value 3} {:value 2}]

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer.clj
@@ -17,7 +17,8 @@
 (defn clj-data-importer [{:keys [columns rows] :as data} headers? guess-types?]
   (reify
     p/DatasetImporter
-    (columns [this] columns)
+    (columns [this]
+      (mapv #(assoc % :ns "main") columns))
     (records [this]
       (data-records data))
     java.io.Closeable

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -700,8 +700,8 @@
                               :type       "text",
                               :title      new-column-name
                               :hidden     false,
-                              :groupId "transformations"
-                              :groupName "transformations"
+                              :groupId "main"
+                              :groupName "main"
                               :direction  nil,
                               :columnName "d1"}
         mappings*            [[[">=" 0] ["<=" 1] "one"]
@@ -745,8 +745,8 @@
                               :type       "text"
                               :title      new-column-name
                               :hidden     false
-                              :groupId "transformations"
-                              :groupName "transformations"
+                              :groupId "main"
+                              :groupName "main"
                               :direction  nil
                               :columnName "d1"}
         mappings*            [[["v2" "v3"] "mapped-1"]

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -697,11 +697,13 @@
         new-column-name      "Derived column name"
         uncategorized-value  "Uncategorised value"
         new-derived-column   {:sort       nil,
-	                      :type       "text",
-	                      :title      new-column-name
-	                      :hidden     false,
-	                      :direction  nil,
-	                      :columnName "d1"}
+                              :type       "text",
+                              :title      new-column-name
+                              :hidden     false,
+                              :groupId "transformations"
+                              :groupName "transformations"
+                              :direction  nil,
+                              :columnName "d1"}
         mappings*            [[[">=" 0] ["<=" 1] "one"]
                               [["=" 2] nil "two"]]
         tx                   (gen-transformation "core/derive-category"
@@ -739,12 +741,14 @@
         apply-transformation (partial async-tx-apply {:tenant-conn *tenant-conn*} dataset-id)
         new-column-name      "Derived column name"
         uncategorized-value  "Uncategorised value"
-        new-derived-column   {:sort       nil,
-	                      :type       "text",
-	                      :title      new-column-name
-	                      :hidden     false,
-	                      :direction  nil,
-	                      :columnName "d1"}
+        new-derived-column   {:sort       nil
+                              :type       "text"
+                              :title      new-column-name
+                              :hidden     false
+                              :groupId "transformations"
+                              :groupName "transformations"
+                              :direction  nil
+                              :columnName "d1"}
         mappings*            [[["v2" "v3"] "mapped-1"]
                               [["v4"] "mapped-2"]]
         tx                   (gen-transformation "core/derive-category"


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

So far we could have 2 **static** possible groupIds: `main`, `metadata` or **dynamic** ones that currently should relate to [flow-group-question-id](https://github.com/akvo/akvo-lumen/blob/master/backend/src/akvo/lumen/lib/import/flow_common.clj#L88)

PS: `transformations` is not going to be a group... but in the mid/long term maybe will be a `subgroup`
