### PR TITLE
[#2763] Run VACUUM after "apply/undo transformation" and after "update dataset"

### DIFF
--- a/backend/src/akvo/lumen/db/job_execution.clj
+++ b/backend/src/akvo/lumen/db/job_execution.clj
@@ -1,4 +1,11 @@
 (ns akvo.lumen.db.job-execution
-  (:require [hugsql.core :as hugsql]))
+  (:require [hugsql.core :as hugsql]
+            [akvo.lumen.util :as u]))
 
 (hugsql/def-db-fns "akvo/lumen/lib/job-execution.sql")
+
+(defn vacuum-table [conn opts]
+  (u/time-with-log
+   (str "vacuum-table " (:table-name opts))
+   (do
+     (vacuum-table* conn opts {} {:transaction? false}))))

--- a/backend/src/akvo/lumen/lib/job-execution.sql
+++ b/backend/src/akvo/lumen/lib/job-execution.sql
@@ -15,6 +15,11 @@ INSERT INTO job_execution(id, data_source_id, dataset_id, type)
 CREATE TABLE :i:to-table (LIKE :i:from-table INCLUDING ALL);
 INSERT INTO :i:to-table SELECT * FROM :i:from-table;
 
+
+-- :name vacuum-table* :! :n
+-- :doc Vacuum a data table
+VACUUM (VERBOSE, ANALYZE, FULL) :i:table-name;
+
 -- :name data-source-spec-by-job-execution-id :? :1
 -- :doc Get the data source spec by job execution id
 SELECT spec

--- a/backend/src/akvo/lumen/lib/transformation.clj
+++ b/backend/src/akvo/lumen/lib/transformation.clj
@@ -51,6 +51,9 @@
             :transformation (engine/execute-transformation tx-deps dataset-id job-execution-id (:transformation command))
             :undo (engine/execute-undo tx-deps dataset-id job-execution-id)))
         (db.job-execution/update-successful-job-execution tx-conn {:id job-execution-id}))
+      (let [table-name (:table-name (db.transformation/latest-dataset-version-by-dataset-id tenant-conn
+                                                                     {:dataset-id dataset-id}))]
+       (db.job-execution/vacuum-table tenant-conn {:table-name table-name}))
       (catch Exception e
         (let [msg (.getMessage e)]
           (engine/log-ex e)

--- a/backend/src/akvo/lumen/lib/transformation.clj
+++ b/backend/src/akvo/lumen/lib/transformation.clj
@@ -51,9 +51,8 @@
             :transformation (engine/execute-transformation tx-deps dataset-id job-execution-id (:transformation command))
             :undo (engine/execute-undo tx-deps dataset-id job-execution-id)))
         (db.job-execution/update-successful-job-execution tx-conn {:id job-execution-id}))
-      (let [table-name (:table-name (db.transformation/latest-dataset-version-by-dataset-id tenant-conn
-                                                                     {:dataset-id dataset-id}))]
-       (db.job-execution/vacuum-table tenant-conn {:table-name table-name}))
+      (let [dsv (db.transformation/latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id})]
+        (db.job-execution/vacuum-table tenant-conn (select-keys dsv [:table-name])))
       (catch Exception e
         (let [msg (.getMessage e)]
           (engine/log-ex e)

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -173,7 +173,9 @@
                                  dataset-id
                                  table-name
                                  imported-table-name
-                                 dataset-version))))))))
+                                 dataset-version)))))))
+  (let [dsv (db.transformation/latest-dataset-version-by-dataset-id tenant-conn {:dataset-id dataset-id})]
+    (db.job-execution/vacuum-table tenant-conn (select-keys dsv [:table-name]))))
 
 (defn update-dataset [tenant-conn caddisfly import-config error-tracker dataset-id data-source-id data-source-spec]
   (if-let [current-tx-job (db.transformation/pending-transformation-job-execution tenant-conn {:dataset-id dataset-id})]


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Relates #2763 

#### About updating dataset:
Thus VACUUM can **not** be run inside a transaction **SO FAR** we need to wait for the full dataset update that also processes the transformations related instead of calling VACUUM after every transformation as should be the ideal implementation