### PR TITLE
[#2127] One dataset multiple dataset_version tables (main and RQGs) 

### DIFF
--- a/backend/src/akvo/lumen/db/dataset.clj
+++ b/backend/src/akvo/lumen/db/dataset.clj
@@ -1,16 +1,32 @@
 (ns akvo.lumen.db.dataset
   (:require [hugsql.core :as hugsql]
+            [akvo.lumen.lib.import.flow-common :as flow-common]
+            [akvo.lumen.lib.transformation.engine :as tx.engine]
             [clojure.tools.logging :as log]))
+
 
 (hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")
 
 (defn dataset-by-id [conn opts]
   (first (dataset-by-id* conn opts)))
 
+(defn adapt-group [c]
+  (let [[groupId groupName] (cond
+                              (some? (get c "groupId")) [(get c "groupId") (get c "groupName")]
+                              (contains? flow-common/metadata-keys (get c "columnName")) ["metadata" "metadata"]
+                              (tx.engine/is-derived? (get c "columnName")) ["transformations" "transformations"]
+                              :else [nil nil])]
+    (-> c
+        (assoc "groupId" groupId)
+        (assoc "groupName" groupName))))
+
 (defn dataset-in-groups-by-id
   "dataset arranged in groups"
   [conn opts]
-  (let [dataset-col (dataset-by-id* conn opts)
+  (log/error :opts opts)
+  (let [dataset-col (map (fn [ds]
+                           (update ds :columns (fn [cols]
+                                                 (mapv adapt-group cols)))) (dataset-by-id* conn opts))
         commons-keys [:updated :created :source :modified :title :author :id]
         specific-keys [:transformations :columns :table-name]]
     (assoc (select-keys (first dataset-col) commons-keys)

--- a/backend/src/akvo/lumen/db/dataset.clj
+++ b/backend/src/akvo/lumen/db/dataset.clj
@@ -1,4 +1,20 @@
 (ns akvo.lumen.db.dataset
-  (:require [hugsql.core :as hugsql]))
+  (:require [hugsql.core :as hugsql]
+            [clojure.tools.logging :as log]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")
+
+(defn dataset-by-id [conn opts]
+  (first (dataset-by-id* conn opts)))
+
+(defn dataset-in-groups-by-id
+  "dataset arranged in groups"
+  [conn opts]
+  (let [dataset-col (dataset-by-id* conn opts)
+        commons-keys [:updated :created :source :modified :title :author :id]
+        specific-keys [:transformations :columns :table-name]]
+    (assoc (select-keys (first dataset-col) commons-keys)
+           :groups (reduce (fn [c ds]
+                             (let [ds-groups (map #(get % "groupId") (:columns ds))]
+                               (reduce #(assoc % %2 (select-keys ds specific-keys)) c ds-groups)))
+                           {} dataset-col))))

--- a/backend/src/akvo/lumen/db/dataset.clj
+++ b/backend/src/akvo/lumen/db/dataset.clj
@@ -4,7 +4,6 @@
             [akvo.lumen.lib.transformation.engine :as tx.engine]
             [clojure.tools.logging :as log]))
 
-
 (hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")
 
 (defn dataset-by-id [conn opts]
@@ -23,7 +22,6 @@
 (defn dataset-in-groups-by-id
   "dataset arranged in groups"
   [conn opts]
-  (log/error :opts opts)
   (let [dataset-col (map (fn [ds]
                            (update ds :columns (fn [cols]
                                                  (mapv adapt-group cols)))) (dataset-by-id* conn opts))

--- a/backend/src/akvo/lumen/endpoint/split_column.clj
+++ b/backend/src/akvo/lumen/endpoint/split_column.clj
@@ -20,7 +20,8 @@
         tenant :tenant}]
     (let [query           (json/parse-string (get query-params "query") keyword)
           tenant-conn     (p/connection tenant-manager tenant)
-          dataset-version (db.transformation/latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id})
+          dataset-version (let [v (:version (db.transformation/latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id}))]
+                            (first (db.transformation/latest-dataset-versions-by-dataset-id tenant-conn {:dataset-id dataset-id :version v})))
           sql-query       {:table-name  (:table-name dataset-version)
                            :column-name (:columnName query)
                            :limit       (str (:limit query "200"))}

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -94,7 +94,7 @@
                               (let [k (if (i.csv/valid-column-name? (:columnName col))
                                         :main :transformations)]
                                 (update c k #(conj % (assoc col :groupId k :groupName k)))))
-                            {:main [] :transformations []}  columns))]
+                            {:main [] :transformations (:transformations (get (:groups dataset) nil))}  columns))]
       (lib/ok
        {:id              id
         :name            (:title dataset)
@@ -102,6 +102,7 @@
         :created         (:created dataset)
         :updated         (:updated dataset)
         :status          "OK"
+
         :transformations (:transformations dataset)
         :source          (:source dataset)
         :groups          groups}))

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -125,7 +125,7 @@
 (defn fetch-group
   [tenant-conn id group-id]
   (when-let [dataset (db.dataset/dataset-in-groups-by-id tenant-conn {:id id})]
-    (let [group-dataset (get (:groups dataset) group-id)
+    (let [group-dataset (get (:groups dataset) (if (= "main" group-id) nil group-id))
           column-remove-condition (condp = group-id
                                     "metadata" #(not (contains? flow-common/metadata-keys (get % "columnName")))
                                     "transformations" #(not (tx.engine/is-derived? (get % "columnName")))

--- a/backend/src/akvo/lumen/lib/dataset.clj
+++ b/backend/src/akvo/lumen/lib/dataset.clj
@@ -78,8 +78,8 @@
 
   always we'll use 'transformations' groupId to include all generated transformations"
   [tenant-conn id]
-  (if-let [dataset (w/keywordize-keys (db.dataset/dataset-by-id tenant-conn {:id id}))]
-    (let [columns (remove #(get % :hidden) (:columns dataset))
+  (if-let [dataset (w/keywordize-keys (db.dataset/dataset-in-groups-by-id tenant-conn {:id id}))]
+    (let [columns (remove #(get % :hidden) (reduce #(into % %2) [] (map :columns (vals (:groups dataset)))) )
           groups  (if (= "AKVO_FLOW" (-> dataset :source :kind))
                     (let [columns-by-group (group-by :groupId columns)
                           groups           (dissoc columns-by-group nil)
@@ -89,7 +89,7 @@
                                        (let [k (if (contains? flow-common/metadata-keys (:columnName col))
                                                  :metadata :transformations)]
                                          (update c k #(conj % (assoc col :groupId k :groupName k)))))
-                                     {:metadata [] :transformations []}  nil-group)))
+                                     {:metadata [] :transformations (get groups "transformations" [])}  nil-group)))
                     (reduce (fn [c col]
                               (let [k (if (i.csv/valid-column-name? (:columnName col))
                                         :main :transformations)]
@@ -124,15 +124,16 @@
 
 (defn fetch-group
   [tenant-conn id group-id]
-  (when-let [dataset (db.dataset/dataset-by-id tenant-conn {:id id})]
-    (let [column-remove-condition (condp = group-id
+  (when-let [dataset (db.dataset/dataset-in-groups-by-id tenant-conn {:id id})]
+    (let [group-dataset (get (:groups dataset) group-id)
+          column-remove-condition (condp = group-id
                                     "metadata" #(not (contains? flow-common/metadata-keys (get % "columnName")))
                                     "transformations" #(not (tx.engine/is-derived? (get % "columnName")))
                                     "main" #(not (i.csv/valid-column-name? (get % "columnName")))
                                     #(not (= group-id (get % "groupId"))))
-          columns (remove #(or (get % "hidden") (column-remove-condition %)) (:columns dataset))
+          columns (remove #(or (get % "hidden") (column-remove-condition %)) (:columns group-dataset))
           data (rest (jdbc/query tenant-conn
-                                 [(select-data-sql (:table-name dataset) columns)]
+                                 [(select-data-sql (:table-name group-dataset) columns)]
                                  {:as-arrays? true}))]
       (-> (select-keys dataset [:updated :created :modified])
           remove-token

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -60,7 +60,7 @@ SELECT * from dataset WHERE id IN (:v*:ids);
 -- :doc update dataset meta
 UPDATE dataset SET title = :title WHERE id = :id;
 
--- :name dataset-by-id :? :1
+-- :name dataset-by-id* :? :*
 WITH
 source_data AS (
 SELECT (spec->'source')::jsonb - 'refreshToken' as source

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -19,71 +19,79 @@
             [clojure.string :as string]
             [clojure.tools.logging :as log]))
 
-(defn- successful-execution [conn job-execution-id data-source-id table-name columns {:keys [spec-name spec-description]} claims]
+(defn- successful-execution [conn job-execution-id data-source-id ns-table-names columns {:keys [spec-name spec-description]} claims]
   (let [dataset-id (util/squuid)
-        imported-table-name (util/gen-table-name "imported")
         {:strs [rqg]} (env/all conn)]
     (db.dataset/insert-dataset conn {:id dataset-id
                           :title spec-name ;; TODO Consistent naming. Change on client side?
                           :description spec-description
-                          :author claims})
-    (db.job-execution/clone-data-table conn
-                      {:from-table table-name
-                       :to-table imported-table-name}
-                      {}
-                      {:transaction? false})
-    (db.dataset-version/new-dataset-version conn {:id (util/squuid)
-                               :dataset-id dataset-id
-                               :job-execution-id job-execution-id
-                               :table-name table-name
-                               :imported-table-name imported-table-name
-                               :version 1
-                               :columns (mapv (fn [{:keys [title id type key multipleType multipleId groupName groupId ns]}]
-                                                (let [column-def {:columnName id
-                                                                  :direction nil
-                                                                  :hidden false
-                                                                  :key (boolean key)
-                                                                  :multipleId multipleId
-                                                                  :multipleType multipleType
-                                                                  :groupName groupName
-                                                                  :groupId groupId
-                                                                  :sort nil
-                                                                  :title (string/trim title)
-                                                                  :type type}]
-                                                  (if rqg
-                                                    (assoc column-def :ns ns :repeatable (= groupId ns))
-                                                    column-def)))
-                                              columns)
-                               :transformations []})
+                                     :author claims})
+    (doseq [[ns* cols] (group-by :ns columns)]
+      (let [imported-table-name (util/gen-table-name "imported")
+            table-name (get ns-table-names ns*)]
+        (db.job-execution/clone-data-table conn
+                                           {:from-table table-name
+                                            :to-table imported-table-name}
+                                           {}
+                                           {:transaction? false})
+        (db.dataset-version/new-dataset-version conn {:id (util/squuid)
+                                                      :dataset-id dataset-id
+                                                      :job-execution-id job-execution-id
+                                                      :table-name table-name
+                                                      :imported-table-name imported-table-name
+                                                      :version 1
+                                                      :columns (mapv (fn [{:keys [title id type key multipleType multipleId groupName groupId ns]}]
+                                                                       (let [column-def {:columnName id
+                                                                                         :direction nil
+                                                                                         :hidden false
+                                                                                         :key (boolean key)
+                                                                                         :multipleId multipleId
+                                                                                         :multipleType multipleType
+                                                                                         :groupName groupName
+                                                                                         :groupId groupId
+                                                                                         :sort nil
+                                                                                         :title (string/trim title)
+                                                                                         :type type}]
+                                                                         (if rqg
+                                                                           (assoc column-def :ns ns :repeatable (= groupId ns))
+                                                                           column-def)))
+                                                                     cols)
+                                                      :transformations []})))
     (db.job-execution/update-job-execution conn {:id             job-execution-id
-                                :status         "OK"
-                                :dataset-id     dataset-id})))
+                                                 :status         "OK"
+                                                 :dataset-id     dataset-id})))
 
-(defn- failed-execution [conn job-execution-id reason table-name]
+(defn- failed-execution [conn job-execution-id reason table-name-col]
   (db.job-execution/update-failed-job-execution conn {:id job-execution-id
-                                     :reason [reason]})
-  (db.transformation/drop-table conn {:table-name table-name}))
+                                                      :reason [reason]})
+  (doseq [table-name table-name-col]
+    (db.transformation/drop-table conn {:table-name table-name})))
 
 (defn- execute
   "Import runs within a future and since this is not taking part of ring
   request / response cycle we need to make sure to capture errors."
   [conn import-config error-tracker job-execution-id data-source-id claims spec]
   (future
-    (let [table-name (util/gen-table-name "ds")]
-      (try
-        (with-open [importer (common/dataset-importer (get spec "source")
-                                                      (assoc import-config :environment (env/all conn)))]
-          (let [columns (p/columns importer)]
-            (postgres/create-dataset-table conn table-name columns)
-            (doseq [record (map (comp postgres/coerce-to-sql first) (take common/rows-limit (p/records importer)))]
-              (jdbc/insert! conn table-name record))
-            (successful-execution conn job-execution-id  data-source-id table-name columns {:spec-name (get spec "name")
-                                                                                            :spec-description (get spec "description" "")} claims)))
-        (catch Throwable e
-          (failed-execution conn job-execution-id (.getMessage e) table-name)
-          (log/error e)
-          (p/track error-tracker e)
-          (throw e))))))
+    (let [ns-table-names-atom (atom {})]
+     (try
+       (with-open [importer (common/dataset-importer (get spec "source")
+                                                     (assoc import-config :environment (env/all conn)))]
+         (let [columns        (map  (fn [c] (update c :ns (fn [ns] (or ns "main")))) (p/columns importer))
+               ns-table-names (reset! ns-table-names-atom (reduce #(assoc % %2 (util/gen-table-name "ds")) {} (distinct (map :ns columns))))]
+           (doseq [[ns* cols] (group-by :ns columns)]
+             ;; todo foreign references????
+             (postgres/create-dataset-table conn (get ns-table-names ns*) cols))
+           (doseq [record-groups (take common/rows-limit (p/records importer))]
+             (doseq [record record-groups]
+               (jdbc/insert! conn (get ns-table-names (:ns (meta record) "main"))
+                             (postgres/coerce-to-sql record))))
+           (successful-execution conn job-execution-id  data-source-id ns-table-names columns {:spec-name        (get spec "name")
+                                                                                               :spec-description (get spec "description" "")} claims)))
+       (catch Throwable e
+         (failed-execution conn job-execution-id (.getMessage e) (vals @ns-table-names-atom))
+         (log/error e)
+         (p/track error-tracker e)
+         (throw e))))))
 
 (defn handle [tenant-conn import-config error-tracker claims data-source]
   (let [data-source-id (str (util/squuid))

--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -75,7 +75,7 @@
                                                       (assoc import-config :environment (env/all conn)))]
           (let [columns (p/columns importer)]
             (postgres/create-dataset-table conn table-name columns)
-            (doseq [record (map postgres/coerce-to-sql (take common/rows-limit (p/records importer)))]
+            (doseq [record (map (comp postgres/coerce-to-sql first) (take common/rows-limit (p/records importer)))]
               (jdbc/insert! conn table-name record))
             (successful-execution conn job-execution-id  data-source-id table-name columns {:spec-name (get spec "name")
                                                                                             :spec-description (get spec "description" "")} claims)))

--- a/backend/src/akvo/lumen/lib/import/csv.clj
+++ b/backend/src/akvo/lumen/lib/import/csv.clj
@@ -66,11 +66,11 @@
 
 (defn data-records [column-spec rows]
   (for [row rows]
-    (apply merge
-           (map (fn [{:keys [id type]} value]
-                  {id (transform-value value type)})
-                column-spec
-                row))))
+    [(apply merge
+             (map (fn [{:keys [id type]} value]
+                    {id (transform-value value type)})
+                  column-spec
+                  row))]))
 
 (defn get-column-count [data]
   (let [counts (distinct (map count data))]

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -102,13 +102,30 @@
 ;; {question-group-id -> [{question-id -> response}]
 ;; to
 ;; {question-id -> first-response}
-(defn question-responses
-  "Returns a map from question-id to the first response iteration"
-  [questions responses]
+(defn- question-responses-base [questions responses]
   (->> responses
        vals
        (map first)
        (apply merge)))
+
+;; Transforms the structure
+;; {question-group-id -> [{question-id -> response}]
+;; to
+;; [(with-meta
+;;          {question-id -> first-response}
+;;          {:ns xxx})]
+(defn question-responses
+  "Returns a list of map with meta from question-id to the first response iteration"
+  [groups questions responses]
+  (let [dict (let [[rep-col non-rep-col] (split-with :repeatable groups)]
+               {:rqg-ns (set (map :id rep-col)) :main-ns (set (map :id non-rep-col))})]
+    (into [(with-meta
+             (question-responses-base questions (select-keys responses (:main-ns dict)))
+             {:ns "main"})]
+          (mapv #(with-meta
+                   (question-responses-base questions {% (get responses %)})
+                   {:ns %})
+                (:rqg-ns dict)))))
 
 (def metadata-keys #{"identifier" "instance_id" "display_name" "submitter" "submitted_at" "surveyal_time" "device_id"})
 

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -84,7 +84,7 @@
 (defn response-data
   [form responses]
   (let [questions (flow-common/questions form)
-        responses (flow-common/question-responses questions responses)]
+        responses (flow-common/question-responses (:questionGroups form) questions responses)]
     (reduce (fn [response-data {:keys [type id]}]
               (if-let [response (get responses id)]
                 (assoc response-data

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -12,8 +12,9 @@
   [form]
   (into (flow-common/commons-columns form)
         (into
-         [{:title "Latitude" :type "number" :id "latitude"}
-          {:title "Longitude" :type "number" :id "longitude"}]
+         (->> [{:title "Latitude" :type "number" :id "latitude"}
+               {:title "Longitude" :type "number" :id "longitude"}]
+              (mapv #(assoc % :groupName "metadata" :groupId "metadata")))
          (common/coerce flow-common/question-type->lumen-type (flow-common/questions form)))))
 
 (defmulti render-response

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -26,12 +26,12 @@
        (conj c i))) [] (flow-common/questions form)))
 
 (defn dataset-columns
-  "returns a vector of [{:title :type :id :key}]
+  "returns a vector of [{:title :type :id :key :groupName :groupId}]
   `:key` is optional"
   [form]
   (let [questions (flow-questions form)]
     (into (flow-common/commons-columns form)
-          (into [{:title "Device Id" :type "text" :id "device_id"}]
+          (into [{:title "Device Id" :type "text" :id "device_id" :groupName "metadata" :groupId "metadata"}]
                 (common/coerce flow-common/question-type->lumen-type questions)))))
 
 (defn render-response

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -68,15 +68,16 @@
 (defn response-data
   [form responses]
   (let [questions (flow-questions form)
-        responses (flow-common/question-responses questions responses)]
-    (reduce (fn [response-data {:keys [type id repeatable derived-id derived-fn]}]
-              (if-let [response ((or derived-fn identity) (get responses (or derived-id id)))]
-                (assoc response-data
-                       (format "c%s" id)
-                       (render-response type response))
-                response-data))
-            {}
-            questions)))
+        responses-col (flow-common/question-responses (:questionGroups form) questions responses)]
+    (mapv #(reduce (fn [response-data {:keys [type id derived-id derived-fn]}]
+                    (if-let [response ((or derived-fn identity) (get % (or derived-id id)))]
+                      (assoc response-data
+                             (format "c%s" id)
+                             (render-response type response))
+                      response-data))
+                  {}
+                  questions)
+          responses-col)))
 
 (defn form-data
   "First pulls all data-points belonging to the survey. Then map over all form
@@ -88,9 +89,11 @@
     (map (fn [form-instance]
            (let [data-point-id (get form-instance "dataPointId")]
              (if-let [data-point (get data-points data-point-id)]
-               (merge (response-data form (get form-instance "responses"))
-                      (flow-common/common-records form-instance data-point)
-                      {:device_id (get form-instance "deviceIdentifier")})
+               (let [[main-group & more-groups] (response-data form (get form-instance "responses"))]
+                 (into [(merge main-group
+                                (flow-common/common-records form-instance data-point)
+                                {:device_id (get form-instance "deviceIdentifier")})]
+                       more-groups))
                (throw (ex-info "Flow form (dataPointId) referenced data point not in survey"
                                {:form-instance-id (get form-instance "id")
                                 :data-point-id data-point-id

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -69,14 +69,14 @@
   [form responses]
   (let [questions (flow-questions form)
         responses-col (flow-common/question-responses (:questionGroups form) questions responses)]
-    (mapv #(reduce (fn [response-data {:keys [type id derived-id derived-fn]}]
-                    (if-let [response ((or derived-fn identity) (get % (or derived-id id)))]
-                      (assoc response-data
-                             (format "c%s" id)
-                             (render-response type response))
-                      response-data))
-                  {}
-                  questions)
+    (mapv #(with-meta (reduce (fn [response-data {:keys [type id derived-id derived-fn]}]
+                                (if-let [response ((or derived-fn identity) (get % (or derived-id id)))]
+                                  (assoc response-data
+                                         (format "c%s" id)
+                                         (render-response type response))
+                                  response-data))
+                              {}
+                              questions) (meta %))
           responses-col)))
 
 (defn form-data
@@ -90,9 +90,11 @@
            (let [data-point-id (get form-instance "dataPointId")]
              (if-let [data-point (get data-points data-point-id)]
                (let [[main-group & more-groups] (response-data form (get form-instance "responses"))]
-                 (into [(merge main-group
-                                (flow-common/common-records form-instance data-point)
-                                {:device_id (get form-instance "deviceIdentifier")})]
+                 (into [(with-meta
+                          (merge main-group
+                                 (flow-common/common-records form-instance data-point)
+                                 {:device_id (get form-instance "deviceIdentifier")})
+                          (meta main-group))]
                        more-groups))
                (throw (ex-info "Flow form (dataPointId) referenced data point not in survey"
                                {:form-instance-id (get form-instance "id")

--- a/backend/src/akvo/lumen/lib/transformation.sql
+++ b/backend/src/akvo/lumen/lib/transformation.sql
@@ -19,13 +19,21 @@ UPDATE dataset
 SELECT id FROM dataset WHERE id = :id
 
 -- :name latest-dataset-version-by-dataset-id :? :1
--- :doc Returns the most recent dataset version for a given dataset id
-SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations
+-- :doc Returns the most recent version for a given dataset id
+SELECT version
   FROM dataset_version
  WHERE dataset_id = :dataset-id
    AND version = (SELECT MAX(v.version)
                     FROM dataset_version v
-                   WHERE v.dataset_id = :dataset-id);
+                   WHERE v.dataset_id = :dataset-id)
+
+
+-- :name latest-dataset-versions-by-dataset-id :? :*
+-- :doc Returns the most recent dataset versions for a given dataset id
+SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations
+  FROM dataset_version
+ WHERE dataset_id = :dataset-id
+   AND version = :version ;
 
 -- :name latest-dataset-versions-by-dataset-ids :? :*
 -- :doc Returns the most recent dataset version for a given dataset id
@@ -44,13 +52,19 @@ order by dataset_id, version desc;
 -- :name update-dataset-version :! :n
 -- :doc Update dataset version
 UPDATE dataset_version SET columns= :columns,  transformations= :transformations
-where dataset_id= :dataset-id and version= :version;
+where id= :id ;
 
 -- :name initial-dataset-version-to-update-by-dataset-id :? :1
-SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations
+SELECT version
   FROM  dataset_version
   WHERE dataset_id= :dataset-id AND transformations='[]'
   ORDER BY version DESC LIMIT 1;
+
+-- :name initial-dataset-versions-to-update-by-dataset-id :? :*
+SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations
+  FROM  dataset_version
+  WHERE dataset_id= :dataset-id AND version= :version;
+
 
 -- :name dataset-version-by-dataset-id :? :1
 -- :doc Returns the most recent dataset version for a given dataset id

--- a/backend/src/akvo/lumen/lib/transformation/merge_datasets.clj
+++ b/backend/src/akvo/lumen/lib/transformation/merge_datasets.clj
@@ -115,7 +115,8 @@
 
 (defn get-source-dataset [conn source]
   (let [source-dataset-id (get source "datasetId")]
-    (if-let [source-dataset (db.transformation/latest-dataset-version-by-dataset-id conn {:dataset-id source-dataset-id})]
+    (if-let [source-dataset (let [v (:version (db.transformation/latest-dataset-version-by-dataset-id conn {:dataset-id source-dataset-id}))]
+                              (first (db.transformation/latest-dataset-versions-by-dataset-id conn {:dataset-id source-dataset-id :version v})))]
       source-dataset
       (throw (ex-info (format "Dataset %s does not exist" source-dataset-id)
                       {:source source})))))

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -139,7 +139,7 @@
           (let [table-name          (util/gen-table-name "ds")
                 imported-table-name (util/gen-table-name "imported")]
             (postgres/create-dataset-table conn table-name importer-columns)
-            (doseq [record (map postgres/coerce-to-sql (p/records importer))]
+            (doseq [record (map (comp postgres/coerce-to-sql first) (p/records importer))]
               (jdbc/insert! conn table-name record))
             (db.job-execution/clone-data-table conn {:from-table table-name
                                     :to-table   imported-table-name}

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -146,8 +146,8 @@
     multipleId   (assoc "multipleId" multipleId)))
 
 (defn dict-dsv [initial-dataset-version-col latest-dataset-version-col]
-  (let [res (reduce (fn [c ds] (update c (get (first (:columns ds)) "ns") conj ds)) {} latest-dataset-version-col)
-        res1 (reduce (fn [c ds] (update c (get (first (:columns ds)) "ns") conj ds)) res initial-dataset-version-col)]
+  (let [res (reduce (fn [c ds] (update c (get (first (:columns ds)) "ns" "main") conj ds)) {} latest-dataset-version-col)
+        res1 (reduce (fn [c ds] (update c (get (first (:columns ds)) "ns" "main") conj ds)) res initial-dataset-version-col)]
     res1))
 
 (defn- do-update [tenant-conn caddisfly import-config dataset-id data-source-id job-execution-id data-source-spec]

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.update
   (:require [akvo.lumen.protocols :as p]
             [akvo.lumen.lib.import.common :as import]
+            [akvo.lumen.lib.import.common :as common]
             [akvo.lumen.postgres :as postgres]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.lib.env :as env]
@@ -51,10 +52,8 @@
   pointing to the new table-name, imported-table-name and columns. We
   also delete the previous table-name and imported-table-name so we
   don't accumulate unused datasets on each update."
-  [conn job-execution-id dataset-id table-name imported-table-name dataset-version]
+  [conn job-execution-id dataset-id]
   (db.transformation/touch-dataset conn {:id dataset-id})
-  (db.transformation/drop-table conn {:table-name (:imported-table-name dataset-version)})
-  (db.transformation/drop-table conn {:table-name (:table-name dataset-version)})
   (db.job-execution/update-successful-job-execution conn {:id job-execution-id}))
 
 (defn- failed-update [conn job-execution-id reason]
@@ -114,66 +113,91 @@
                                    columns))
       nil)))
 
+(defn- compatible-errors-logic [tenant-conn data-source-spec dataset-id initial-dataset-version-col importer-columns]
+  (first
+   (filter some? (map #(let [imported-dataset-columns (vec (:columns %))
+
+                             columns-used (columns-used-in-txs
+                                           (import/importer-type (get data-source-spec "source"))
+                                           %
+                                           (db.transformation/latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id}))
+
+                             imported-dataset-columns-checked (reduce (fn [c co]
+                                                                        (if (contains? columns-used (get co "columnName"))
+                                                                          (conj c co)
+                                                                          c)) [] imported-dataset-columns)
+                             ]
+                         (compatible-columns-error? imported-dataset-columns-checked importer-columns))
+                      initial-dataset-version-col)))
+  )
+
+(defn- coerce-column [{:keys [title id type key multipleId multipleType groupName groupId ns] :as column}]
+  (cond-> {"type" type
+           "title" title
+           "columnName" id
+           "groupName" groupName
+           "groupId" groupId
+           "ns" ns
+           "sort" nil
+           "direction" nil
+           "hidden" false}
+    key           (assoc "key" (boolean key))
+    multipleType (assoc "multipleType" multipleType)
+    multipleId   (assoc "multipleId" multipleId)))
+
+(defn dict-dsv [initial-dataset-version-col latest-dataset-version-col]
+  (let [res (reduce (fn [c ds] (update c (get (first (:columns ds)) "ns") conj ds)) {} latest-dataset-version-col)
+        res1 (reduce (fn [c ds] (update c (get (first (:columns ds)) "ns") conj ds)) res initial-dataset-version-col)]
+    res1))
+
 (defn- do-update [tenant-conn caddisfly import-config dataset-id data-source-id job-execution-id data-source-spec]
   (jdbc/with-db-transaction [conn tenant-conn]
     (with-open [importer (import/dataset-importer (get data-source-spec "source") import-config)]
-      (let [initial-dataset-version  (db.transformation/initial-dataset-version-to-update-by-dataset-id conn {:dataset-id dataset-id})
-            imported-dataset-columns (vec (:columns initial-dataset-version))
+      (let [version (:version (db.transformation/initial-dataset-version-to-update-by-dataset-id conn {:dataset-id dataset-id}))
+            initial-dataset-version-col  (db.transformation/initial-dataset-versions-to-update-by-dataset-id conn {:dataset-id dataset-id :version version})
             importer-columns         (p/columns importer)
-
-            columns-used (columns-used-in-txs
-                          (import/importer-type (get data-source-spec "source"))
-                          initial-dataset-version
-                          (db.transformation/latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id}))
-            imported-dataset-columns-checked (reduce (fn [c co]
-                                                       (if (contains? columns-used (get co "columnName"))
-                                                         (conj c co)
-                                                         c)) [] imported-dataset-columns)]
-        (if-let [compatible-errors (compatible-columns-error? imported-dataset-columns-checked importer-columns)]
+            columns-by-ns (map  (fn [c] (update c :ns (fn [ns] (or ns "main")))) (p/columns importer))
+            grouped-columns-by-ns (group-by :ns columns-by-ns)
+            ns-table-names (reduce #(assoc % %2 (util/gen-table-name "ds")) {} (distinct (map :ns columns-by-ns)))]
+        (if-let [compatible-errors (compatible-errors-logic tenant-conn data-source-spec dataset-id initial-dataset-version-col importer-columns)]
           (failed-update conn job-execution-id
                          (cond-> "Column mismatch"
                            (seq (:missed-columns compatible-errors))
                            (str ".\n Following columns are missed in new data version: " (:missed-columns compatible-errors))
                            (seq (:wrong-types compatible-errors))
                            (str ".\n Following columns have changed the column type in new data version: " (:wrong-types compatible-errors))))
-          (let [table-name          (util/gen-table-name "ds")
-                imported-table-name (util/gen-table-name "imported")]
-            (postgres/create-dataset-table conn table-name importer-columns)
-            (doseq [record (map (comp postgres/coerce-to-sql first) (p/records importer))]
-              (jdbc/insert! conn table-name record))
-            (db.job-execution/clone-data-table conn {:from-table table-name
-                                    :to-table   imported-table-name}
-                              {}
-                              {:transaction? false})
-            (let [dataset-version  (db.transformation/latest-dataset-version-by-dataset-id conn {:dataset-id dataset-id})
-                  coerce-column-fn (fn [{:keys [title id type key multipleId multipleType groupName groupId] :as column}]
-                                     (cond-> {"type" type
-                                              "title" title
-                                              "columnName" id
-                                              "groupName" groupName
-                                              "groupId" groupId
-                                              "sort" nil
-                                              "direction" nil
-                                              "hidden" false}
-                                       key           (assoc "key" (boolean key))
-                                       multipleType (assoc "multipleType" multipleType)
-                                       multipleId   (assoc "multipleId" multipleId)))
-                  importer-columns (mapv coerce-column-fn importer-columns)]
-              (engine/apply-transformation-log conn
-                                               caddisfly
-                                               table-name
-                                               imported-table-name
-                                               importer-columns
-                                               imported-dataset-columns
-                                               dataset-id
-                                               job-execution-id
-                                               dataset-version)
-              (successful-update conn
-                                 job-execution-id
-                                 dataset-id
-                                 table-name
-                                 imported-table-name
-                                 dataset-version))))))))
+          (let [latest-version  (:version (db.transformation/latest-dataset-version-by-dataset-id conn {:dataset-id dataset-id}))
+                latest-dataset-version-col (db.transformation/latest-dataset-versions-by-dataset-id conn {:dataset-id dataset-id :version latest-version})
+                dataset-version-col-by-ns (dict-dsv initial-dataset-version-col latest-dataset-version-col)]
+            (doseq [[ns* cols] grouped-columns-by-ns]
+             ;; todo foreign references????
+              (postgres/create-dataset-table conn (get ns-table-names ns*) cols))
+
+            (doseq [record-groups (take common/rows-limit (p/records importer))]
+              (doseq [record record-groups]
+                (jdbc/insert! conn (get ns-table-names (:ns (meta record) "main"))
+                              (postgres/coerce-to-sql record))))
+            
+            (doseq [[ns* [initial-dataset-version latest-dataset-version]] dataset-version-col-by-ns]
+              (let [imported-table-name (util/gen-table-name "imported")
+                    table-name (get ns-table-names ns*)]
+                (db.job-execution/clone-data-table conn {:from-table table-name
+                                                         :to-table   imported-table-name}
+                                                   {}
+                                                   {:transaction? false})
+                (engine/apply-transformation-log conn
+                                                 caddisfly
+                                                 table-name
+                                                 imported-table-name
+                                                 (mapv coerce-column (get grouped-columns-by-ns ns*))
+                                                 (vec (:columns initial-dataset-version))
+                                                 dataset-id
+                                                 job-execution-id
+                                                 initial-dataset-version
+                                                 latest-dataset-version)
+                (db.transformation/drop-table conn {:table-name (:imported-table-name latest-dataset-version)})
+                (db.transformation/drop-table conn {:table-name (:table-name latest-dataset-version)})))
+            (successful-update conn job-execution-id dataset-id)))))))
 
 (defn update-dataset [tenant-conn caddisfly import-config error-tracker dataset-id data-source-id data-source-spec]
   (if-let [current-tx-job (db.transformation/pending-transformation-job-execution tenant-conn {:dataset-id dataset-id})]

--- a/backend/src/akvo/lumen/protocols.clj
+++ b/backend/src/akvo/lumen/protocols.clj
@@ -92,7 +92,8 @@
              lowercase alphanumeric ([a-z][a-z0-9]*)
 
      Optional:
-       :key - True if this column is required to be non-null and unique")
+       :key - True if this column is required to be non-null and unique
+       :ns - nil means `main` else the table-dataset_version ns value")
   (records [this]
     "Returns a sequence of record data. A record is a map of column ids to values.
      The type of the value depends on the type of the column where

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -179,7 +179,6 @@
               (is (= {:id dataset-id
                       :name title
                       :status "OK"
-                      :transformations []
                       :groups {:transformations []
                                :main (map #(assoc % :groupName "main" :groupId "main") commons/dataset-link-columns)}}
                      (select-keys meta-group-dataset [:id :name :status :transformations :groups]))))

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -179,6 +179,7 @@
               (is (= {:id dataset-id
                       :name title
                       :status "OK"
+                      :transformations nil
                       :groups {:transformations []
                                :main (map #(assoc % :groupName "main" :groupId "main") commons/dataset-link-columns)}}
                      (select-keys meta-group-dataset [:id :name :status :transformations :groups]))))

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer.clj
@@ -8,11 +8,11 @@
 
 (defn data-records [{:keys [columns rows]}]
   (for [row rows]
-    (apply merge
-           (map (fn [{:keys [id type]} {:keys [value]}]
-                  {id value})
-                columns
-                row))))
+    [(apply merge
+             (map (fn [{:keys [id type]} {:keys [value]}]
+                    {id value})
+                  columns
+                  row))]))
 
 (defn clj-data-importer [{:keys [columns rows] :as data} headers? guess-types?]
   (reify

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
@@ -30,9 +30,11 @@
                                    :data (i-c/sample-imported-dataset [:text :number] 2) })
           dataset (dataset-version-by-dataset-id *tenant-conn* {:dataset-id dataset-id
                                                                 :version 1})
-          stored-data (->> (latest-dataset-version-by-dataset-id *tenant-conn*
-                                                                 {:dataset-id dataset-id})
-                           (get-data *tenant-conn*))]
+          stored-data (let [v (:version (latest-dataset-version-by-dataset-id *tenant-conn*
+                                                                     {:dataset-id dataset-id}))]
+                        (->> (first (latest-dataset-versions-by-dataset-id *tenant-conn*
+                                                                     {:dataset-id dataset-id :version v}))
+                             (get-data *tenant-conn*)))]
       (is (= (map keys (:columns dataset)) '(("groupId"
                                               "key"
                                               "groupName"
@@ -72,9 +74,11 @@
           dataset-id (:dataset_id dataset)
           dataset (dataset-version-by-dataset-id *tenant-conn* {:dataset-id dataset-id
                                                                 :version 1})
-          stored-data (->> (latest-dataset-version-by-dataset-id *tenant-conn*
-                                                                 {:dataset-id dataset-id})
-                           (get-data *tenant-conn*))
+          stored-data (let [v (:version (latest-dataset-version-by-dataset-id *tenant-conn*
+                                                                     {:dataset-id dataset-id}))]
+                        (->> (first (latest-dataset-versions-by-dataset-id *tenant-conn*
+                                                                     {:dataset-id dataset-id :version v}))
+                             (get-data *tenant-conn*)))
           updated-res (update-file *tenant-conn* (:akvo.lumen.component.caddisfly/caddisfly *system*)
                                    *error-tracker* (:dataset-id job) (:data-source-id job)
                         {:kind "clj"

--- a/backend/test/akvo/lumen/lib/import/flow_common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/flow_common_test.clj
@@ -1,0 +1,109 @@
+(ns akvo.lumen.lib.import.flow-common-test
+  (:require [akvo.lumen.lib.import.flow-common :as flow-common]
+            [clojure.test :refer :all]))
+
+(deftest double-check
+  (testing "flow only send values for questions that are filled"
+    (let [groups [{:id "597899156"
+                   :name "Repeated"
+                   :repeatable true}
+                  {:id "617319144"
+                   :name "Non repeatable"
+                   :repeatable false}]
+          questions [{:groupId "597899156",
+                      :name "Name",
+                      :groupName "Repeated",
+                      :createdAt "2020-06-09T13:47:32.786Z",
+                      :type "FREE_TEXT",
+                      :personalData false,
+                      :variableName nil,
+                      :id "583119147",
+                      :order 1,
+                      :modifiedAt "2020-06-09T13:47:53.534Z"}
+                     {:groupId "597899156",
+                      :name "Age",
+                      :groupName "Repeated",
+                      :createdAt "2020-06-09T13:47:34.083Z",
+                      :type "NUMBER",
+                      :personalData false,
+                      :variableName nil,
+                      :id "594979148",
+                      :order 2,
+                      :modifiedAt "2020-06-09T13:48:07.215Z"}
+                     {:groupId "597899156",
+                      :name "Likes Pizza",
+                      :groupName "Repeated",
+                      :createdAt "2020-06-09T13:47:35.352Z",
+                      :type "OPTION",
+                      :personalData false,
+                      :variableName nil,
+                      :id "609479145",
+                      :order 3,
+                      :modifiedAt "2020-06-09T13:48:57.306Z"}
+                     {:groupId "617319144",
+                      :name "Family name",
+                      :groupName "Non repeatable",
+                      :createdAt "2020-06-09T13:46:35.817Z",
+                      :type "FREE_TEXT",
+                      :personalData false,
+                      :variableName nil,
+                      :id "617309149",
+                      :order 1,
+                      :modifiedAt "2020-06-09T13:47:25.423Z"}
+                     {:groupId "617319144",
+                      :name "Location",
+                      :groupName "Non repeatable",
+                      :createdAt "2020-06-09T13:47:05.152Z",
+                      :type "FREE_TEXT",
+                      :personalData false,
+                      :variableName nil,
+                      :id "588869155",
+                      :order 2,
+                      :modifiedAt "2020-06-09T13:47:20.516Z"}]]
+      (let [responses {"597899156" [{"583119147" "Mary",
+                                     "609479145" [{"text" "yes", "code" "1"}],
+                                     "594979148" 36.0}
+                                    {"583119147" "Pol",
+                                     "609479145" [{"text" "no", "code" "2"}],
+                                     "594979148" 12.0}],
+                       "617319144" [{"588869155" "Sevilla",
+                                     "617309149" "Poppins"}]}]
+        (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
+                {"583119147" "Mary",
+                 "609479145" [{"text" "yes", "code" "1"}],
+                 "594979148" 36.0}]
+               (flow-common/question-responses groups questions responses))))
+      (let [responses {"597899156" [{"609479145" [{"text" "yes", "code" "1"}],
+                                     "594979148" 36.0}
+                                    {"583119147" "Pol",
+                                     "609479145" [{"text" "no", "code" "2"}],
+                                     "594979148" 12.0}],
+                       "617319144" [{"588869155" "Sevilla",
+                                     "617309149" "Poppins"}]}]
+        (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
+                {"609479145" [{"text" "yes", "code" "1"}], "594979148" 36.0}]
+               (flow-common/question-responses groups questions responses))))
+      (let [responses {"597899156" [{"609479145" [{"text" "yes", "code" "1"}],
+                                     "594979148" 36.0}
+                                    {"583119147" "Pol",
+                                     "594979148" 12.0}],
+                       "617319144" [{"588869155" "Sevilla",
+                                     "617309149" "Poppins"}]}]
+        (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
+                {"609479145" [{"text" "yes", "code" "1"}], "594979148" 36.0}]
+               (flow-common/question-responses groups questions responses))))
+      (let [responses {"597899156" [{}
+                                    {}],
+                       "617319144" [{"617309149" "Poppins"}]}]
+        (is (= [{"617309149" "Poppins"} {}]
+               (flow-common/question-responses groups questions responses)))))))
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
### TODO
- [x] foreign keys in dataset-version
- [x] how to deal with transformations (storing and reading)
- [ ] how to deal with vizss
- [ ] update process
- [x] test older dataset without feature-flag
- [x] check sql queries modifed are not used in other places
- [x] how to apply transformations? order of transformations in update process with dependant transformations data-groups



## Important
... one iteration of each form submission ... still don't try to store multiple RQG answers


Relates to https://github.com/akvo/akvo-lumen/pull/2734

```
but instead of trying
FROM
;; {question-id -> response1 }

TO
;; {question-id -> [response1]}

we do ...

TO
;; [{question-id -> response1} {question-id -> response2}]
```


Being each map a table representation, so first map will be `main` table, the others will be `RQG` answers

- [ ] **Update release notes if necessary**
