### PR TITLE
Aggregate on OPTION column types

### DIFF
--- a/backend/src/akvo/lumen/lib/aggregation/bar.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/bar.clj
@@ -21,14 +21,14 @@
             (SELECT %1$s AS x, %2$s AS sort_value
              FROM %3$s 
              WHERE %4$s 
-             GROUP BY %1$s 
+             GROUP BY x
              ORDER BY %5$s 
              LIMIT %6$s), 
           data_table AS
             (SELECT %1$s as x, %2$s as y, %7$s as s
              FROM %3$s
              WHERE %4$s
-             GROUP BY %1$s, %7$s) 
+             GROUP BY x, %7$s)
           SELECT
             data_table.x AS x,
             data_table.y,
@@ -51,7 +51,7 @@
 
 (defn- bucket-sql [table-name bucket-column aggregation filter-sql sort-sql truncate-size]
   (format "SELECT * 
-           FROM (SELECT %1$s as x, %2$s FROM %3$s WHERE %4$s GROUP BY %1$s)z 
+           FROM (SELECT %1$s as x, %2$s FROM %3$s WHERE %4$s GROUP BY x)z
            ORDER BY %5$s 
            LIMIT %6$s"
           (:columnName bucket-column)

--- a/backend/src/akvo/lumen/lib/aggregation/bar.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/bar.clj
@@ -14,6 +14,11 @@
     "asc" (format "%s ASC NULLS FIRST" column)
     "dsc" (format "%s DESC NULLS LAST" column)))
 
+(defn- sql-option-bucket-column [bucket-column]
+  (if (= "option" (:type bucket-column))
+    (format "unnest(regexp_split_to_array(%1$s,'\\|'))" (:columnName bucket-column))
+    (:columnName bucket-column)))
+
 (defn- subbucket-sql [table-name bucket-column subbucket-column aggregation filter-sql sort-sql truncate-size]
   (format "
           WITH
@@ -41,7 +46,7 @@
           ON
             sort_table.x = data_table.x
           ORDER BY %5$s, data_table.s"
-          (:columnName bucket-column)
+          (sql-option-bucket-column bucket-column)
           aggregation
           table-name
           filter-sql
@@ -54,7 +59,7 @@
            FROM (SELECT %1$s as x, %2$s FROM %3$s WHERE %4$s GROUP BY x)z
            ORDER BY %5$s 
            LIMIT %6$s"
-          (:columnName bucket-column)
+          (sql-option-bucket-column bucket-column)
           aggregation
           table-name
           filter-sql

--- a/backend/src/akvo/lumen/lib/import/flow.clj
+++ b/backend/src/akvo/lumen/lib/import/flow.clj
@@ -14,7 +14,7 @@
 
 (defmethod import/dataset-importer "AKVO_FLOW"
   [{:strs [instance surveyId formId token email version] :as spec}
-   {:keys [flow-api] :as config}]
+   {:keys [flow-api environment] :as config}]
   (let [version (if version version 1)
         headers-fn #((:internal-api-headers flow-api) {:email email :token token})
         survey (delay (flow-common/survey-definition (:internal-url flow-api)
@@ -28,8 +28,8 @@
       (columns [this]
         (try
           (cond
-            (<= version 2) (v2/dataset-columns (flow-common/form @survey formId))
-            (<= version 3) (v3/dataset-columns (flow-common/form @survey formId)))
+            (<= version 2) (v2/dataset-columns (flow-common/form @survey formId) environment)
+            (<= version 3) (v3/dataset-columns (flow-common/form @survey formId) environment))
           (catch Throwable e
             (if-let [ex-d (ex-data e)]
               (do

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -78,6 +78,7 @@
     "GEOSHAPE" "geoshape"
     "GEO-SHAPE-FEATURES" "multiple"
     "CADDISFLY" "multiple"
+    "OPTION" "option"
     "text"))
 
 (defn questions

--- a/backend/src/akvo/lumen/lib/import/flow_common.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_common.clj
@@ -70,16 +70,21 @@
       (into all-data-points (get response "dataPoints")))))
 
 (defn question-type->lumen-type
-  [question]
-  (condp = (:type question)
-    "NUMBER" "number"
-    "DATE" "date"
-    "GEO" "geopoint"
-    "GEOSHAPE" "geoshape"
-    "GEO-SHAPE-FEATURES" "multiple"
-    "CADDISFLY" "multiple"
-    "OPTION" "option"
-    "text"))
+  [environment question]
+  (let [res (condp = (:type question)
+              "NUMBER" "number"
+              "DATE" "date"
+              "GEO" "geopoint"
+              "GEOSHAPE" "geoshape"
+              "GEO-SHAPE-FEATURES" "multiple"
+              "CADDISFLY" "multiple"
+              "OPTION" "option"
+              "text")]
+    (if (= res "option")
+      (if (get environment "optionColumnType")
+        "option"
+        "text")
+      res)))
 
 (defn questions
   "Get the list of questions from a form"

--- a/backend/src/akvo/lumen/lib/import/flow_v2.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v2.clj
@@ -9,13 +9,13 @@
   (:import [java.time Instant]))
 
 (defn dataset-columns
-  [form]
+  [form environment]
   (into (flow-common/commons-columns form)
         (into
          (->> [{:title "Latitude" :type "number" :id "latitude"}
                {:title "Longitude" :type "number" :id "longitude"}]
               (mapv #(assoc % :groupName "metadata" :groupId "metadata")))
-         (common/coerce flow-common/question-type->lumen-type (flow-common/questions form)))))
+         (common/coerce (partial flow-common/question-type->lumen-type environment) (flow-common/questions form)))))
 
 (defmulti render-response
   (fn [type response]

--- a/backend/src/akvo/lumen/lib/import/flow_v3.clj
+++ b/backend/src/akvo/lumen/lib/import/flow_v3.clj
@@ -28,11 +28,11 @@
 (defn dataset-columns
   "returns a vector of [{:title :type :id :key :groupName :groupId}]
   `:key` is optional"
-  [form]
+  [form environment]
   (let [questions (flow-questions form)]
     (into (flow-common/commons-columns form)
           (into [{:title "Device Id" :type "text" :id "device_id" :groupName "metadata" :groupId "metadata"}]
-                (common/coerce flow-common/question-type->lumen-type questions)))))
+                (common/coerce (partial flow-common/question-type->lumen-type environment) questions)))))
 
 (defn render-response
   [type response]

--- a/backend/src/akvo/lumen/lib/update.clj
+++ b/backend/src/akvo/lumen/lib/update.clj
@@ -126,7 +126,8 @@
 
 (defn- import-data-to-table [tenant-conn import-config dataset-id job-execution-id data-source-spec]
   (jdbc/with-db-transaction [conn tenant-conn]
-    (with-open [importer (import/dataset-importer (get data-source-spec "source") import-config)]
+    (with-open [importer (import/dataset-importer (get data-source-spec "source")
+                                                  (assoc import-config :environment (env/all conn)))]
      (let [initial-dataset-version  (db.transformation/initial-dataset-version-to-update-by-dataset-id conn {:dataset-id dataset-id})
            latest-dataset-version (db.transformation/latest-dataset-version-by-dataset-id conn {:dataset-id dataset-id})
            imported-dataset-columns (vec (:columns initial-dataset-version))

--- a/backend/src/akvo/lumen/postgres.clj
+++ b/backend/src/akvo/lumen/postgres.clj
@@ -75,6 +75,7 @@
     "geoline" "geometry(LINE, 4326)"
     "geopoint" "geometry(POINT, 4326)"
     "multiple" "text"
+    "option" "text"
     "text" "text"))
 
 (defn- column-type-fn [{:keys [id type]}]

--- a/client/src/components/visualisation/configMenu/BarConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/BarConfigMenu.jsx
@@ -160,7 +160,7 @@ class BarConfigMenu extends Component {
           columnOptions.find(item => item.value === value).title : null,
       }, spec, onChangeSpec, columnOptions)}
     />) : '';
-    const columnsBucketColumn = filterColumns(columnOptions, ['number', 'text']);
+    const columnsBucketColumn = filterColumns(columnOptions, ['number', 'text', 'option']);
     const columnsMetricColumn = filterColumns(columnOptions, ['number']);
     return (
       <div>

--- a/client/src/translations/en.json
+++ b/client/src/translations/en.json
@@ -232,6 +232,7 @@
   "number": "Number",
   "number_of_buckets_to_show": "Number of buckets to show",
   "number_of_decimal_places": "Number of decimal places",
+  "option": "Option",
   "or": "or",
   "outline": "Outline",
   "overflow": "Overflow",


### PR DESCRIPTION
Before this PR, we had "OPTION" values represented as:
`TEXT` in `client`
`TEXT` in `backend`
`TEXT` in `db`

This PR changes the way "OPTION" is represented in client and backend but db keeps the same
`OPTION` in `client`
`OPTION` in `backend`
`TEXT` in `db`

Changes will be behind feature-flag `optionColumnType` 

<img width="1020" alt="Screenshot 2020-08-11 at 14 27 01" src="https://user-images.githubusercontent.com/731829/89899905-429f0b80-dbe3-11ea-90a7-f18957bf4dec.png">
<img width="589" alt="Screenshot 2020-08-11 at 14 25 37" src="https://user-images.githubusercontent.com/731829/89899917-4599fc00-dbe3-11ea-83cb-15d9fe871d84.png">

- [ ] Update fr, and es i18n client versions



To test it, we need to update the flow dataset or import a new one 