### PR TITLE
[#2127] Add namespace column to dataset_version

### DIFF
--- a/backend/resources/akvo/lumen/migrations/tenants/023-dataset-version-alter-unique-constraint.down.sql
+++ b/backend/resources/akvo/lumen/migrations/tenants/023-dataset-version-alter-unique-constraint.down.sql
@@ -1,4 +1,4 @@
-DROP INDEX IF EXISTS dataset_version_dataset_id_version_columns_key;
+ALTER TABLE dataset_version DROP CONSTRAINT IF EXISTS dataset_version_dataset_id_version_columns_key;
 
 ALTER TABLE public.dataset_version
       ADD UNIQUE (dataset_id, version);

--- a/backend/resources/akvo/lumen/migrations/tenants/023-dataset-version-alter-unique-constraint.up.sql
+++ b/backend/resources/akvo/lumen/migrations/tenants/023-dataset-version-alter-unique-constraint.up.sql
@@ -1,5 +1,4 @@
-ALTER TABLE public.dataset_version
-      DROP CONSTRAINT IF EXISTS dataset_version_dataset_id_version_key;
+ALTER TABLE dataset_version DROP CONSTRAINT IF EXISTS adataset_version_dataset_id_version_key;
 
 CREATE UNIQUE INDEX dataset_version_dataset_id_version_columns_key
 ON dataset_version (dataset_id, version, md5(columns::text));

--- a/backend/resources/akvo/lumen/migrations/tenants/024-dataset-version-add-ns-and-constraint.down.sql
+++ b/backend/resources/akvo/lumen/migrations/tenants/024-dataset-version-add-ns-and-constraint.down.sql
@@ -1,8 +1,8 @@
-ALTER TABLE history.dataset_version DROP COLUMN IF EXISTS "ns";
-ALTER TABLE public.dataset_version DROP COLUMN IF EXISTS "ns";
+ALTER TABLE history.dataset_version DROP COLUMN IF EXISTS "namespace";
+ALTER TABLE public.dataset_version DROP COLUMN IF EXISTS "namespace";
 
-ALTER TABLE dataset_version DROP CONSTRAINT IF EXISTS dataset_version_dataset_id_version_ns_key;
-DROP INDEX IF EXISTS dataset_version_dataset_id_version_ns_key;
+ALTER TABLE dataset_version DROP CONSTRAINT IF EXISTS dataset_version_dataset_id_version_namespace_key;
+DROP INDEX IF EXISTS dataset_version_dataset_id_version_namespace_key;
 
 CREATE UNIQUE INDEX dataset_version_dataset_id_version_columns_key
 ON dataset_version (dataset_id, version, md5(columns::text));

--- a/backend/resources/akvo/lumen/migrations/tenants/024-dataset-version-add-ns-and-constraint.down.sql
+++ b/backend/resources/akvo/lumen/migrations/tenants/024-dataset-version-add-ns-and-constraint.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE history.dataset_version DROP COLUMN IF EXISTS "ns";
+ALTER TABLE public.dataset_version DROP COLUMN IF EXISTS "ns";
+
+ALTER TABLE dataset_version DROP CONSTRAINT IF EXISTS dataset_version_dataset_id_version_ns_key;
+DROP INDEX IF EXISTS dataset_version_dataset_id_version_ns_key;
+
+CREATE UNIQUE INDEX dataset_version_dataset_id_version_columns_key
+ON dataset_version (dataset_id, version, md5(columns::text));

--- a/backend/resources/akvo/lumen/migrations/tenants/024-dataset-version-add-ns-and-constraint.up.sql
+++ b/backend/resources/akvo/lumen/migrations/tenants/024-dataset-version-add-ns-and-constraint.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.dataset_version ADD COLUMN "ns" varchar(100) DEFAULT 'main';
+ALTER TABLE history.dataset_version ADD COLUMN "ns" varchar(100) DEFAULT 'main';
+
+ALTER TABLE dataset_version DROP CONSTRAINT IF EXISTS dataset_version_dataset_id_version_columns_key;
+DROP INDEX IF EXISTS dataset_version_dataset_id_version_columns_key;
+
+CREATE UNIQUE INDEX dataset_version_dataset_id_version_ns_key
+ON dataset_version (dataset_id, version, ns);

--- a/backend/resources/akvo/lumen/migrations/tenants/024-dataset-version-add-ns-and-constraint.up.sql
+++ b/backend/resources/akvo/lumen/migrations/tenants/024-dataset-version-add-ns-and-constraint.up.sql
@@ -1,8 +1,8 @@
-ALTER TABLE public.dataset_version ADD COLUMN "ns" varchar(100) DEFAULT 'main';
-ALTER TABLE history.dataset_version ADD COLUMN "ns" varchar(100) DEFAULT 'main';
+ALTER TABLE public.dataset_version ADD COLUMN "namespace" varchar(100) DEFAULT 'main';
+ALTER TABLE history.dataset_version ADD COLUMN "namespace" varchar(100) DEFAULT 'main';
 
 ALTER TABLE dataset_version DROP CONSTRAINT IF EXISTS dataset_version_dataset_id_version_columns_key;
 DROP INDEX IF EXISTS dataset_version_dataset_id_version_columns_key;
 
-CREATE UNIQUE INDEX dataset_version_dataset_id_version_ns_key
-ON dataset_version (dataset_id, version, ns);
+CREATE UNIQUE INDEX dataset_version_dataset_id_version_namespace_key
+ON dataset_version (dataset_id, version, namespace);


### PR DESCRIPTION
So far dataset_version identity is based on `dataset-id` and `version``

but with RQG approach we'll have `N` dataset_version for each dataset 

`namespace` column is added to identity together with `dataset-id` and `version`

This PR changes the `columns` value as identity prop and proposes `namespace` thinking in backwards compatibility and to don't need querying the `columns` jsonb value to derive which "data-group" is related with, in other words it should simplify the sql query and domain logic 

By default this column will have `main` as default value

- [ ] **Update release notes if necessary**
