### PR TITLE
[#2127] When `rgq` flag is on, add `ns` and `repeatable` keys

### DIFF
--- a/backend/src/akvo/lumen/lib/import/common.clj
+++ b/backend/src/akvo/lumen/lib/import/common.clj
@@ -40,6 +40,7 @@
              :groupId (:groupId q)
              :metadata (:metadata q)
              :groupName (:groupName q)
+             :ns (:ns q)
              :id (format "c%s" (:id q))}
             (when (= t "multiple")
               (if (:caddisflyResourceUuid q)


### PR DESCRIPTION
The client needs to know which data groups are repeatable. For that,
we client can rely on the metadata in the column definition.

After importing a Flow form, we store as part of the columns
definition the `ns` and `repeatable` keys in the columns and expose
them as part of the endpoint `/dataset/<id>/groups`.