### PR TITLE
[#2127] Adapt sql dataset_version queries to main ns column value

### DIFF
--- a/backend/src/akvo/lumen/db/dataset.clj
+++ b/backend/src/akvo/lumen/db/dataset.clj
@@ -2,3 +2,7 @@
   (:require [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")
+
+
+(defn all-datasets [conn]
+  (db-all-datasets conn {:ns "main"}))

--- a/backend/src/akvo/lumen/db/dataset.clj
+++ b/backend/src/akvo/lumen/db/dataset.clj
@@ -10,3 +10,6 @@
 
 (defn dataset-by-id [conn opts]
   (db-dataset-by-id conn (merge defaults opts)))
+
+(defn table-name-and-columns-by-dataset-id [conn opts]
+  (db-table-name-and-columns-by-dataset-id conn (merge defaults opts)))

--- a/backend/src/akvo/lumen/db/dataset.clj
+++ b/backend/src/akvo/lumen/db/dataset.clj
@@ -20,3 +20,5 @@
 (defn imported-dataset-columns-by-dataset-id [conn opts]
   (db-imported-dataset-columns-by-dataset-id conn (merge defaults opts)))
 
+(defn data-source-by-dataset-id [conn opts]
+  (db-data-source-by-dataset-id conn (merge defaults opts)))

--- a/backend/src/akvo/lumen/db/dataset.clj
+++ b/backend/src/akvo/lumen/db/dataset.clj
@@ -1,24 +1,23 @@
 (ns akvo.lumen.db.dataset
-  (:require [hugsql.core :as hugsql]))
+  (:require [akvo.lumen.db.dataset-version :as dv]
+            [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")
 
-(def defaults {:ns "main"})
-
 (defn all-datasets [conn]
-  (db-all-datasets conn defaults))
+  (db-all-datasets conn dv/defaults))
 
 (defn dataset-by-id [conn opts]
-  (db-dataset-by-id conn (merge defaults opts)))
+  (db-dataset-by-id conn (merge dv/defaults opts)))
 
 (defn table-name-and-columns-by-dataset-id [conn opts]
-  (db-table-name-and-columns-by-dataset-id conn (merge defaults opts)))
+  (db-table-name-and-columns-by-dataset-id conn (merge dv/defaults opts)))
 
 (defn table-name-by-dataset-id [conn opts]
-  (db-table-name-by-dataset-id conn (merge defaults opts)))
+  (db-table-name-by-dataset-id conn (merge dv/defaults opts)))
 
 (defn imported-dataset-columns-by-dataset-id [conn opts]
-  (db-imported-dataset-columns-by-dataset-id conn (merge defaults opts)))
+  (db-imported-dataset-columns-by-dataset-id conn (merge dv/defaults opts)))
 
 (defn data-source-by-dataset-id [conn opts]
-  (db-data-source-by-dataset-id conn (merge defaults opts)))
+  (db-data-source-by-dataset-id conn (merge dv/defaults opts)))

--- a/backend/src/akvo/lumen/db/dataset.clj
+++ b/backend/src/akvo/lumen/db/dataset.clj
@@ -13,3 +13,7 @@
 
 (defn table-name-and-columns-by-dataset-id [conn opts]
   (db-table-name-and-columns-by-dataset-id conn (merge defaults opts)))
+
+(defn table-name-by-dataset-id [conn opts]
+  (db-table-name-by-dataset-id conn (merge defaults opts))
+  )

--- a/backend/src/akvo/lumen/db/dataset.clj
+++ b/backend/src/akvo/lumen/db/dataset.clj
@@ -3,6 +3,10 @@
 
 (hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")
 
+(def defaults {:ns "main"})
 
 (defn all-datasets [conn]
-  (db-all-datasets conn {:ns "main"}))
+  (db-all-datasets conn defaults))
+
+(defn dataset-by-id [conn opts]
+  (db-dataset-by-id conn (merge defaults opts)))

--- a/backend/src/akvo/lumen/db/dataset.clj
+++ b/backend/src/akvo/lumen/db/dataset.clj
@@ -15,5 +15,8 @@
   (db-table-name-and-columns-by-dataset-id conn (merge defaults opts)))
 
 (defn table-name-by-dataset-id [conn opts]
-  (db-table-name-by-dataset-id conn (merge defaults opts))
-  )
+  (db-table-name-by-dataset-id conn (merge defaults opts)))
+
+(defn imported-dataset-columns-by-dataset-id [conn opts]
+  (db-imported-dataset-columns-by-dataset-id conn (merge defaults opts)))
+

--- a/backend/src/akvo/lumen/db/dataset_version.clj
+++ b/backend/src/akvo/lumen/db/dataset_version.clj
@@ -3,7 +3,7 @@
 
 (hugsql/def-db-fns "akvo/lumen/lib/dataset_version.sql")
 
-(def defaults {:ns "main"})
+(def defaults {:namespace "main"})
 
 (defn new-dataset-version [conn opts]
   (db-new-dataset-version conn (merge defaults opts)))

--- a/backend/src/akvo/lumen/db/dataset_version.clj
+++ b/backend/src/akvo/lumen/db/dataset_version.clj
@@ -2,3 +2,8 @@
   (:require [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/dataset_version.sql")
+
+(def defaults {:ns "main"})
+
+(defn new-dataset-version [conn opts]
+  (db-new-dataset-version conn (merge defaults opts)))

--- a/backend/src/akvo/lumen/db/transformation.clj
+++ b/backend/src/akvo/lumen/db/transformation.clj
@@ -12,3 +12,6 @@
 
 (defn latest-dataset-versions-by-dataset-ids [conn opts]
   (db-latest-dataset-versions-by-dataset-ids conn (merge dv/defaults opts)))
+
+(defn update-dataset-version [conn opts]
+  (db-update-dataset-version conn (merge dv/defaults opts)))

--- a/backend/src/akvo/lumen/db/transformation.clj
+++ b/backend/src/akvo/lumen/db/transformation.clj
@@ -15,3 +15,6 @@
 
 (defn update-dataset-version [conn opts]
   (db-update-dataset-version conn (merge dv/defaults opts)))
+
+(defn initial-dataset-version-to-update-by-dataset-id [conn opts]
+  (db-initial-dataset-version-to-update-by-dataset-id conn (merge dv/defaults opts)))

--- a/backend/src/akvo/lumen/db/transformation.clj
+++ b/backend/src/akvo/lumen/db/transformation.clj
@@ -1,4 +1,8 @@
 (ns akvo.lumen.db.transformation
-  (:require [hugsql.core :as hugsql]))
+  (:require [akvo.lumen.db.dataset-version :as dv]
+            [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/transformation.sql")
+
+(defn latest-dataset-version-by-dataset-id [conn opts]
+  (db-latest-dataset-version-by-dataset-id conn (merge dv/defaults opts)))

--- a/backend/src/akvo/lumen/db/transformation.clj
+++ b/backend/src/akvo/lumen/db/transformation.clj
@@ -7,8 +7,8 @@
 (defn latest-dataset-version-by-dataset-id [conn opts]
   (db-latest-dataset-version-by-dataset-id conn (merge dv/defaults opts)))
 
-(defn latest-dataset-versions [conn opts]
-  (db-latest-dataset-versions conn (merge dv/defaults opts)))
+(defn latest-dataset-versions [conn]
+  (db-latest-dataset-versions conn dv/defaults))
 
 (defn latest-dataset-versions-by-dataset-ids [conn opts]
   (db-latest-dataset-versions-by-dataset-ids conn (merge dv/defaults opts)))

--- a/backend/src/akvo/lumen/db/transformation.clj
+++ b/backend/src/akvo/lumen/db/transformation.clj
@@ -6,3 +6,9 @@
 
 (defn latest-dataset-version-by-dataset-id [conn opts]
   (db-latest-dataset-version-by-dataset-id conn (merge dv/defaults opts)))
+
+(defn latest-dataset-versions [conn opts]
+  (db-latest-dataset-versions conn (merge dv/defaults opts)))
+
+(defn latest-dataset-versions-by-dataset-ids [conn opts]
+  (db-latest-dataset-versions-by-dataset-ids conn (merge dv/defaults opts)))

--- a/backend/src/akvo/lumen/db/transformation.clj
+++ b/backend/src/akvo/lumen/db/transformation.clj
@@ -18,3 +18,7 @@
 
 (defn initial-dataset-version-to-update-by-dataset-id [conn opts]
   (db-initial-dataset-version-to-update-by-dataset-id conn (merge dv/defaults opts)))
+
+(defn dataset-version-by-dataset-id [conn opts]
+  (db-dataset-version-by-dataset-id conn (merge dv/defaults opts)))
+

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -61,13 +61,14 @@ SELECT * from dataset WHERE id IN (:v*:ids);
 -- :doc update dataset meta
 UPDATE dataset SET title = :title WHERE id = :id;
 
--- :name dataset-by-id :? :1
+-- :name db-dataset-by-id :? :1
 WITH
 source_data AS (
 SELECT (spec->'source')::jsonb - 'refreshToken' as source
   FROM data_source, dataset_version, job_execution, dataset
  WHERE dataset_version.dataset_id = dataset.id
    AND dataset_version.version = 1
+   AND dataset_version.ns = :ns
    AND dataset_version.job_execution_id = job_execution.id
    AND job_execution.data_source_id = data_source.id
    AND dataset_version.dataset_id=:id

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -1,4 +1,4 @@
--- :name all-datasets :? :*
+-- :name db-all-datasets :? :*
 -- :doc All datasets. Including pending datasets and datasets that failed to import
 WITH
 source_data AS (
@@ -6,6 +6,7 @@ source_data AS (
    FROM data_source, dataset_version, job_execution, dataset
   WHERE dataset_version.dataset_id = dataset.id
     AND dataset_version.version = 1
+    AND dataset_version.ns = :ns
     AND dataset_version.job_execution_id = job_execution.id
     AND job_execution.data_source_id = data_source.id
 ),

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -101,14 +101,15 @@ SELECT dataset_version.table_name AS "table-name",
                   FROM dataset_version
                  WHERE dataset_version.dataset_id=:id);
 
--- :name table-name-by-dataset-id :? :1
+-- :name db-table-name-by-dataset-id :? :1
 SELECT dataset_version.table_name AS "table-name"
   FROM dataset_version, dataset
  WHERE dataset_version.dataset_id=:id
    AND dataset.id=dataset_version.dataset_id
+   AND dataset_version.ns = :ns
    AND version=(SELECT max(version)
-                  FROM dataset_version
-                 WHERE dataset_version.dataset_id=:id);
+                       FROM dataset_version
+                       WHERE dataset_version.dataset_id=:id);
 
 -- :name imported-dataset-columns-by-dataset-id :? :1
 SELECT dataset_version.columns

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -118,10 +118,11 @@ SELECT dataset_version.columns
    AND ns = :ns
    AND version = 1;
 
--- :name data-source-by-dataset-id :? :1
+-- :name db-data-source-by-dataset-id :? :1
 SELECT data_source.*
   FROM data_source, dataset_version, job_execution
  WHERE dataset_version.dataset_id = :dataset-id
+   AND dataset_version.ns = :ns
    AND dataset_version.job_execution_id = job_execution.id
    AND job_execution.type = 'IMPORT'
    AND job_execution.status = 'OK'

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -111,10 +111,11 @@ SELECT dataset_version.table_name AS "table-name"
                        FROM dataset_version
                        WHERE dataset_version.dataset_id=:id);
 
--- :name imported-dataset-columns-by-dataset-id :? :1
+-- :name db-imported-dataset-columns-by-dataset-id :? :1
 SELECT dataset_version.columns
   FROM dataset_version
  WHERE dataset_id = :dataset-id
+   AND ns = :ns
    AND version = 1;
 
 -- :name data-source-by-dataset-id :? :1

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -6,7 +6,7 @@ source_data AS (
    FROM data_source, dataset_version, job_execution, dataset
   WHERE dataset_version.dataset_id = dataset.id
     AND dataset_version.version = 1
-    AND dataset_version.ns = :ns
+    AND dataset_version.namespace = :namespace
     AND dataset_version.job_execution_id = job_execution.id
     AND job_execution.data_source_id = data_source.id
 ),
@@ -68,7 +68,7 @@ SELECT (spec->'source')::jsonb - 'refreshToken' as source
   FROM data_source, dataset_version, job_execution, dataset
  WHERE dataset_version.dataset_id = dataset.id
    AND dataset_version.version = 1
-   AND dataset_version.ns = :ns
+   AND dataset_version.namespace = :namespace
    AND dataset_version.job_execution_id = job_execution.id
    AND job_execution.data_source_id = data_source.id
    AND dataset_version.dataset_id=:id
@@ -96,7 +96,7 @@ SELECT dataset_version.table_name AS "table-name",
   FROM dataset_version, dataset
  WHERE dataset_version.dataset_id=:id
    AND dataset.id=dataset_version.dataset_id
-   AND dataset_version.ns = :ns
+   AND dataset_version.namespace = :namespace
    AND version=(SELECT max(version)
                   FROM dataset_version
                  WHERE dataset_version.dataset_id=:id);
@@ -106,7 +106,7 @@ SELECT dataset_version.table_name AS "table-name"
   FROM dataset_version, dataset
  WHERE dataset_version.dataset_id=:id
    AND dataset.id=dataset_version.dataset_id
-   AND dataset_version.ns = :ns
+   AND dataset_version.namespace = :namespace
    AND version=(SELECT max(version)
                        FROM dataset_version
                        WHERE dataset_version.dataset_id=:id);
@@ -115,14 +115,14 @@ SELECT dataset_version.table_name AS "table-name"
 SELECT dataset_version.columns
   FROM dataset_version
  WHERE dataset_id = :dataset-id
-   AND ns = :ns
+   AND namespace = :namespace
    AND version = 1;
 
 -- :name db-data-source-by-dataset-id :? :1
 SELECT data_source.*
   FROM data_source, dataset_version, job_execution
  WHERE dataset_version.dataset_id = :dataset-id
-   AND dataset_version.ns = :ns
+   AND dataset_version.namespace = :namespace
    AND dataset_version.job_execution_id = job_execution.id
    AND job_execution.type = 'IMPORT'
    AND job_execution.status = 'OK'

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -90,12 +90,13 @@ SELECT dataset_version.table_name AS "table-name",
                   FROM dataset_version
                  WHERE dataset_version.dataset_id=:id);
 
--- :name table-name-and-columns-by-dataset-id :? :1
+-- :name db-table-name-and-columns-by-dataset-id :? :1
 SELECT dataset_version.table_name AS "table-name",
        dataset_version.columns
   FROM dataset_version, dataset
  WHERE dataset_version.dataset_id=:id
    AND dataset.id=dataset_version.dataset_id
+   AND dataset_version.ns = :ns
    AND version=(SELECT max(version)
                   FROM dataset_version
                  WHERE dataset_version.dataset_id=:id);

--- a/backend/src/akvo/lumen/lib/dataset_version.sql
+++ b/backend/src/akvo/lumen/lib/dataset_version.sql
@@ -1,7 +1,7 @@
--- :name new-dataset-version :! :n
+-- :name db-new-dataset-version :! :n
 -- :doc Inserts a new dataset version
 INSERT INTO dataset_version (id, dataset_id, job_execution_id, version,
                              table_name, imported_table_name,
-                             transformations, columns)
+                             transformations, columns, ns)
 VALUES (:id, :dataset-id, :job-execution-id, :version,
-        :table-name, :imported-table-name, :transformations, :columns)
+        :table-name, :imported-table-name, :transformations, :columns, :ns)

--- a/backend/src/akvo/lumen/lib/dataset_version.sql
+++ b/backend/src/akvo/lumen/lib/dataset_version.sql
@@ -2,6 +2,6 @@
 -- :doc Inserts a new dataset version
 INSERT INTO dataset_version (id, dataset_id, job_execution_id, version,
                              table_name, imported_table_name,
-                             transformations, columns, ns)
+                             transformations, columns, namespace)
 VALUES (:id, :dataset-id, :job-execution-id, :version,
-        :table-name, :imported-table-name, :transformations, :columns, :ns)
+        :table-name, :imported-table-name, :transformations, :columns, :namespace)

--- a/backend/src/akvo/lumen/lib/transformation.sql
+++ b/backend/src/akvo/lumen/lib/transformation.sql
@@ -23,7 +23,7 @@ SELECT id FROM dataset WHERE id = :id
 SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations
   FROM dataset_version
  WHERE dataset_id = :dataset-id
-   AND ns = :ns
+   AND namespace = :namespace
    AND version = (SELECT MAX(v.version)
                     FROM dataset_version v
                    WHERE v.dataset_id = :dataset-id);
@@ -33,7 +33,7 @@ SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-na
 select DISTINCT ON (dataset_id) dataset_id, id, version, transformations, columns
 FROM dataset_version
 WHERE dataset_id IN (:v*:dataset-ids)
-AND dataset_version.ns = :ns
+AND dataset_version.namespace = :namespace
 order by dataset_id, version desc;
 
 -- :name db-latest-dataset-versions :? :*
@@ -41,7 +41,7 @@ order by dataset_id, version desc;
 select DISTINCT ON (dataset_id) dataset_id, dataset_version.id as id, version, title, transformations
 FROM dataset_version, dataset
 where dataset.id=dataset_id
-AND dataset_version.ns = :ns
+AND dataset_version.namespace = :namespace
 order by dataset_id, version desc;
 
 -- :name db-update-dataset-version :! :n
@@ -49,13 +49,13 @@ order by dataset_id, version desc;
 UPDATE dataset_version SET columns= :columns,  transformations= :transformations
 where dataset_id= :dataset-id
 AND version= :version
-AND ns = :ns;
+AND namespace = :namespace;
 
 -- :name db-initial-dataset-version-to-update-by-dataset-id :? :1
 SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations
   FROM  dataset_version
   WHERE dataset_id= :dataset-id AND transformations='[]'
-  AND ns = :ns
+  AND namespace = :namespace
   ORDER BY version DESC LIMIT 1;
 
 -- :name db-dataset-version-by-dataset-id :? :1
@@ -63,7 +63,7 @@ SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-na
 SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations
   FROM dataset_version
  WHERE dataset_id = :dataset-id
-   AND ns = :ns
+   AND namespace = :namespace
    AND version = :version;
 
 -- :name clear-dataset-version-data-table :! :n

--- a/backend/src/akvo/lumen/lib/transformation.sql
+++ b/backend/src/akvo/lumen/lib/transformation.sql
@@ -44,10 +44,12 @@ where dataset.id=dataset_id
 AND dataset_version.ns = :ns
 order by dataset_id, version desc;
 
--- :name update-dataset-version :! :n
+-- :name db-update-dataset-version :! :n
 -- :doc Update dataset version
 UPDATE dataset_version SET columns= :columns,  transformations= :transformations
-where dataset_id= :dataset-id and version= :version;
+where dataset_id= :dataset-id
+AND version= :version
+AND ns = :ns;
 
 -- :name initial-dataset-version-to-update-by-dataset-id :? :1
 SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations

--- a/backend/src/akvo/lumen/lib/transformation.sql
+++ b/backend/src/akvo/lumen/lib/transformation.sql
@@ -28,18 +28,20 @@ SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-na
                     FROM dataset_version v
                    WHERE v.dataset_id = :dataset-id);
 
--- :name latest-dataset-versions-by-dataset-ids :? :*
--- :doc Returns the most recent dataset version for a given dataset id
+-- :name db-latest-dataset-versions-by-dataset-ids :? :*
+-- :doc Returns the most recent dataset version for a given dataset ids
 select DISTINCT ON (dataset_id) dataset_id, id, version, transformations, columns
 FROM dataset_version
 WHERE dataset_id IN (:v*:dataset-ids)
+AND dataset_version.ns = :ns
 order by dataset_id, version desc;
 
--- :name latest-dataset-versions :? :*
+-- :name db-latest-dataset-versions :? :*
 -- :doc Returns the most recent dataset version for a given dataset id
 select DISTINCT ON (dataset_id) dataset_id, dataset_version.id as id, version, title, transformations
 FROM dataset_version, dataset
 where dataset.id=dataset_id
+AND dataset_version.ns = :ns
 order by dataset_id, version desc;
 
 -- :name update-dataset-version :! :n

--- a/backend/src/akvo/lumen/lib/transformation.sql
+++ b/backend/src/akvo/lumen/lib/transformation.sql
@@ -58,11 +58,12 @@ SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-na
   AND ns = :ns
   ORDER BY version DESC LIMIT 1;
 
--- :name dataset-version-by-dataset-id :? :1
+-- :name db-dataset-version-by-dataset-id :? :1
 -- :doc Returns the most recent dataset version for a given dataset id
 SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations
   FROM dataset_version
  WHERE dataset_id = :dataset-id
+   AND ns = :ns
    AND version = :version;
 
 -- :name clear-dataset-version-data-table :! :n

--- a/backend/src/akvo/lumen/lib/transformation.sql
+++ b/backend/src/akvo/lumen/lib/transformation.sql
@@ -51,10 +51,11 @@ where dataset_id= :dataset-id
 AND version= :version
 AND ns = :ns;
 
--- :name initial-dataset-version-to-update-by-dataset-id :? :1
+-- :name db-initial-dataset-version-to-update-by-dataset-id :? :1
 SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations
   FROM  dataset_version
   WHERE dataset_id= :dataset-id AND transformations='[]'
+  AND ns = :ns
   ORDER BY version DESC LIMIT 1;
 
 -- :name dataset-version-by-dataset-id :? :1

--- a/backend/src/akvo/lumen/lib/transformation.sql
+++ b/backend/src/akvo/lumen/lib/transformation.sql
@@ -18,11 +18,12 @@ UPDATE dataset
 -- :doc Checks the existence of a dataset for a given id
 SELECT id FROM dataset WHERE id = :id
 
--- :name latest-dataset-version-by-dataset-id :? :1
+-- :name db-latest-dataset-version-by-dataset-id :? :1
 -- :doc Returns the most recent dataset version for a given dataset id
 SELECT id, table_name AS "table-name", imported_table_name AS "imported-table-name", columns, version, transformations
   FROM dataset_version
  WHERE dataset_id = :dataset-id
+   AND ns = :ns
    AND version = (SELECT MAX(v.version)
                     FROM dataset_version v
                    WHERE v.dataset_id = :dataset-id);

--- a/backend/src/akvo/lumen/lib/visualisation/map_metadata.clj
+++ b/backend/src/akvo/lumen/lib/visualisation/map_metadata.clj
@@ -108,12 +108,12 @@
                               first :st_extent)]
       (parse-box st-extent))))
 
-(defn get-column-titles [tenant-conn selector-name selector-value]
-  (let [sql-str "SELECT columns, modified FROM dataset_version WHERE %s='%s' ORDER BY version DESC LIMIT 1"]
+(defn get-column-titles [tenant-conn selector-name selector-value dataset-version-ns]
+  (let [sql-str "SELECT columns, modified FROM dataset_version WHERE %s='%s' AND ns='%s' ORDER BY version DESC LIMIT 1"]
     (map (fn [{:strs [columnName title]}]
            {:columnName columnName
             :title title})
-         (-> (jdbc/query tenant-conn (format sql-str selector-name selector-value))
+         (-> (jdbc/query tenant-conn (format sql-str selector-name selector-value dataset-version-ns))
              first
              :columns))))
 
@@ -125,7 +125,7 @@
       :title))
 
 (defn point-metadata [tenant-conn table-name layer where-clause]
-  (let [column-titles (get-column-titles tenant-conn "table_name" table-name)]
+  (let [column-titles (get-column-titles tenant-conn "table_name" table-name "main")]
     {:boundingBox (bounds tenant-conn table-name layer where-clause)
      :pointColorMapping (point-color-mapping tenant-conn table-name layer where-clause)
      :availableColors palette
@@ -133,10 +133,9 @@
      :columnTitles column-titles}))
 
 (defn shape-aggregation-metadata [tenant-conn table-name layer where-clause]
-  (let [column-titles (get-column-titles tenant-conn "table_name" table-name)
+  (let [column-titles (get-column-titles tenant-conn "table_name" table-name "main")
         column-title-for-name (get-column-title-for-name
-                               (get-column-titles tenant-conn "dataset_id"
-                                                  (:aggregationDataset layer))
+                               (get-column-titles tenant-conn "dataset_id" (:aggregationDataset layer) "main")
                                (:aggregationColumn layer))
         shape-color-mapping-title (format "%s (%s)" column-title-for-name
                                           (:aggregationMethod layer))]
@@ -147,7 +146,7 @@
      :shapeColorMappingTitle shape-color-mapping-title}))
 
 (defn shape-metadata [tenant-conn table-name layer where-clause]
-  (let [column-titles (get-column-titles tenant-conn "table_name" table-name)]
+  (let [column-titles (get-column-titles tenant-conn "table_name" table-name "main")]
     {:columnTitles column-titles
      :boundingBox (bounds tenant-conn table-name layer where-clause)}))
 

--- a/backend/src/akvo/lumen/lib/visualisation/map_metadata.clj
+++ b/backend/src/akvo/lumen/lib/visualisation/map_metadata.clj
@@ -109,7 +109,7 @@
       (parse-box st-extent))))
 
 (defn get-column-titles [tenant-conn selector-name selector-value dataset-version-ns]
-  (let [sql-str "SELECT columns, modified FROM dataset_version WHERE %s='%s' AND ns='%s' ORDER BY version DESC LIMIT 1"]
+  (let [sql-str "SELECT columns, modified FROM dataset_version WHERE %s='%s' AND namespace='%s' ORDER BY version DESC LIMIT 1"]
     (map (fn [{:strs [columnName title]}]
            {:columnName columnName
             :title title})

--- a/backend/test/akvo/lumen/db/transformation_test.clj
+++ b/backend/test/akvo/lumen/db/transformation_test.clj
@@ -1,0 +1,9 @@
+(ns akvo.lumen.db.transformation-test
+  (:require [akvo.lumen.db.dataset-version :as dv]
+            [hugsql.core :as hugsql]))
+
+(hugsql/def-db-fns "akvo/lumen/lib/transformation_test.sql")
+
+(defn get-table-name [conn opts]
+  (db-get-table-name conn (merge dv/defaults opts)))
+

--- a/backend/test/akvo/lumen/endpoint/share_test.clj
+++ b/backend/test/akvo/lumen/endpoint/share_test.clj
@@ -20,7 +20,6 @@
 ;;; Helpers
 ;;;
 
-(hugsql/def-db-fns "akvo/lumen/lib/dataset_version.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/job-execution.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/visualisation.sql")
 

--- a/backend/test/akvo/lumen/endpoint/share_test.clj
+++ b/backend/test/akvo/lumen/endpoint/share_test.clj
@@ -5,6 +5,7 @@
                                          tenant-conn-fixture
                                          system-fixture]]
             [akvo.lumen.lib.dashboard :as dashboard]
+            [akvo.lumen.db.dataset :as db.dataset]
             [akvo.lumen.lib.dataset :as ds]
             [akvo.lumen.lib.share :as share]
             [akvo.lumen.test-utils :as tu]
@@ -19,7 +20,6 @@
 ;;; Helpers
 ;;;
 
-(hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/dataset_version.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/job-execution.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/visualisation.sql")

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
@@ -10,6 +10,8 @@
             [akvo.lumen.db.transformation :refer [latest-dataset-version-by-dataset-id]]
             [akvo.lumen.specs.import :as i-c]
             [akvo.lumen.lib.import.clj-data-importer :as i]
+            [akvo.lumen.db.transformation :refer [latest-dataset-version-by-dataset-id dataset-version-by-dataset-id]]
+            [akvo.lumen.db.transformation-test :refer [get-data]]
             [akvo.lumen.test-utils :refer [import-file update-file] :as tu]
             [akvo.lumen.utils.logging-config :refer [with-no-logs]]
             [clojure.string :as string]
@@ -18,8 +20,6 @@
   (:import [java.util.concurrent ExecutionException]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/job-execution.sql")
-(hugsql/def-db-fns "akvo/lumen/lib/transformation_test.sql")
-(hugsql/def-db-fns "akvo/lumen/lib/transformation.sql")
 
 (use-fixtures :once system-fixture tenant-conn-fixture error-tracker-fixture tu/spec-instrument)
 

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
@@ -7,6 +7,7 @@
                                          *error-tracker*
                                          error-tracker-fixture]]
             [clojure.tools.logging :as log]
+            [akvo.lumen.db.transformation :refer [latest-dataset-version-by-dataset-id]]
             [akvo.lumen.specs.import :as i-c]
             [akvo.lumen.lib.import.clj-data-importer :as i]
             [akvo.lumen.test-utils :refer [import-file update-file] :as tu]

--- a/backend/test/akvo/lumen/lib/import/csv_test.clj
+++ b/backend/test/akvo/lumen/lib/import/csv_test.clj
@@ -10,12 +10,13 @@
             [clojure.string :as string]
             [akvo.lumen.test-utils :as tu]
             [akvo.lumen.lib.import.csv :as csv]
+            [akvo.lumen.db.transformation :refer [dataset-version-by-dataset-id]]
             [clojure.test :refer :all]
             [hugsql.core :as hugsql])
   (:import [java.util.concurrent ExecutionException]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/job-execution.sql")
-(hugsql/def-db-fns "akvo/lumen/lib/transformation.sql")
+
 
 
 (use-fixtures :once system-fixture tenant-conn-fixture error-tracker-fixture tu/spec-instrument)

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -12,6 +12,9 @@
             [akvo.lumen.lib :as lib]
             [akvo.lumen.db.transformation :refer [latest-dataset-version-by-dataset-id]]
             [akvo.lumen.lib.multiple-column :as multiple-column]
+            [akvo.lumen.db.transformation-test :refer [get-data get-val-from-table get-row-count table-exists]]
+            [akvo.lumen.db.transformation :refer [latest-dataset-version-by-dataset-id dataset-version-by-dataset-id]]
+
             [akvo.lumen.lib.transformation :as transformation]
             [akvo.lumen.lib.transformation.derive-category :as derive-category]
             [akvo.lumen.lib.transformation.engine :as engine]
@@ -69,7 +72,6 @@
 (use-fixtures :once tu/spec-instrument caddisfly-fixture system-fixture tenant-conn-fixture error-tracker-fixture summarise-transformation-logs-fixture)
 
 (hugsql/def-db-fns "akvo/lumen/lib/job-execution.sql")
-(hugsql/def-db-fns "akvo/lumen/lib/transformation_test.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/transformation.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/visualisation.sql")
 

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -10,6 +10,7 @@
                                          *caddisfly*
                                          caddisfly-fixture]]
             [akvo.lumen.lib :as lib]
+            [akvo.lumen.db.transformation :refer [latest-dataset-version-by-dataset-id]]
             [akvo.lumen.lib.multiple-column :as multiple-column]
             [akvo.lumen.lib.transformation :as transformation]
             [akvo.lumen.lib.transformation.derive-category :as derive-category]

--- a/backend/test/akvo/lumen/lib/transformation_test.sql
+++ b/backend/test/akvo/lumen/lib/transformation_test.sql
@@ -1,7 +1,8 @@
--- :name get-table-name :? :1
+-- :name db-get-table-name :? :1
 SELECT table_name AS "table-name"
   FROM dataset_version
  WHERE job_execution_id = :job-id
+ AND ns = :ns
 
 -- :name get-val-from-table :? :1
 SELECT :i:column-name

--- a/backend/test/akvo/lumen/lib/transformation_test.sql
+++ b/backend/test/akvo/lumen/lib/transformation_test.sql
@@ -2,7 +2,7 @@
 SELECT table_name AS "table-name"
   FROM dataset_version
  WHERE job_execution_id = :job-id
- AND ns = :ns
+ AND namespace = :namespace
 
 -- :name get-val-from-table :? :1
 SELECT :i:column-name

--- a/backend/test/akvo/lumen/test_utils.clj
+++ b/backend/test/akvo/lumen/test_utils.clj
@@ -4,6 +4,7 @@
             [akvo.lumen.lib.auth :as l.auth]
             [akvo.lumen.lib.aes :as aes]
             [akvo.lumen.lib.import :as import]
+            [akvo.lumen.db.dataset :as db.dataset]
             [akvo.lumen.config :as config]
             [akvo.lumen.lib.import.clj-data-importer]
             [akvo.lumen.lib.update :as update]
@@ -29,7 +30,6 @@
            [org.postgresql.util PSQLException]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/job-execution.sql")
-(hugsql/def-db-fns "akvo/lumen/lib/dataset.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/raster.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/visualisation.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/dashboard.sql")
@@ -174,7 +174,7 @@
           :as req}]
       (let [tenant-conn (p/connection tenant-manager tenant)]
         (handler (assoc req :auth-service
-                        (l.auth/new-auth-service {:auth-datasets       (map :id (all-datasets tenant-conn))
+                        (l.auth/new-auth-service {:auth-datasets       (map :id (db.dataset/all-datasets tenant-conn))
                                                   :auth-visualisations (mapv :id (all-visualisations tenant-conn))
                                                   :auth-dashboards     (mapv :id (all-dashboards tenant-conn))
                                                   :auth-collections    (mapv :id (all-collections tenant-conn))


### PR DESCRIPTION
Relates https://github.com/akvo/akvo-lumen/pull/2781

In relation to dataset or dataset-version, remove direct sql references and use clj namespaces for it 

Use default `main` dataset_version.namespace value in updated queries 

- [ ] **Update release notes if necessary**
