### PR TITLE
[#2735] - show divider line and reduce row height

### DIFF
--- a/client/src/components/dataset/ColumnHeader.scss
+++ b/client/src/components/dataset/ColumnHeader.scss
@@ -8,7 +8,7 @@
 
     * {
         vertical-align: top;
-        line-height: 60px;
+        line-height: 40px;
     }
 
     &.columnMenuActive {

--- a/client/src/components/dataset/DatasetTable.jsx
+++ b/client/src/components/dataset/DatasetTable.jsx
@@ -555,9 +555,9 @@ class DatasetTable extends Component {
                   />
                 )}
                 <Table
-                  groupHeaderHeight={60}
-                  headerHeight={60}
-                  rowHeight={60}
+                  groupHeaderHeight={40}
+                  headerHeight={40}
+                  rowHeight={40}
                   rowsCount={rows.size}
                   width={width}
                   height={height}

--- a/client/src/components/dataset/DatasetTable.scss
+++ b/client/src/components/dataset/DatasetTable.scss
@@ -46,15 +46,15 @@
 
         .public_fixedDataTableRow_highlighted {
             background-color: #fff;
-       
-            .public_fixedDataTableCell_main {
-                background-color: #fff;
-                border-top: 1px solid #e0e4e8;
-            }
+        }
+
+        .public_fixedDataTableCell_main {
+            background-color: #fff;
+            border-top: 1px solid #e0e4e8;
         }
 
         .public_fixedDataTableCell_cellContent {
-            padding: 1.5em 12px;
+            padding: 0.8em 12px;
             font-size: 14px;
         }
     }

--- a/client/src/components/dataset/DatasetTableV2.jsx
+++ b/client/src/components/dataset/DatasetTableV2.jsx
@@ -465,9 +465,9 @@ function DatasetTable(props) {
                   />
                 )}
                 <Table
-                  groupHeaderHeight={60}
-                  headerHeight={60}
-                  rowHeight={60}
+                  groupHeaderHeight={40}
+                  headerHeight={40}
+                  rowHeight={40}
                   rowsCount={props.rows.size}
                   width={width}
                   height={height}


### PR DESCRIPTION
This commit will fix the bug that hides the divider line in odd rows.
And also make the dataset table row height smaller

- [ ] **Update release notes if necessary**
