### PR TITLE
[#625] Add more legend order support

### DIFF
--- a/backend/src/akvo/lumen/lib/aggregation/bubble.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/bubble.clj
@@ -39,7 +39,7 @@
                 :data     (mapv (fn [[size-value label]] {:value size-value}) sql-response)
                 :metadata {:type (:type column-size)}}]
       :common {:metadata {:sampled (= (count sql-response) max-points)}
-               :data     (mapv (fn [[size-value label]] {:label label}) sql-response)}})))
+               :data     (mapv (fn [[size-value label]] {:label label :key label}) sql-response)}})))
 
 (defn query-v2
   [tenant-conn {:keys [columns table-name]} query]
@@ -64,7 +64,7 @@
                   :data     (mapv (fn [[size-value label]] {:value size-value}) sql-response)
                   :metadata {:type (:type column-size)}}]
         :common {:metadata {}
-                 :data     (mapv (fn [[size-value label]] {:label label}) sql-response)}})
+                 :data     (mapv (fn [[size-value label]] {:label label :key label}) sql-response)}})
       (lib/bad-request
        {:message (format "Results are more than %d. Please select another column or use a different aggregation."
                          max-points)}))))

--- a/backend/src/akvo/lumen/lib/aggregation/scatter.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/scatter.clj
@@ -7,7 +7,7 @@
             [clojure.tools.logging :as log]))
 
 (defn- serie-data [tag sql-data index]
-  (mapv #(let [key-value (nth % index)] (array-map tag key-value :key key-value)) sql-data))
+  (mapv #(let [v (nth % index)] (array-map tag v :key v)) sql-data))
 
 (defn serie [sql-data column index]
   (when (:title column)
@@ -119,7 +119,7 @@
                    (serie sql-response column idx))
                  [column-x column-y column-size column-category])
         :common {:metadata {:type (:type column-label)}
-                 :data (serie-data :label sql-response 4)}})
+                 :data (serie-data :label sql-response 3)}})
       (lib/bad-request
        {:message (format "Results are more than %d. Please select another column or use a different aggregation."
                          max-points)}))))

--- a/backend/src/akvo/lumen/lib/aggregation/scatter.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/scatter.clj
@@ -7,7 +7,7 @@
             [clojure.tools.logging :as log]))
 
 (defn- serie-data [tag sql-data index]
-  (mapv #(array-map tag (nth % index)) sql-data))
+  (mapv #(let [key-value (nth % index)] (array-map tag key-value :key key-value)) sql-data))
 
 (defn serie [sql-data column index]
   (when (:title column)

--- a/backend/test/akvo/lumen/lib/aggregation/scatter_test.clj
+++ b/backend/test/akvo/lumen/lib/aggregation/scatter_test.clj
@@ -10,10 +10,10 @@
     (is (= (scatter/serie sql-data column 0)
            {:key (:title column),
             :label (:title column),
-            :data [{:value :a0} {:value :a1}],
+            :data [{:value :a0 :key :a0} {:value :a1 :key :a1}],
             :metadata {:type (:type column)}}))
     (is (= (scatter/serie sql-data column 1)
            {:key (:title column),
             :label (:title column),
-            :data [{:value :b0} {:value :b1}],
+            :data [{:value :b0 :key :b0} {:value :b1 :key :b1}],
             :metadata {:type (:type column)}}))))

--- a/backend/test/akvo/lumen/lib/aggregation_test.clj
+++ b/backend/test/akvo/lumen/lib/aggregation_test.clj
@@ -335,20 +335,23 @@
                 [{:key "C",
                   :label "C",
                   :data
-                  [{:value 1548979200000}
-                   {:value 1549065600000}
-                   {:value 1549152000000}
-                   {:value 1549238400000}],
+                  [{:value 1548979200000, :key 1548979200000}
+                   {:value 1549065600000, :key 1549065600000}
+                   {:value 1549152000000, :key 1549152000000}
+                   {:value 1549238400000, :key 1549238400000}],
                   :metadata {:type "date"}}
                  {:key "B",
                   :label "B",
-                  :data [{:value 1.0} {:value 2.0} {:value 3.0} {:value 4.0}],
+                  :data [{:value 1.0, :key 1.0}
+                         {:value 2.0, :key 2.0}
+                         {:value 3.0, :key 3.0}
+                         {:value 4.0, :key 4.0}],
                   :metadata {:type "number"}}
                  nil
                  nil],
                 :common
                 {:metadata {:type nil, :sampled false},
-                 :data [{:label nil} {:label nil} {:label nil} {:label nil}]}}))))))
+                 :data [{:label nil :key nil} {:label nil :key nil} {:label nil :key nil} {:label nil :key nil}]}}))))))
 
 (deftest bubble-tests
   (let [data {:columns [{:id "c1", :title "A", :type "text"}
@@ -375,7 +378,7 @@
                   :metadata {:type nil}}],
                 :common
                 {:metadata {:sampled false},
-                 :data [{:label "c"} {:label "b"} {:label "a"}]}}))))
+                 :data [{:label "c" :key "c"} {:label "b" :key "b"} {:label "a" :key "a"}]}}))))
     (testing "Metric queries"
       (let [[tag query-result] (query {:bucketColumn "c1"
                                        :metricColumn "c2"
@@ -388,4 +391,4 @@
                   :metadata {:type "number"}}],
                 :common
                 {:metadata {:sampled false},
-                 :data [{:label "c"} {:label "b"} {:label "a"}]}}))))))
+                 :data [{:label "c" :key "c"} {:label "b" :key "b"} {:label "a" :key "a"}]}}))))))

--- a/client/src/components/charts/BarChart.jsx
+++ b/client/src/components/charts/BarChart.jsx
@@ -31,6 +31,7 @@ export default class BarChart extends Component {
     }),
     grouped: PropTypes.bool,
     horizontal: PropTypes.bool,
+    env: PropTypes.object.isRequired,
   }
 
   static defaultProps = {

--- a/client/src/components/charts/BubbleChart.jsx
+++ b/client/src/components/charts/BubbleChart.jsx
@@ -17,6 +17,7 @@ import Legend from './Legend';
 import RenderComplete from './RenderComplete';
 import Tooltip from './Tooltip';
 import BubbleLegend from './BubbleLegend';
+import { sortLegendListFunc, ensureSpecLegend, noSortFunc } from './LegendsSortable';
 
 const getDatum = (data, datum) => data.filter(({ key }) => key === datum)[0];
 
@@ -48,6 +49,7 @@ class BubbleChart extends Component {
     marginRight: PropTypes.number,
     marginTop: PropTypes.number,
     marginBottom: PropTypes.number,
+    env: PropTypes.object.isRequired,
   }
 
   static defaultProps = {
@@ -215,6 +217,7 @@ class BubbleChart extends Component {
       marginRight,
       marginBottom,
       marginLeft,
+      env,
     } = this.props;
 
     const series = this.getData();
@@ -224,6 +227,11 @@ class BubbleChart extends Component {
     const totalCount = series.data.reduce((total, datum) => total + datum.value, 0);
 
     const { tooltipItems, tooltipVisible, tooltipPosition, hasRendered } = this.state;
+    let legendSeriesData = series.data;
+    if (env.environment.orderedLegend) {
+      const specLegend = ensureSpecLegend(visualisation.spec.legend);
+      legendSeriesData = sortLegendListFunc(noSortFunc, specLegend)(series.data);
+    }
 
     return (
       <ChartLayout
@@ -243,9 +251,9 @@ class BubbleChart extends Component {
             description={
               legendDescription && <BubbleLegend title={legendDescription} />
             }
-            data={series.data.map(({ key }) => key)}
+            data={legendSeriesData.map(({ key }) => key)}
             colorMapping={
-              series.data.reduce((acc, { key }, i) => ({
+              legendSeriesData.reduce((acc, { key }, i) => ({
                 ...acc,
                 [key]: this.getColor(key, i),
               }), {})

--- a/client/src/components/charts/Chart.jsx
+++ b/client/src/components/charts/Chart.jsx
@@ -217,6 +217,7 @@ export default class Chart extends Component {
             legendTitle={visualisation.spec.categoryLabel}
             legendDescription={visualisation.spec.sizeLabel}
             legendPosition={visualisation.spec.legendPosition}
+            env={env}
           />
         );
       case 'bar':

--- a/client/src/components/charts/Chart.jsx
+++ b/client/src/components/charts/Chart.jsx
@@ -240,6 +240,7 @@ export default class Chart extends Component {
             legendPosition={visualisation.spec.legendPosition}
             valueLabelsVisible={visualisation.spec.showValueLabels}
             horizontal={visualisation.spec.horizontal}
+            env={env}
           />
         );
       case 'bubble':

--- a/client/src/components/charts/Chart.jsx
+++ b/client/src/components/charts/Chart.jsx
@@ -259,6 +259,7 @@ export default class Chart extends Component {
             legendVisible={visualisation.spec.showLegend}
             legendPosition={visualisation.spec.legendPosition}
             labelsVisible={visualisation.spec.showLabels}
+            env={env}
           />
         );
       default:

--- a/client/src/components/charts/Chart.jsx
+++ b/client/src/components/charts/Chart.jsx
@@ -177,6 +177,7 @@ export default class Chart extends Component {
             legendTitle={visualisation.spec.legendTitle}
             onChangeVisualisationSpec={onChangeVisualisationSpec}
             edit={Boolean(onChangeVisualisationSpec)}
+            env={env}
           />
         );
       case 'line':

--- a/client/src/components/charts/LegendsSortable.jsx
+++ b/client/src/components/charts/LegendsSortable.jsx
@@ -39,7 +39,7 @@ SortableItem.propTypes = {
 };
 
 const getLegends = (specLegend, visualisation) => {
-  const specLegendsList = get(specLegend, 'order.list');
+  const specLegendsList = get(specLegend, 'order.list') || [];
 
   const visLegendsList = get(visualisation, 'data.common.data') || [];
 

--- a/client/src/components/charts/LegendsSortable.jsx
+++ b/client/src/components/charts/LegendsSortable.jsx
@@ -114,6 +114,7 @@ export const resetLegend = (specLegend, visualisation, val) => {
   return legend;
 };
 
+export const noSortFunc = () => 1;
 
 export const sortLegendListFunc = (defaultSortFunction, specLegend) => {
   if (specLegend.order.mode === 'custom') {

--- a/client/src/components/charts/LegendsSortable.jsx
+++ b/client/src/components/charts/LegendsSortable.jsx
@@ -9,7 +9,7 @@ import { sortAlphabetically, sortChronologically } from '../../utilities/utils';
 import { palette } from '../../utilities/visualisationColors';
 import LegendShape from './LegendShape';
 
-const sortLegendsFunctionFactory = visualisation => (get(visualisation, 'data.common.metadata.type') === 'text' ?
+export const sortLegendsFunctionFactory = data => (get(data, 'data.common.metadata.type') === 'text' ?
   sortAlphabetically : sortChronologically);
 
 const sortableItemStyle = { display: 'flex', alignItems: 'center', flexDirection: 'row', margin: '5px 0px 5px 5px' };
@@ -112,4 +112,19 @@ export const resetLegend = (specLegend, visualisation, val) => {
     return resetLegend(specLegend, visualisation, 'auto');
   }
   return legend;
+};
+
+
+export const sortListFunc = (defaultSortFunction, specLegend) => {
+  if (specLegend.order.mode === 'custom') {
+    return (list) => {
+      if (isEqual(new Set(specLegend.order.list), new Set(list.map(({ key }) => key)))) {
+        // if bucket column changes we need to get the new spec api call returned
+        // before sorting new values
+        return specLegend.order.list.map(k => list.find(({ key }) => k === key));
+      }
+      return list.sort((a, b) => defaultSortFunction(a, b, ({ key }) => key));
+    };
+  }
+  return list => list.sort((a, b) => defaultSortFunction(a, b, ({ key }) => key));
 };

--- a/client/src/components/charts/LegendsSortable.jsx
+++ b/client/src/components/charts/LegendsSortable.jsx
@@ -115,7 +115,7 @@ export const resetLegend = (specLegend, visualisation, val) => {
 };
 
 
-export const sortListFunc = (defaultSortFunction, specLegend) => {
+export const sortLegendListFunc = (defaultSortFunction, specLegend) => {
   if (specLegend.order.mode === 'custom') {
     return (list) => {
       if (isEqual(new Set(specLegend.order.list), new Set(list.map(({ key }) => key)))) {

--- a/client/src/components/charts/LegendsSortable.jsx
+++ b/client/src/components/charts/LegendsSortable.jsx
@@ -21,7 +21,9 @@ const NoSortableItem = ({ value, color }) =>
 </div>);
 
 NoSortableItem.propTypes = {
-  value: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.string.isRequired,
+    PropTypes.number.isrequires]),
   color: PropTypes.string.isRequired,
 };
 
@@ -34,7 +36,9 @@ const SortableItem = sortableElement(({ index, value, color }) =>
      <div style={{ marginLeft: '4px' }}>{value}</div></div>));
 
 SortableItem.propTypes = {
-  value: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.string.isRequired,
+    PropTypes.number.isrequires]),
   index: PropTypes.number.isRequired,
 };
 

--- a/client/src/components/charts/LegendsSortable.jsx
+++ b/client/src/components/charts/LegendsSortable.jsx
@@ -78,9 +78,9 @@ export const LegendsSortable = ({
   (
     <div style={{ marginBottom: '5px' }}>
       {sortable ?
-      legendItems.map((value, index) =>
+      legendItems && legendItems.map((value, index) =>
         <SortableItem key={`item-${value}`} value={value} index={legends.indexOf(value)} color={getColor(value, index)} />) :
-      legendItems.map((value, index) =>
+      legendItems && legendItems.map((value, index) =>
         <NoSortableItem value={value} key={`item-${value}`} color={getColor(value, index)} />)
       }
     </div>
@@ -95,7 +95,7 @@ export const LegendsSortable = ({
 
 LegendsSortable.propTypes = {
   visualisation: PropTypes.object.isRequired,
-  colors: PropTypes.object.isRequired,
+  colors: PropTypes.object,
   onChangeSpec: PropTypes.func.isRequired,
   specLegend: PropTypes.object.isRequired,
 };

--- a/client/src/components/charts/PieChart.jsx
+++ b/client/src/components/charts/PieChart.jsx
@@ -69,12 +69,12 @@ export default class PieChart extends Component {
   }
 
   getData() {
-    const { data, env } = this.props;
+    const { data, env, visualisation } = this.props;
     if (!get(data, 'series[0]')) return false;
     const series = merge({}, data.common, data.series[0]);
     const sortFunctionFactory = sortLegendsFunctionFactory(data);
 
-    const specLegend = ensureSpecLegend(this.props.visualisation.spec.legend);
+    const specLegend = ensureSpecLegend(visualisation.spec.legend);
     let sortList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
     if (env.environment.orderedLegend) {
       sortList = sortListFunc(sortFunctionFactory, specLegend);

--- a/client/src/components/charts/PieChart.jsx
+++ b/client/src/components/charts/PieChart.jsx
@@ -9,7 +9,7 @@ import merge from 'lodash/merge';
 import itsSet from 'its-set';
 import { sortAlphabetically, sortChronologically } from '../../utilities/utils';
 import { round, replaceLabelIfValueEmpty } from '../../utilities/chart';
-import { sortListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from './LegendsSortable';
+import { sortLegendListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from './LegendsSortable';
 import Legend from './Legend';
 import ResponsiveWrapper from '../common/ResponsiveWrapper';
 import ColorPicker from '../common/ColorPicker';
@@ -75,14 +75,14 @@ export default class PieChart extends Component {
     const sortFunctionFactory = sortLegendsFunctionFactory(data);
 
     const specLegend = ensureSpecLegend(visualisation.spec.legend);
-    let sortList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
+    let sortLegendList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
     if (env.environment.orderedLegend) {
-      sortList = sortListFunc(sortFunctionFactory, specLegend);
+      sortLegendList = sortLegendListFunc(sortFunctionFactory, specLegend);
     }
 
     return {
       ...series,
-      data: sortList(series.data
+      data: sortLegendList(series.data
           .filter(itsSet))
         .map(datum => ({
           ...datum,

--- a/client/src/components/charts/PolarAreaChart.jsx
+++ b/client/src/components/charts/PolarAreaChart.jsx
@@ -8,7 +8,7 @@ import { Portal } from 'react-portal';
 import merge from 'lodash/merge';
 import itsSet from 'its-set';
 
-import { sortListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from './LegendsSortable';
+import { sortLegendListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from './LegendsSortable';
 import { round, replaceLabelIfValueEmpty } from '../../utilities/chart';
 import Legend from './Legend';
 import ResponsiveWrapper from '../common/ResponsiveWrapper';
@@ -77,14 +77,14 @@ export default class PieChart extends Component {
     const sortFunctionFactory = sortLegendsFunctionFactory(data);
 
     const specLegend = ensureSpecLegend(this.props.visualisation.spec.legend);
-    let sortList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
+    let sortLegendList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
     if (env.environment.orderedLegend) {
-      sortList = sortListFunc(sortFunctionFactory, specLegend);
+      sortLegendList = sortLegendListFunc(sortFunctionFactory, specLegend);
     }
 
     return {
       ...series,
-      data: sortList(series.data
+      data: sortLegendList(series.data
         .filter(itsSet))
         .map(datum => ({
           ...datum,

--- a/client/src/components/charts/PolarAreaChart.jsx
+++ b/client/src/components/charts/PolarAreaChart.jsx
@@ -8,6 +8,7 @@ import { Portal } from 'react-portal';
 import merge from 'lodash/merge';
 import itsSet from 'its-set';
 
+import { sortListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from './LegendsSortable';
 import { round, replaceLabelIfValueEmpty } from '../../utilities/chart';
 import Legend from './Legend';
 import ResponsiveWrapper from '../common/ResponsiveWrapper';
@@ -46,6 +47,7 @@ export default class PieChart extends Component {
     style: PropTypes.object,
     labelsVisible: PropTypes.bool,
     visualisation: PropTypes.object,
+    env: PropTypes.object.isRequired,
   }
 
   static defaultProps = {
@@ -68,15 +70,22 @@ export default class PieChart extends Component {
   }
 
   getData() {
-    const { data } = this.props;
+    const { data, env } = this.props;
     if (!get(data, 'series[0]')) return false;
 
     const series = merge({}, data.common, data.series[0]);
+    const sortFunctionFactory = sortLegendsFunctionFactory(data);
+
+    const specLegend = ensureSpecLegend(this.props.visualisation.spec.legend);
+    let sortList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
+    if (env.environment.orderedLegend) {
+      sortList = sortListFunc(sortFunctionFactory, specLegend);
+    }
 
     return {
       ...series,
-      data: series.data
-        .filter(itsSet)
+      data: sortList(series.data
+        .filter(itsSet))
         .map(datum => ({
           ...datum,
           value: Math.abs(datum.value),

--- a/client/src/components/charts/bar/SimpleBarChart.jsx
+++ b/client/src/components/charts/bar/SimpleBarChart.jsx
@@ -27,7 +27,7 @@ import ChartLayout from '../ChartLayout';
 import Tooltip from '../Tooltip';
 import { labelFont, MAX_FONT_SIZE, MIN_FONT_SIZE } from '../../../constants/chart';
 import RenderComplete from '../RenderComplete';
-import { sortListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from '../LegendsSortable';
+import { sortLegendListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from '../LegendsSortable';
 
 const getDatum = (data, datum) => data.filter(({ key }) => key === datum)[0];
 
@@ -275,9 +275,9 @@ export default class SimpleBarChart extends Component {
       getLabelFontSize(yAxisLabel, xAxisLabel, MAX_FONT_SIZE, MIN_FONT_SIZE, height, width);
     const sortFunctionFactory = sortLegendsFunctionFactory(series.data);
     const specLegend = ensureSpecLegend(visualisation.spec.legend);
-    let sortList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
+    let sortLegendList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
     if (env.environment.orderedLegend) {
-      sortList = sortListFunc(sortFunctionFactory, specLegend);
+      sortLegendList = sortLegendListFunc(sortFunctionFactory, specLegend);
     }
 
     return (
@@ -294,9 +294,9 @@ export default class SimpleBarChart extends Component {
           <Legend
             horizontal={!horizontal}
             title={get(this.props, 'data.metadata.bucketColumnTitle')}
-            data={sortList(series.data).map(({ key }) => key)}
+            data={sortLegendList(series.data).map(({ key }) => key)}
             colorMapping={
-              sortList(series.data).reduce((acc, { key }, i) => ({
+              sortLegendList(series.data).reduce((acc, { key }, i) => ({
                 ...acc,
                 [key]: this.getColor(key, i, series.data.length),
               }), {})

--- a/client/src/components/charts/bar/SimpleBarChart.jsx
+++ b/client/src/components/charts/bar/SimpleBarChart.jsx
@@ -27,7 +27,7 @@ import ChartLayout from '../ChartLayout';
 import Tooltip from '../Tooltip';
 import { labelFont, MAX_FONT_SIZE, MIN_FONT_SIZE } from '../../../constants/chart';
 import RenderComplete from '../RenderComplete';
-import { sortLegendListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from '../LegendsSortable';
+import { sortLegendListFunc, ensureSpecLegend, noSortFunc } from '../LegendsSortable';
 
 const getDatum = (data, datum) => data.filter(({ key }) => key === datum)[0];
 
@@ -273,13 +273,11 @@ export default class SimpleBarChart extends Component {
     const dataCount = series.data.length;
     const axisLabelFontSize =
       getLabelFontSize(yAxisLabel, xAxisLabel, MAX_FONT_SIZE, MIN_FONT_SIZE, height, width);
-    const sortFunctionFactory = sortLegendsFunctionFactory(series.data);
-    const specLegend = ensureSpecLegend(visualisation.spec.legend);
-    let sortLegendList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
+    let legendSeriesData = series.data;
     if (env.environment.orderedLegend) {
-      sortLegendList = sortLegendListFunc(sortFunctionFactory, specLegend);
+      const specLegend = ensureSpecLegend(visualisation.spec.legend);
+      legendSeriesData = sortLegendListFunc(noSortFunc, specLegend)(series.data);
     }
-
     return (
       <ChartLayout
         style={style}
@@ -294,9 +292,9 @@ export default class SimpleBarChart extends Component {
           <Legend
             horizontal={!horizontal}
             title={get(this.props, 'data.metadata.bucketColumnTitle')}
-            data={sortLegendList(series.data).map(({ key }) => key)}
+            data={legendSeriesData.map(({ key }) => key)}
             colorMapping={
-              sortLegendList(series.data).reduce((acc, { key }, i) => ({
+              legendSeriesData.reduce((acc, { key }, i) => ({
                 ...acc,
                 [key]: this.getColor(key, i, series.data.length),
               }), {})

--- a/client/src/components/charts/bar/SimpleBarChart.jsx
+++ b/client/src/components/charts/bar/SimpleBarChart.jsx
@@ -27,6 +27,7 @@ import ChartLayout from '../ChartLayout';
 import Tooltip from '../Tooltip';
 import { labelFont, MAX_FONT_SIZE, MIN_FONT_SIZE } from '../../../constants/chart';
 import RenderComplete from '../RenderComplete';
+import { sortListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from '../LegendsSortable';
 
 const getDatum = (data, datum) => data.filter(({ key }) => key === datum)[0];
 
@@ -258,6 +259,7 @@ export default class SimpleBarChart extends Component {
       xAxisLabel,
       grid,
       visualisation,
+      env,
     } = this.props;
 
     const { tooltipItems, tooltipVisible, tooltipPosition, hasRendered } = this.state;
@@ -271,6 +273,12 @@ export default class SimpleBarChart extends Component {
     const dataCount = series.data.length;
     const axisLabelFontSize =
       getLabelFontSize(yAxisLabel, xAxisLabel, MAX_FONT_SIZE, MIN_FONT_SIZE, height, width);
+    const sortFunctionFactory = sortLegendsFunctionFactory(series.data);
+    const specLegend = ensureSpecLegend(visualisation.spec.legend);
+    let sortList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
+    if (env.environment.orderedLegend) {
+      sortList = sortListFunc(sortFunctionFactory, specLegend);
+    }
 
     return (
       <ChartLayout
@@ -286,7 +294,7 @@ export default class SimpleBarChart extends Component {
           <Legend
             horizontal={!horizontal}
             title={get(this.props, 'data.metadata.bucketColumnTitle')}
-            data={series.data.map(({ key }) => key)}
+            data={sortList(series.data).map(({ key }) => key)}
             colorMapping={
               series.data.reduce((acc, { key }, i) => ({
                 ...acc,

--- a/client/src/components/charts/bar/SimpleBarChart.jsx
+++ b/client/src/components/charts/bar/SimpleBarChart.jsx
@@ -296,7 +296,7 @@ export default class SimpleBarChart extends Component {
             title={get(this.props, 'data.metadata.bucketColumnTitle')}
             data={sortList(series.data).map(({ key }) => key)}
             colorMapping={
-              series.data.reduce((acc, { key }, i) => ({
+              sortList(series.data).reduce((acc, { key }, i) => ({
                 ...acc,
                 [key]: this.getColor(key, i, series.data.length),
               }), {})

--- a/client/src/components/charts/bar/SimpleBarChartHorizontal.jsx
+++ b/client/src/components/charts/bar/SimpleBarChartHorizontal.jsx
@@ -28,6 +28,7 @@ import ChartLayout from '../ChartLayout';
 import Tooltip from '../Tooltip';
 import { labelFont, MAX_FONT_SIZE, MIN_FONT_SIZE, LABEL_CHAR_WIDTH } from '../../../constants/chart';
 import RenderComplete from '../RenderComplete';
+import { sortListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from '../LegendsSortable';
 
 const getDatum = (data, datum) => data.filter(({ key }) => key === datum)[0];
 
@@ -238,6 +239,7 @@ export default class SimpleBarChart extends Component {
       xAxisLabel,
       grid,
       visualisation,
+      env,
     } = this.props;
 
     const { tooltipItems, tooltipVisible, tooltipPosition, hasRendered } = this.state;
@@ -253,6 +255,12 @@ export default class SimpleBarChart extends Component {
       getLabelFontSize(yAxisLabel, xAxisLabel, MAX_FONT_SIZE, MIN_FONT_SIZE, height, width);
     const maxLabelChars = Math.floor(marginLeft / LABEL_CHAR_WIDTH);
     const labelSizeToAxisLabelSize = Math.ceil(axisLabelFontSize / labelFont.fontSize);
+    const sortFunctionFactory = sortLegendsFunctionFactory(series.data);
+    const specLegend = ensureSpecLegend(visualisation.spec.legend);
+    let sortList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
+    if (env.environment.orderedLegend) {
+      sortList = sortListFunc(sortFunctionFactory, specLegend);
+    }
 
     return (
       <ChartLayout
@@ -267,7 +275,7 @@ export default class SimpleBarChart extends Component {
           <Legend
             horizontal={!horizontal}
             title={get(this.props, 'data.metadata.bucketColumnTitle')}
-            data={series.data.map(({ key }) => key)}
+            data={sortList(series.data).map(({ key }) => key)}
             colorMapping={
               series.data.reduce((acc, { key }, i) => ({
                 ...acc,

--- a/client/src/components/charts/bar/SimpleBarChartHorizontal.jsx
+++ b/client/src/components/charts/bar/SimpleBarChartHorizontal.jsx
@@ -28,7 +28,7 @@ import ChartLayout from '../ChartLayout';
 import Tooltip from '../Tooltip';
 import { labelFont, MAX_FONT_SIZE, MIN_FONT_SIZE, LABEL_CHAR_WIDTH } from '../../../constants/chart';
 import RenderComplete from '../RenderComplete';
-import { sortListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from '../LegendsSortable';
+import { sortLegendListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from '../LegendsSortable';
 
 const getDatum = (data, datum) => data.filter(({ key }) => key === datum)[0];
 
@@ -257,9 +257,9 @@ export default class SimpleBarChart extends Component {
     const labelSizeToAxisLabelSize = Math.ceil(axisLabelFontSize / labelFont.fontSize);
     const sortFunctionFactory = sortLegendsFunctionFactory(series.data);
     const specLegend = ensureSpecLegend(visualisation.spec.legend);
-    let sortList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
+    let sortLegendList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
     if (env.environment.orderedLegend) {
-      sortList = sortListFunc(sortFunctionFactory, specLegend);
+      sortLegendList = sortLegendListFunc(sortFunctionFactory, specLegend);
     }
 
     return (
@@ -275,9 +275,9 @@ export default class SimpleBarChart extends Component {
           <Legend
             horizontal={!horizontal}
             title={get(this.props, 'data.metadata.bucketColumnTitle')}
-            data={sortList(series.data).map(({ key }) => key)}
+            data={sortLegendList(series.data).map(({ key }) => key)}
             colorMapping={
-              sortList(series.data).reduce((acc, { key }, i) => ({
+              sortLegendList(series.data).reduce((acc, { key }, i) => ({
                 ...acc,
                 [key]: this.getColor(key, i, series.data.length),
               }), {})

--- a/client/src/components/charts/bar/SimpleBarChartHorizontal.jsx
+++ b/client/src/components/charts/bar/SimpleBarChartHorizontal.jsx
@@ -28,7 +28,7 @@ import ChartLayout from '../ChartLayout';
 import Tooltip from '../Tooltip';
 import { labelFont, MAX_FONT_SIZE, MIN_FONT_SIZE, LABEL_CHAR_WIDTH } from '../../../constants/chart';
 import RenderComplete from '../RenderComplete';
-import { sortLegendListFunc, ensureSpecLegend, sortLegendsFunctionFactory } from '../LegendsSortable';
+import { sortLegendListFunc, ensureSpecLegend, noSortFunc } from '../LegendsSortable';
 
 const getDatum = (data, datum) => data.filter(({ key }) => key === datum)[0];
 
@@ -255,11 +255,10 @@ export default class SimpleBarChart extends Component {
       getLabelFontSize(yAxisLabel, xAxisLabel, MAX_FONT_SIZE, MIN_FONT_SIZE, height, width);
     const maxLabelChars = Math.floor(marginLeft / LABEL_CHAR_WIDTH);
     const labelSizeToAxisLabelSize = Math.ceil(axisLabelFontSize / labelFont.fontSize);
-    const sortFunctionFactory = sortLegendsFunctionFactory(series.data);
-    const specLegend = ensureSpecLegend(visualisation.spec.legend);
-    let sortLegendList = list => list.sort((a, b) => sortFunctionFactory(a, b, ({ key }) => key));
+    let legendSeriesData = series.data;
     if (env.environment.orderedLegend) {
-      sortLegendList = sortLegendListFunc(sortFunctionFactory, specLegend);
+      const specLegend = ensureSpecLegend(visualisation.spec.legend);
+      legendSeriesData = sortLegendListFunc(noSortFunc, specLegend)(series.data);
     }
 
     return (
@@ -275,9 +274,9 @@ export default class SimpleBarChart extends Component {
           <Legend
             horizontal={!horizontal}
             title={get(this.props, 'data.metadata.bucketColumnTitle')}
-            data={sortLegendList(series.data).map(({ key }) => key)}
+            data={legendSeriesData.map(({ key }) => key)}
             colorMapping={
-              sortLegendList(series.data).reduce((acc, { key }, i) => ({
+              legendSeriesData.reduce((acc, { key }, i) => ({
                 ...acc,
                 [key]: this.getColor(key, i, series.data.length),
               }), {})

--- a/client/src/components/charts/bar/SimpleBarChartHorizontal.jsx
+++ b/client/src/components/charts/bar/SimpleBarChartHorizontal.jsx
@@ -277,7 +277,7 @@ export default class SimpleBarChart extends Component {
             title={get(this.props, 'data.metadata.bucketColumnTitle')}
             data={sortList(series.data).map(({ key }) => key)}
             colorMapping={
-              series.data.reduce((acc, { key }, i) => ({
+              sortList(series.data).reduce((acc, { key }, i) => ({
                 ...acc,
                 [key]: this.getColor(key, i, series.data.length),
               }), {})

--- a/client/src/components/visualisation/configMenu/BarConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/BarConfigMenu.jsx
@@ -13,6 +13,7 @@ import ButtonRowInput from './ButtonRowInput';
 import ConfigMenuSection from '../../common/ConfigMenu/ConfigMenuSection';
 import ConfigMenuSectionOption from '../../common/ConfigMenu/ConfigMenuSectionOption';
 import { filterColumns, columnSelectOptions, columnSelectSelectedOption } from '../../../utilities/column';
+import { LegendsSortable, resetLegend } from '../../charts/LegendsSortable';
 
 const getColumnTitle = (columnName, columnOptions) =>
   get(columnOptions.find(obj => obj.value === columnName), 'title');
@@ -115,6 +116,8 @@ class BarConfigMenu extends Component {
       onChangeSpec,
       columnOptions,
       aggregationOptions,
+      env,
+      intl,
     } = this.props;
     const spec = visualisation.spec;
     const seriesColumnOptions = columnOptions.filter(c => c.value !== spec.metricColumnY);
@@ -162,6 +165,8 @@ class BarConfigMenu extends Component {
     />) : '';
     const columnsBucketColumn = filterColumns(columnOptions, ['number', 'text', 'option']);
     const columnsMetricColumn = filterColumns(columnOptions, ['number']);
+    const specLegend = spec.legend || {};
+
     return (
       <div>
         <ConfigMenuSection
@@ -218,6 +223,32 @@ class BarConfigMenu extends Component {
                 spec={spec}
                 onChangeSpec={value => handleChangeSpec(value, spec, onChangeSpec, columnOptions)}
               />
+              {Boolean(env.environment.orderedLegend) && (
+                <div style={{ marginBottom: '20px' }}>
+                  <ButtonRowInput
+                    labelClass="label"
+                    options={[{
+                      label: <FormattedMessage id="legend_order_auto_mode" />,
+                      value: 'auto',
+                    }, {
+                      label: <FormattedMessage id="legend_order_custom_mode" />,
+                      value: 'custom',
+                    }]}
+                    selected={get(spec, 'legend.order.mode') || 'auto'}
+                    label={intl.formatMessage({ id: 'legend_category_order' })}
+                    onChange={(val) => {
+                      const legend = resetLegend(specLegend, visualisation, val);
+                      onChangeSpec({ legend });
+                    }}
+                    buttonSpacing="0"
+                  />
+                  <LegendsSortable
+                    onChangeSpec={onChangeSpec}
+                    visualisation={visualisation}
+                    colors={spec.colors}
+                    specLegend={specLegend}
+                  />
+                </div>)}
               <ToggleInput
                 name="splitBucket"
                 type="checkbox"

--- a/client/src/components/visualisation/configMenu/BarConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/BarConfigMenu.jsx
@@ -223,32 +223,45 @@ class BarConfigMenu extends Component {
                 spec={spec}
                 onChangeSpec={value => handleChangeSpec(value, spec, onChangeSpec, columnOptions)}
               />
-              {Boolean(env.environment.orderedLegend) && (
-                <div style={{ marginBottom: '20px' }}>
-                  <ButtonRowInput
-                    labelClass="label"
-                    options={[{
-                      label: <FormattedMessage id="legend_order_auto_mode" />,
-                      value: 'auto',
-                    }, {
-                      label: <FormattedMessage id="legend_order_custom_mode" />,
-                      value: 'custom',
-                    }]}
-                    selected={get(spec, 'legend.order.mode') || 'auto'}
-                    label={intl.formatMessage({ id: 'legend_category_order' })}
-                    onChange={(val) => {
-                      const legend = resetLegend(specLegend, visualisation, val);
-                      onChangeSpec({ legend });
-                    }}
-                    buttonSpacing="0"
-                  />
-                  <LegendsSortable
-                    onChangeSpec={onChangeSpec}
-                    visualisation={visualisation}
-                    colors={spec.colors}
-                    specLegend={specLegend}
-                  />
-                </div>)}
+              <div>
+                <ToggleInput
+                  name="showLegend"
+                  type="checkbox"
+                  labelId="show_legend"
+                  className="InputGroup"
+                  checked={Boolean(spec.showLegend)}
+                  onChange={val => onChangeSpec({
+                    showLegend: val,
+                  })}
+                />
+                {Boolean(spec.showLegend) && Boolean(env.environment.orderedLegend) && (
+                  <div style={{ marginBottom: '20px' }}>
+                    <ButtonRowInput
+                      labelClass="label"
+                      options={[{
+                        label: <FormattedMessage id="legend_order_auto_mode" />,
+                        value: 'auto',
+                      }, {
+                        label: <FormattedMessage id="legend_order_custom_mode" />,
+                        value: 'custom',
+                      }]}
+                      selected={get(spec, 'legend.order.mode') || 'auto'}
+                      label={intl.formatMessage({ id: 'legend_category_order' })}
+                      onChange={(val) => {
+                        const legend = resetLegend(specLegend, visualisation, val);
+                        onChangeSpec({ legend });
+                      }}
+                      buttonSpacing="0"
+                    />
+                    <LegendsSortable
+                      onChangeSpec={onChangeSpec}
+                      visualisation={visualisation}
+                      colors={spec.colors}
+                      specLegend={specLegend}
+                    />
+                  </div>)}
+              </div>
+
               <ToggleInput
                 name="splitBucket"
                 type="checkbox"

--- a/client/src/components/visualisation/configMenu/BubbleConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/BubbleConfigMenu.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 
 import ConfigMenuSectionOptionSelect from '../../common/ConfigMenu/ConfigMenuSectionOptionSelect';
 import ConfigMenuSectionOptionText from '../../common/ConfigMenu/ConfigMenuSectionOptionText';
 import ToggleInput from '../../common/ToggleInput';
 import { filterColumns } from '../../../utilities/column';
 import ConfigMenuSection from '../../common/ConfigMenu/ConfigMenuSection';
+import ButtonRowInput from './ButtonRowInput';
+import { LegendsSortable, resetLegend } from '../../charts/LegendsSortable';
 
 const getColumnTitle = (columnName, columnOptions) =>
   get(columnOptions.find(obj => obj.value === columnName), 'title');
@@ -77,13 +79,14 @@ function BubbleConfigMenu(props) {
     columnOptions,
     aggregationOptions,
     intl,
+    env,
   } = props;
   const spec = visualisation.spec;
 
   const onChangeSpec = (data) => {
     props.onChangeSpec({ ...data, version: 2 });
   };
-
+  const specLegend = spec.legend || {};
   return (
     <div>
 
@@ -151,6 +154,33 @@ function BubbleConfigMenu(props) {
                 showLegend: val,
               })}
             />
+            {Boolean(spec.showLegend) && Boolean(env.environment.orderedLegend) && (
+              <div style={{ marginBottom: '20px' }} >
+                <ButtonRowInput
+                  labelClass="label"
+                  options={[{
+                    label: <FormattedMessage id="legend_order_auto_mode" />,
+                    value: 'auto',
+                  }, {
+                    label: <FormattedMessage id="legend_order_custom_mode" />,
+                    value: 'custom',
+                  }]}
+                  selected={get(spec, 'legend.order.mode') || 'auto'}
+                  label={intl.formatMessage({ id: 'legend_category_order' })}
+                  onChange={(val) => {
+                    const legend = resetLegend(specLegend, visualisation, val);
+                    onChangeSpec({ legend });
+                  }}
+                  buttonSpacing="0"
+                />
+                <LegendsSortable
+                  onChangeSpec={onChangeSpec}
+                  visualisation={visualisation}
+                  colors={spec.colors}
+                  specLegend={specLegend}
+                />
+              </div>)}
+
             {Boolean(spec.showLegend) && (
               <div>
                 <ConfigMenuSectionOptionText

--- a/client/src/components/visualisation/configMenu/ScatterConfigMenu.jsx
+++ b/client/src/components/visualisation/configMenu/ScatterConfigMenu.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import itsSet from 'its-set';
 import { get } from 'lodash';
 
@@ -9,6 +9,8 @@ import ConfigMenuSection from '../../common/ConfigMenu/ConfigMenuSection';
 import ToggleInput from '../../common/ToggleInput';
 import ConfigMenuSectionOptionText from '../../common/ConfigMenu/ConfigMenuSectionOptionText';
 import ConfigMenuSectionOptionSelect from '../../common/ConfigMenu/ConfigMenuSectionOptionSelect';
+import ButtonRowInput from './ButtonRowInput';
+import { LegendsSortable, resetLegend } from '../../charts/LegendsSortable';
 
 const getColumnTitle = (columnName, columnOptions) =>
   get(columnOptions.find(obj => obj.value === columnName), 'title');
@@ -46,6 +48,8 @@ function ScatterConfigMenu(props) {
     visualisation,
     columnOptions,
     aggregationOptions,
+    env,
+    intl,
   } = props;
 
   const spec = visualisation.spec;
@@ -53,7 +57,7 @@ function ScatterConfigMenu(props) {
   const onChangeSpec = (data) => {
     props.onChangeSpec({ ...data, version: 2 });
   };
-
+  const specLegend = spec.legend || {};
   return (
     <div>
       <ConfigMenuSection
@@ -179,6 +183,32 @@ function ScatterConfigMenu(props) {
                 showLegend: val,
               })}
             />
+            {Boolean(spec.showLegend) && Boolean(env.environment.orderedLegend) && (
+              <div style={{ marginBottom: '20px' }} >
+                <ButtonRowInput
+                  labelClass="label"
+                  options={[{
+                    label: <FormattedMessage id="legend_order_auto_mode" />,
+                    value: 'auto',
+                  }, {
+                    label: <FormattedMessage id="legend_order_custom_mode" />,
+                    value: 'custom',
+                  }]}
+                  selected={get(spec, 'legend.order.mode') || 'auto'}
+                  label={intl.formatMessage({ id: 'legend_category_order' })}
+                  onChange={(val) => {
+                    const legend = resetLegend(specLegend, visualisation, val);
+                    onChangeSpec({ legend });
+                  }}
+                  buttonSpacing="0"
+                />
+                <LegendsSortable
+                  onChangeSpec={onChangeSpec}
+                  visualisation={visualisation}
+                  colors={spec.colors}
+                  specLegend={specLegend}
+                />
+              </div>)}
             {Boolean(spec.showLegend) && (
               <div>
                 <ConfigMenuSectionOptionText


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Add support for the following types:
- Polar chart
- Horizontal Simple Bar
- Vertical Simple Bar
- Bubble chart

Also needs feature flag 'optionColumnType'