### PR TITLE
[#2763] Vacuum after every tx of update process

### DIFF
--- a/backend/src/akvo/lumen/lib/transformation/engine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/engine.clj
@@ -231,9 +231,9 @@
   [op-spec older-columns new-columns]
   op-spec)
 
-(defn apply-transformation-log [conn caddisfly table-name imported-table-name
-                                new-columns old-columns dataset-id transformations]
-
+(defn apply-dataset-transformations-on-table
+  "no transactional thus we can discard the temporary table we are working with"
+  [conn caddisfly dataset-id transformations table-name new-columns old-columns]
   (loop [transformations transformations
          columns         new-columns
          applied-txs     []]


### PR DESCRIPTION
Expected behaviour after applying transformation-log after a new update is to get a new dataset_version with incremented version as a result of applying all transformations with new data imported

Right now we loop all transformations and create/update only one dataset_version row to get the final dataset_version row state

This PR doesn't create a new dataset_version until all transformations are applied to the new ds_table.

The transformations are applied to the new ds_table without db transaction thus if we had any problem we just discard this table




- [ ] **Update release notes if necessary**
