### PR TITLE
[#2735] - remove duplicate border from dataset grid

### DIFF
--- a/client/src/components/dataset/ColumnGroupHeader.scss
+++ b/client/src/components/dataset/ColumnGroupHeader.scss
@@ -9,6 +9,5 @@
 }
 
 .ColumnGroupHeader {
-    margin: 5px;
-
+    margin: 10px;
 }

--- a/client/src/components/dataset/DatasetTable.scss
+++ b/client/src/components/dataset/DatasetTable.scss
@@ -50,7 +50,7 @@
 
         .public_fixedDataTableCell_main {
             background-color: #fff;
-            border-top: 1px solid #e0e4e8;
+            border-bottom: 1px solid #e0e4e8;
         }
 
         .public_fixedDataTableCell_cellContent {


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Before: 
![image](https://user-images.githubusercontent.com/30107382/86462885-56259f80-bd24-11ea-8a13-4d8b4c43e36c.png)

After:
![image](https://user-images.githubusercontent.com/30107382/86462914-6473bb80-bd24-11ea-9e75-ee08d1d92fba.png)
