### PR TITLE
[#2127] Normalise import data (processing one of multiple responses)

### DIFF
--- a/backend/src/akvo/lumen/lib/import.clj
+++ b/backend/src/akvo/lumen/lib/import.clj
@@ -75,7 +75,8 @@
                                                       (assoc import-config :environment (env/all conn)))]
           (let [columns (p/columns importer)]
             (postgres/create-dataset-table conn table-name columns)
-            (doseq [record (map postgres/coerce-to-sql (take common/rows-limit (p/records importer)))]
+            (doseq [record (map (comp postgres/coerce-to-sql common/extract-first-and-merge)
+                                (take common/rows-limit (p/records importer)))]
               (jdbc/insert! conn table-name record))
             (successful-execution conn job-execution-id  data-source-id table-name columns {:spec-name (get spec "name")
                                                                                             :spec-description (get spec "description" "")} claims)))

--- a/backend/src/akvo/lumen/lib/import/common.clj
+++ b/backend/src/akvo/lumen/lib/import/common.clj
@@ -57,4 +57,4 @@
        (group-by #(:ns (meta %)))
        vals
        (map first)
-       (reduce #(merge % %2) {})))
+       (reduce merge {})))

--- a/backend/src/akvo/lumen/lib/import/common.clj
+++ b/backend/src/akvo/lumen/lib/import/common.clj
@@ -49,3 +49,12 @@
                 {:multipleType (:multipleType q)
                  :multipleId (:multipleId q)})))))
        questions))
+
+(defn extract-first-and-merge
+  "extract every first group-responses into one `main` response"
+  [ns-responses]
+  (->> ns-responses
+       (group-by #(:ns (meta %)))
+       vals
+       (map first)
+       (reduce #(merge % %2) {})))

--- a/backend/src/akvo/lumen/lib/import/csv.clj
+++ b/backend/src/akvo/lumen/lib/import/csv.clj
@@ -66,11 +66,11 @@
 
 (defn data-records [column-spec rows]
   (for [row rows]
-    (apply merge
-           (map (fn [{:keys [id type]} value]
-                  {id (transform-value value type)})
-                column-spec
-                row))))
+    [(apply merge
+             (map (fn [{:keys [id type]} value]
+                    {id (transform-value value type)})
+                  column-spec
+                  row))]))
 
 (defn get-column-count [data]
   (let [counts (distinct (map count data))]

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -102,7 +102,7 @@
 ;; {question-group-id -> [{question-id -> response}]
 ;; to
 ;; {question-id -> first-response}
-(defn- question-responses-base [questions responses]
+(defn- question-responses-base [responses]
   (->> responses
        vals
        (map first)
@@ -120,10 +120,10 @@
   (let [dict (let [[rep-col non-rep-col] (split-with :repeatable groups)]
                {:rqg-ns (set (map :id rep-col)) :main-ns (set (map :id non-rep-col))})]
     (into [(with-meta
-             (question-responses-base questions (select-keys responses (:main-ns dict)))
+             (question-responses-base (select-keys responses (:main-ns dict)))
              {:ns "main"})]
           (mapv #(with-meta
-                   (question-responses-base questions {% (get responses %)})
+                   (question-responses-base {% (get responses %)})
                    {:ns %})
                 (:rqg-ns dict)))))
 

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -1,6 +1,7 @@
 (ns akvo.lumen.lib.import.flow-common
   (:require
    [akvo.commons.psql-util :as pg]
+   [akvo.lumen.util :as u]
    [akvo.lumen.lib.import.common :as common]
    [akvo.lumen.http.client :as http.client]
    [cheshire.core :as json]
@@ -117,7 +118,7 @@
 (defn question-responses
   "Returns a list of maps with meta from question-id to the first response iteration"
   [groups questions responses]
-  (let [dict (let [[rep-col non-rep-col] (split-with :repeatable groups)]
+  (let [dict (let [[rep-col non-rep-col] (u/split-with-non-stop :repeatable groups)]
                {:rqg-ns (set (map :id rep-col)) :main-ns (set (map :id non-rep-col))})]
     (into [(with-meta
              (question-responses-base (select-keys responses (:main-ns dict)))

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -117,7 +117,7 @@
 ;;          {:ns xxx})]
 (defn question-responses
   "Returns a list of maps with meta from question-id to the first response iteration"
-  [groups questions responses]
+  [groups responses]
   (let [dict (let [[rep-col non-rep-col] (u/split-with-non-stop :repeatable groups)]
                {:rqg-ns (set (map :id rep-col)) :main-ns (set (map :id non-rep-col))})]
     (into [(with-meta

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -84,15 +84,17 @@
 (defn response-data
   [form responses]
   (let [questions (flow-common/questions form)
-        responses (flow-common/question-responses questions responses)]
-    (reduce (fn [response-data {:keys [type id]}]
-              (if-let [response (get responses id)]
-                (assoc response-data
-                       (format "c%s" id)
-                       (render-response type response))
-                response-data))
-            {}
-            questions)))
+        responses-col (flow-common/question-responses (:questionGroups form) questions responses)]
+    (mapv #(with-meta
+             (reduce (fn [response-data {:keys [type id]}]
+                       (if-let [response (get % id)]
+                         (assoc response-data
+                                (format "c%s" id)
+                                (render-response type response))
+                         response-data))
+                     {}
+                     questions) (meta %))
+          responses-col)))
 
 (defn form-data
   "Returns a lazy sequence of form data, ready to be inserted as a lumen dataset"
@@ -102,8 +104,10 @@
     (map (fn [form-instance]
            (let [data-point-id (get form-instance "dataPointId")
                  data-point (get data-points data-point-id)]
-             (merge (response-data form (get form-instance "responses"))
-                    (flow-common/common-records form-instance data-point)
-                    {:latitude (get-in data-points [data-point-id "latitude"])
-                     :longitude (get-in data-points [data-point-id "longitude"])})))
+             (let [[main-group & more-groups] (response-data form (get form-instance "responses"))]
+               (into [(merge main-group
+                             (flow-common/common-records form-instance data-point)
+                             {:latitude (get-in data-points [data-point-id "latitude"])
+                              :longitude (get-in data-points [data-point-id "longitude"])})]
+                     more-groups))))
          (flow-common/form-instances headers-fn form))))

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -84,7 +84,7 @@
 (defn response-data
   [form responses]
   (let [questions (flow-common/questions form)
-        responses-col (flow-common/question-responses (:questionGroups form) questions responses)]
+        responses-col (flow-common/question-responses (:questionGroups form) responses)]
     (mapv #(with-meta
              (reduce (fn [response-data {:keys [type id]}]
                        (if-let [response (get % id)]

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -68,15 +68,17 @@
 (defn response-data
   [form responses]
   (let [questions (flow-questions form)
-        responses (flow-common/question-responses questions responses)]
-    (reduce (fn [response-data {:keys [type id repeatable derived-id derived-fn]}]
-              (if-let [response ((or derived-fn identity) (get responses (or derived-id id)))]
-                (assoc response-data
-                       (format "c%s" id)
-                       (render-response type response))
-                response-data))
-            {}
-            questions)))
+        responses-col (flow-common/question-responses (:questionGroups form) questions responses)]
+    (mapv #(with-meta
+             (reduce (fn [response-data {:keys [type id derived-id derived-fn]}]
+                       (if-let [response ((or derived-fn identity) (get % (or derived-id id)))]
+                         (assoc response-data
+                                (format "c%s" id)
+                                (render-response type response))
+                         response-data))
+                     {}
+                     questions) (meta %))
+          responses-col)))
 
 (defn form-data
   "First pulls all data-points belonging to the survey. Then map over all form
@@ -88,9 +90,11 @@
     (map (fn [form-instance]
            (let [data-point-id (get form-instance "dataPointId")]
              (if-let [data-point (get data-points data-point-id)]
-               (merge (response-data form (get form-instance "responses"))
-                      (flow-common/common-records form-instance data-point)
-                      {:device_id (get form-instance "deviceIdentifier")})
+               (let [[main-group & more-groups] (response-data form (get form-instance "responses"))]
+                 (into [(merge main-group
+                                (flow-common/common-records form-instance data-point)
+                                {:device_id (get form-instance "deviceIdentifier")})]
+                       more-groups))
                (throw (ex-info "Flow form (dataPointId) referenced data point not in survey"
                                {:form-instance-id (get form-instance "id")
                                 :data-point-id data-point-id

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -68,7 +68,7 @@
 (defn response-data
   [form responses]
   (let [questions (flow-questions form)
-        responses-col (flow-common/question-responses (:questionGroups form) questions responses)]
+        responses-col (flow-common/question-responses (:questionGroups form) responses)]
     (mapv #(with-meta
              (reduce (fn [response-data {:keys [type id derived-id derived-fn]}]
                        (if-let [response ((or derived-fn identity) (get % (or derived-id id)))]

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -139,7 +139,7 @@
           (let [table-name          (util/gen-table-name "ds")
                 imported-table-name (util/gen-table-name "imported")]
             (postgres/create-dataset-table conn table-name importer-columns)
-            (doseq [record (map postgres/coerce-to-sql (p/records importer))]
+            (doseq [record (map (comp postgres/coerce-to-sql import/extract-first-and-merge) (p/records importer))]
               (jdbc/insert! conn table-name record))
             (db.job-execution/clone-data-table conn {:from-table table-name
                                     :to-table   imported-table-name}

--- a/backend/src/akvo/lumen/util.clj
+++ b/backend/src/akvo/lumen/util.clj
@@ -98,3 +98,12 @@
          ret# ~expr]
      (log/info ~data (str "Elapsed time: " (/ (double (- (. System (nanoTime)) start#)) 1000000.0) " msecs"))
      ret#))
+
+(defn split-with-non-stop
+  "similar as split-with but doesn't stop the condition on first true.
+  not lazy, returns 2 vectors"
+  [pred col]
+  (reduce
+   (fn [c x]
+     (update c (if (pred x) 0 1) conj x)
+     ) [[] []] col))

--- a/backend/src/akvo/lumen/util.clj
+++ b/backend/src/akvo/lumen/util.clj
@@ -105,5 +105,5 @@
   [pred col]
   (reduce
    (fn [c x]
-     (update c (if (pred x) 0 1) conj x)
-     ) [[] []] col))
+     (update c (if (pred x) 0 1) conj x))
+   [[] []] col))

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer.clj
@@ -8,11 +8,11 @@
 
 (defn data-records [{:keys [columns rows]}]
   (for [row rows]
-    (apply merge
-           (map (fn [{:keys [id type]} {:keys [value]}]
-                  {id value})
-                columns
-                row))))
+    [(apply merge
+             (map (fn [{:keys [id type]} {:keys [value]}]
+                    {id value})
+                  columns
+                  row))]))
 
 (defn clj-data-importer [{:keys [columns rows] :as data} headers? guess-types?]
   (reify

--- a/backend/test/akvo/lumen/lib/import/common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/common_test.clj
@@ -1,0 +1,11 @@
+(ns akvo.lumen.lib.import.common-test
+  (:require [akvo.lumen.lib.import.common :as common]
+            [clojure.test :refer :all]))
+
+(deftest extract-first-and-merge-test
+  (testing "extract every first ns-responses into one `main` response"
+    (is (= {:main 1, :a 1, :b 3}
+           (common/extract-first-and-merge [(with-meta {:main 1} {:ns "main"})
+                                            (with-meta {:a 1} {:ns "one"})
+                                            (with-meta {:a 2} {:ns "one"})
+                                            (with-meta {:b 3} {:ns "two"})])))))

--- a/backend/test/akvo/lumen/lib/import/flow_common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/flow_common_test.clj
@@ -1,0 +1,99 @@
+(ns akvo.lumen.lib.import.flow-common-test
+  (:require [akvo.lumen.lib.import.flow-common :as flow-common]
+            [clojure.test :refer :all]))
+
+(deftest form-submission-nulls-values
+  (testing "flow only send values for questions that are filled"
+    (let [groups [{:id "597899156"
+                   :name "Repeated"
+                   :repeatable true}
+                  {:id "617319144"
+                   :name "Non repeatable"
+                   :repeatable false}]
+          questions [{:groupId "597899156",
+                      :name "Name",
+                      :groupName "Repeated",
+                      :createdAt "2020-06-09T13:47:32.786Z",
+                      :type "FREE_TEXT",
+                      :personalData false,
+                      :variableName nil,
+                      :id "583119147",
+                      :order 1,
+                      :modifiedAt "2020-06-09T13:47:53.534Z"}
+                     {:groupId "597899156",
+                      :name "Age",
+                      :groupName "Repeated",
+                      :createdAt "2020-06-09T13:47:34.083Z",
+                      :type "NUMBER",
+                      :personalData false,
+                      :variableName nil,
+                      :id "594979148",
+                      :order 2,
+                      :modifiedAt "2020-06-09T13:48:07.215Z"}
+                     {:groupId "597899156",
+                      :name "Likes Pizza",
+                      :groupName "Repeated",
+                      :createdAt "2020-06-09T13:47:35.352Z",
+                      :type "OPTION",
+                      :personalData false,
+                      :variableName nil,
+                      :id "609479145",
+                      :order 3,
+                      :modifiedAt "2020-06-09T13:48:57.306Z"}
+                     {:groupId "617319144",
+                      :name "Family name",
+                      :groupName "Non repeatable",
+                      :createdAt "2020-06-09T13:46:35.817Z",
+                      :type "FREE_TEXT",
+                      :personalData false,
+                      :variableName nil,
+                      :id "617309149",
+                      :order 1,
+                      :modifiedAt "2020-06-09T13:47:25.423Z"}
+                     {:groupId "617319144",
+                      :name "Location",
+                      :groupName "Non repeatable",
+                      :createdAt "2020-06-09T13:47:05.152Z",
+                      :type "FREE_TEXT",
+                      :personalData false,
+                      :variableName nil,
+                      :id "588869155",
+                      :order 2,
+                      :modifiedAt "2020-06-09T13:47:20.516Z"}]]
+      (let [responses {"597899156" [{"583119147" "Mary",
+                                     "609479145" [{"text" "yes", "code" "1"}],
+                                     "594979148" 36.0}
+                                    {"583119147" "Pol",
+                                     "609479145" [{"text" "no", "code" "2"}],
+                                     "594979148" 12.0}],
+                       "617319144" [{"588869155" "Sevilla",
+                                     "617309149" "Poppins"}]}]
+        (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
+                {"583119147" "Mary",
+                 "609479145" [{"text" "yes", "code" "1"}],
+                 "594979148" 36.0}]
+               (flow-common/question-responses groups questions responses))))
+      (let [responses {"597899156" [{"609479145" [{"text" "yes", "code" "1"}],
+                                     "594979148" 36.0}
+                                    {"583119147" "Pol",
+                                     "609479145" [{"text" "no", "code" "2"}],
+                                     "594979148" 12.0}],
+                       "617319144" [{"588869155" "Sevilla",
+                                     "617309149" "Poppins"}]}]
+        (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
+                {"609479145" [{"text" "yes", "code" "1"}], "594979148" 36.0}]
+               (flow-common/question-responses groups questions responses))))
+      (let [responses {"597899156" [{"609479145" [{"text" "yes", "code" "1"}],
+                                     "594979148" 36.0}
+                                    {"583119147" "Pol",
+                                     "594979148" 12.0}],
+                       "617319144" [{"588869155" "Sevilla",
+                                     "617309149" "Poppins"}]}]
+        (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
+                {"609479145" [{"text" "yes", "code" "1"}], "594979148" 36.0}]
+               (flow-common/question-responses groups questions responses))))
+      (let [responses {"597899156" [{}
+                                    {}],
+                       "617319144" [{"617309149" "Poppins"}]}]
+        (is (= [{"617309149" "Poppins"} {}]
+               (flow-common/question-responses groups questions responses)))))))

--- a/backend/test/akvo/lumen/lib/import/flow_common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/flow_common_test.clj
@@ -4,96 +4,38 @@
 
 (deftest form-submission-nulls-values
   (testing "flow only send values for questions that are filled"
-    (let [groups [{:id "597899156"
-                   :name "Repeated"
+    (let [groups [{:id "1G"
                    :repeatable true}
-                  {:id "617319144"
-                   :name "Non repeatable"
-                   :repeatable false}]
-          questions [{:groupId "597899156",
-                      :name "Name",
-                      :groupName "Repeated",
-                      :createdAt "2020-06-09T13:47:32.786Z",
-                      :type "FREE_TEXT",
-                      :personalData false,
-                      :variableName nil,
-                      :id "583119147",
-                      :order 1,
-                      :modifiedAt "2020-06-09T13:47:53.534Z"}
-                     {:groupId "597899156",
-                      :name "Age",
-                      :groupName "Repeated",
-                      :createdAt "2020-06-09T13:47:34.083Z",
-                      :type "NUMBER",
-                      :personalData false,
-                      :variableName nil,
-                      :id "594979148",
-                      :order 2,
-                      :modifiedAt "2020-06-09T13:48:07.215Z"}
-                     {:groupId "597899156",
-                      :name "Likes Pizza",
-                      :groupName "Repeated",
-                      :createdAt "2020-06-09T13:47:35.352Z",
-                      :type "OPTION",
-                      :personalData false,
-                      :variableName nil,
-                      :id "609479145",
-                      :order 3,
-                      :modifiedAt "2020-06-09T13:48:57.306Z"}
-                     {:groupId "617319144",
-                      :name "Family name",
-                      :groupName "Non repeatable",
-                      :createdAt "2020-06-09T13:46:35.817Z",
-                      :type "FREE_TEXT",
-                      :personalData false,
-                      :variableName nil,
-                      :id "617309149",
-                      :order 1,
-                      :modifiedAt "2020-06-09T13:47:25.423Z"}
-                     {:groupId "617319144",
-                      :name "Location",
-                      :groupName "Non repeatable",
-                      :createdAt "2020-06-09T13:47:05.152Z",
-                      :type "FREE_TEXT",
-                      :personalData false,
-                      :variableName nil,
-                      :id "588869155",
-                      :order 2,
-                      :modifiedAt "2020-06-09T13:47:20.516Z"}]]
-      (let [responses {"597899156" [{"583119147" "Mary",
-                                     "609479145" [{"text" "yes", "code" "1"}],
-                                     "594979148" 36.0}
-                                    {"583119147" "Pol",
-                                     "609479145" [{"text" "no", "code" "2"}],
-                                     "594979148" 12.0}],
-                       "617319144" [{"588869155" "Sevilla",
-                                     "617309149" "Poppins"}]}]
-        (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
-                {"583119147" "Mary",
-                 "609479145" [{"text" "yes", "code" "1"}],
-                 "594979148" 36.0}]
+                  {:id "2G"
+                   :repeatable false}]]
+      (let [responses {"1G" [{"1G1Q" "A"
+                              "1G2Q" [{"text" "yes", "code" "1"}]
+                              "1G3Q" 36.0}
+                             {"1G1Q" "Pol"
+                              "1G2Q" [{"text" "no", "code" "2"}]
+                              "1G3Q" 12.0}]
+                       "2G" [{"1" "A"
+                              "2" "B"}]}]
+        (is (= [{"1" "A"
+                 "2" "B"}          
+                {"1G1Q" "A"
+                 "1G2Q" [{"text" "yes", "code" "1"}]
+                 "1G3Q" 36.0}]
                (flow-common/question-responses groups responses))))
-      (let [responses {"597899156" [{"609479145" [{"text" "yes", "code" "1"}],
-                                     "594979148" 36.0}
-                                    {"583119147" "Pol",
-                                     "609479145" [{"text" "no", "code" "2"}],
-                                     "594979148" 12.0}],
-                       "617319144" [{"588869155" "Sevilla",
-                                     "617309149" "Poppins"}]}]
-        (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
-                {"609479145" [{"text" "yes", "code" "1"}], "594979148" 36.0}]
+      (let [responses {"1G" [{"1G2Q" [{"text" "yes" "code" "1"}]
+                              "1G3Q" 36.0}
+                             {"1G1Q" "Pol"
+                              "1G3Q" 12.0}]
+                       "2G" [{"2G1Q" "A"
+                              "2G2Q" "B"}]}]
+        (is (= [{"2G1Q" "A"
+                 "2G2Q" "B"}          
+                {"1G2Q" [{"text" "yes", "code" "1"}]
+                 "1G3Q" 36.0}]
                (flow-common/question-responses groups responses))))
-      (let [responses {"597899156" [{"609479145" [{"text" "yes", "code" "1"}],
-                                     "594979148" 36.0}
-                                    {"583119147" "Pol",
-                                     "594979148" 12.0}],
-                       "617319144" [{"588869155" "Sevilla",
-                                     "617309149" "Poppins"}]}]
-        (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
-                {"609479145" [{"text" "yes", "code" "1"}], "594979148" 36.0}]
-               (flow-common/question-responses groups responses))))
-      (let [responses {"597899156" [{}
-                                    {}],
-                       "617319144" [{"617309149" "Poppins"}]}]
-        (is (= [{"617309149" "Poppins"} {}]
+      (let [responses {"1G" [{}
+                             {}]
+                       "2G" [{"2G2Q" "B"}]}]
+        (is (= [{"2G2Q" "B"}
+                {}]
                (flow-common/question-responses groups responses)))))))

--- a/backend/test/akvo/lumen/lib/import/flow_common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/flow_common_test.clj
@@ -72,7 +72,7 @@
                 {"583119147" "Mary",
                  "609479145" [{"text" "yes", "code" "1"}],
                  "594979148" 36.0}]
-               (flow-common/question-responses groups questions responses))))
+               (flow-common/question-responses groups responses))))
       (let [responses {"597899156" [{"609479145" [{"text" "yes", "code" "1"}],
                                      "594979148" 36.0}
                                     {"583119147" "Pol",
@@ -82,7 +82,7 @@
                                      "617309149" "Poppins"}]}]
         (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
                 {"609479145" [{"text" "yes", "code" "1"}], "594979148" 36.0}]
-               (flow-common/question-responses groups questions responses))))
+               (flow-common/question-responses groups responses))))
       (let [responses {"597899156" [{"609479145" [{"text" "yes", "code" "1"}],
                                      "594979148" 36.0}
                                     {"583119147" "Pol",
@@ -91,9 +91,9 @@
                                      "617309149" "Poppins"}]}]
         (is (= [{"588869155" "Sevilla", "617309149" "Poppins"}          
                 {"609479145" [{"text" "yes", "code" "1"}], "594979148" 36.0}]
-               (flow-common/question-responses groups questions responses))))
+               (flow-common/question-responses groups responses))))
       (let [responses {"597899156" [{}
                                     {}],
                        "617319144" [{"617309149" "Poppins"}]}]
         (is (= [{"617309149" "Poppins"} {}]
-               (flow-common/question-responses groups questions responses)))))))
+               (flow-common/question-responses groups responses)))))))

--- a/backend/test/akvo/lumen/util_test.clj
+++ b/backend/test/akvo/lumen/util_test.clj
@@ -5,6 +5,3 @@
 (deftest split-with-non-stop
   (is (= [[1 2 2 0 0] [3 10]] (u/split-with-non-stop (partial > 3) [1 2 3 2 0 10 0] )))
   (is (= [[:c] [:a :b :d]] (u/split-with-non-stop (partial = :c) [:a :b :c :d]))))
-
-
-

--- a/backend/test/akvo/lumen/util_test.clj
+++ b/backend/test/akvo/lumen/util_test.clj
@@ -1,0 +1,10 @@
+(ns akvo.lumen.util-test
+  (:require [akvo.lumen.util :as u]
+            [clojure.test :refer [deftest is]]))
+
+(deftest split-with-non-stop
+  (is (= [[1 2 2 0 0] [3 10]] (u/split-with-non-stop (partial > 3) [1 2 3 2 0 10 0] )))
+  (is (= [[:c] [:a :b :d]] (u/split-with-non-stop (partial = :c) [:a :b :c :d]))))
+
+
+


### PR DESCRIPTION

So far we don't change functionality, so each flow form submission will be represented by one row in dataset_version table, containing only one RQG question/response iteration

In next PRs and behind feature-flag,  we should remove the included adapter logic https://github.com/akvo/akvo-lumen/pull/2784/files#diff-408f43d0bce4b90be771a7b1286a0f1eR54 we could store all RQG question/response iterations


Relates to https://github.com/akvo/akvo-lumen/pull/2734
but instead of trying

```
FROM
;; {question-id -> response1 }

TO
;; {question-id -> [response1]}
```

we do ...

```
FROM
;; {question-id -> response1 }

TO
;; [{question-id -> response1} {question-id -> response2}]

Being each map a table representation, so first map will be main
table, the others will be RQG answers
```

thanks to @iperdomo the better idea approach! 😄 

- [ ] **Update release notes if necessary**
