### PR TITLE
[#2847] Kaocha test runner available (pt 1)

### DIFF
--- a/backend/bin/kaocha
+++ b/backend/bin/kaocha
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+lein kaocha "$@"

--- a/backend/project.clj
+++ b/backend/project.clj
@@ -67,7 +67,8 @@
   :target-path "target/%s/"
   :aliases {"setup" ["run" "-m" "duct.util.repl/setup"]
             "migrate" ["run" "-m" "dev/migrate"]
-            "seed" ["run" "-m" "dev/seed"]}
+            "seed" ["run" "-m" "dev/seed"]
+            "kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]}
   :test-selectors {:default (and (constantly true)
                                  (complement :functional))
                    :functional :functional
@@ -76,6 +77,13 @@
   :profiles
   {:dev           [:project/dev :profiles/dev]
    :test          [:project/test :profiles/test]
+   :kaocha        {:dependencies [[lambdaisland/kaocha "1.0.669"
+                                   :exclusions [fipp
+                                                mvxcvi/puget
+                                                org.clojure/core.rrb-vector
+                                                org.clojure/java.classpath
+                                                org.clojure/spec.alpha
+                                                org.clojure/tools.reader]]]}
    :uberjar       {:aot :all}
    :profiles/dev  {}
    :profiles/test  {}

--- a/backend/test/akvo/lumen/admin/add_tenant_test.clj
+++ b/backend/test/akvo/lumen/admin/add_tenant_test.clj
@@ -2,7 +2,8 @@
   (:require [akvo.lumen.admin.add-tenant :as at]
             [clojure.test :refer [deftest is testing]]))
 
-(deftest conform-label
+
+(deftest ^:unit conform-label
 
   (testing "Valid"
     (let [valid-label "tenant"]
@@ -41,7 +42,7 @@
                  (at/conform-label "-ao")))))
 
 
-(deftest label
+(deftest ^:unit label
   (testing "Production scheme"
     (is (= "tenant"
            (at/label "https://tenant.akvo-lumen.org"))))

--- a/backend/test/akvo/lumen/auth/api_authorization_test.clj
+++ b/backend/test/akvo/lumen/auth/api_authorization_test.clj
@@ -2,7 +2,7 @@
   (:require [akvo.lumen.auth.api-authorization :as m]
             [clojure.test :refer [deftest testing is]]))
 
-(deftest api-tenant-admin?-test
+(deftest ^:unit api-tenant-admin?-test
   (let [tf (fn [cxt tenant allowed-paths bool]
              (testing cxt
                (is (= bool (m/api-tenant-admin? tenant allowed-paths)))))]

--- a/backend/test/akvo/lumen/auth/jwt_authorization_test.clj
+++ b/backend/test/akvo/lumen/auth/jwt_authorization_test.clj
@@ -35,7 +35,7 @@
 (defn update-auth-roles [o]
   (assoc o :auth-roles (keycloak/claimed-roles (:jwt-claims o))))
 
-(deftest wrap-auth-test
+(deftest ^:unit wrap-auth-test
   (testing "GET / without claims"
     (let [response ((wrap-auth test-handler)
                     (immutant-request :get "/"))]

--- a/backend/test/akvo/lumen/component/caddisfly_test.clj
+++ b/backend/test/akvo/lumen/component/caddisfly_test.clj
@@ -18,7 +18,7 @@
      (->> {:local-schema-uri "./caddisfly/caddisfly-tests-v2.json"}
           (ig/init-key :akvo.lumen.component.caddisfly/local)))))
 
-(deftest component-versions-test
+(deftest ^:unit component-versions-test
   (testing "prod component version"
     (is (= (-> (caddisfly :prod) :schema first val keys set)
            #{:name :uuid :sample :device :brand :model :reagents :results :hasImage})))
@@ -29,7 +29,7 @@
 (defn load-local-file [uri]
   (-> uri io/resource slurp (json/parse-string keyword)))
 
-(deftest upgrading-caddisfly-schema
+(deftest ^:unit upgrading-caddisfly-schema
   (testing "compatibility"
     (let [v1 "./caddisfly/tests-schema.json"
           d1 (c/extract-tests (load-local-file v1))

--- a/backend/test/akvo/lumen/component/hikaricp_test.clj
+++ b/backend/test/akvo/lumen/component/hikaricp_test.clj
@@ -2,10 +2,10 @@
   (:require [clojure.test :refer :all]
             [akvo.lumen.component.hikaricp :as hikaricp]))
 
-(deftest ssl-url-test
+(deftest ^:unit ssl-url-test
   (let [domain "http://domain.com/"
         expected-value (str domain "?arg1=3&sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory")]
-    (is (= expected-value 
+    (is (= expected-value
            (hikaricp/ssl-url
             "http://domain.com/?arg1=3&sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory")))
     (is (= expected-value
@@ -14,5 +14,3 @@
     (is (= "http://domain.com/?sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory"
            (hikaricp/ssl-url
             "http://domain.com/")))))
-
-

--- a/backend/test/akvo/lumen/component/keycloak_test.clj
+++ b/backend/test/akvo/lumen/component/keycloak_test.clj
@@ -21,7 +21,7 @@
 
 (use-fixtures :once fixture)
 
-(deftest keycloak-test
+(deftest ^:functional keycloak-test
   (testing "Jerome (admin) permissions to t1"
     (is (= #{"t1/admin"}
            (p/allowed-paths *keycloak* {:email "jerome@t1.akvolumen.org" :iat (tc/to-date (t/now))}))))

--- a/backend/test/akvo/lumen/component/tenant_manager_test.clj
+++ b/backend/test/akvo/lumen/component/tenant_manager_test.clj
@@ -2,11 +2,9 @@
   (:require [clojure.test :refer :all]
             [akvo.lumen.component.tenant-manager :as tenant-manager]))
 
-(deftest hostname->tenant
+(deftest ^:unit hostname->tenant
   (are [host expected-tenant] (= expected-tenant (tenant-manager/tenant-host host))
     "demo.akvolumen.org" "demo"
     "dark-demo.akvotest.org" "demo"
     "dark-dark-lumen.anything.org" "dark-lumen"
     "water-for-people.sub.sub.subdomain.com" "water-for-people"))
-
-

--- a/backend/test/akvo/lumen/db/tardis_test.clj
+++ b/backend/test/akvo/lumen/db/tardis_test.clj
@@ -10,7 +10,7 @@
 
 (use-fixtures :each system-fixture tenant-conn-fixture)
 
-(deftest tardis-with-alter-table
+(deftest ^:functional tardis-with-alter-table
   (testing "with current data in public schema table, we alter table definition. Functionality keeps the same"
     (is (= '() (get-data *tenant-conn* {:table-name "data_source"})))
     (is (= 1 (insert-data-source *tenant-conn* {})))

--- a/backend/test/akvo/lumen/endpoint/dashboard_test.clj
+++ b/backend/test/akvo/lumen/endpoint/dashboard_test.clj
@@ -56,7 +56,7 @@
 (hugsql/def-db-fns "akvo/lumen/lib/visualisation.sql")
 (hugsql/def-db-fns "akvo/lumen/lib/dashboard.sql")
 
-(deftest dashboard-unit
+(deftest ^:functional dashboard-unit
   (testing "filter-type"
     (is (= (dashboard/filter-type (dashboard-spec "abc123") "text")
            {:entities

--- a/backend/test/akvo/lumen/endpoint/invite_test.clj
+++ b/backend/test/akvo/lumen/endpoint/invite_test.clj
@@ -2,7 +2,7 @@
   (:require [akvo.lumen.endpoint.invite :as invite]
             [clojure.test :refer :all]))
 
-(deftest location
+(deftest ^:unit location
   (testing "Production"
     (is (= "https://example.akvolumen.org"
            (invite/location nil {:server-name "example.akvolumen.org"}))))

--- a/backend/test/akvo/lumen/endpoints_test.clj
+++ b/backend/test/akvo/lumen/endpoints_test.clj
@@ -12,7 +12,7 @@
 (use-fixtures :once (partial system-fixture "endpoints-test.edn")
   tenant-conn-fixture error-tracker-fixture tu/spec-instrument)
 
-(deftest handler-test
+(deftest ^:functional handler-test
   (let [h (:handler (:akvo.lumen.component.handler/handler *system*))]
 
     (testing "/"
@@ -175,7 +175,7 @@
                      (select-keys meta-dataset [:id :name :status :transformations :columns]))))
 
             (let [meta-group-dataset (-> (h (get* (api-url "/datasets" dataset-id "groups")))
-                                   body-kw)]
+                                         body-kw)]
               (is (= {:id dataset-id
                       :name title
                       :status "OK"
@@ -185,7 +185,7 @@
                      (select-keys meta-group-dataset [:id :name :status :transformations :groups]))))
 
             (let [meta-group-dataset (-> (h (get* (api-url "/datasets" dataset-id "group" "main")))
-                                   body-kw)]
+                                         body-kw)]
               (is (= {:status "OK"
                       :columns (map #(assoc % :groupName "main" :groupId "main") commons/dataset-link-columns)}
                      (select-keys meta-group-dataset [:status :columns])))))
@@ -198,7 +198,7 @@
                                    body-kw)]
               (is (= '([3 "B"] [2 "A"]) dataset-sort)))
             (let [dataset-sort (-> (h (get* (api-url "/datasets" dataset-id "sort" "c6" "text") {"order" "value"}))
-                                 body-kw)]
+                                   body-kw)]
               (is (= '([2 "A"] [3 "B"]) dataset-sort)))
             (let [dataset-sort (-> (h (get* (api-url "/datasets" dataset-id "sort" "c2" "number")))
                                    body-kw)]

--- a/backend/test/akvo/lumen/import_test.clj
+++ b/backend/test/akvo/lumen/import_test.clj
@@ -4,12 +4,12 @@
             [clojure.spec.gen.alpha :as gen]
             [clojure.test :refer [deftest testing is]]))
 
-(deftest check-generator
-  (testing "sample-imported-dataset result"    
+(deftest ^:unit check-generator
+  (testing "sample-imported-dataset result"
     (let [{:keys [rows columns]} (i/sample-imported-dataset [:text :number :text :date] 1)]
       (is (= 4 (count columns)))
       (is (= 1 (count rows)))))
-  (testing "sample-imported-dataset with generators "    
+  (testing "sample-imported-dataset with generators "
     (let [{:keys [rows columns]} (i/sample-imported-dataset [[:text #(s/gen #{"2017-12-03T10:15:30.00Z"  })]
                                                              [:number #(s/gen #{1.0})]
                                                              :text :date] 2)]

--- a/backend/test/akvo/lumen/lib/aes_test.clj
+++ b/backend/test/akvo/lumen/lib/aes_test.clj
@@ -2,7 +2,7 @@
   (:require [akvo.lumen.lib.aes :as aes]
             [clojure.test :refer :all]))
 
-(deftest aes
+(deftest ^:unit aes
   (let [secret "secret"
         clear-text "clear-text"]
     (testing "Encryption & decryption round trip"

--- a/backend/test/akvo/lumen/lib/aggregation/bar_test.clj
+++ b/backend/test/akvo/lumen/lib/aggregation/bar_test.clj
@@ -3,7 +3,7 @@
             [clojure.tools.logging :as log]
             [clojure.test :refer :all]))
 
-(deftest subbucket-response-test
+(deftest ^:unit subbucket-response-test
   (let [sql-data [["Agriculture"  145.0 "B" 183.0]
                   ["Agriculture"  38.0 "C" 183.0]
                   ["Education"  52.0 "A" 284.0]
@@ -18,23 +18,23 @@
     (is (= (bar/subbucket-column-response sql-data subbucket-column)
            {:series
 	    [{:key "B",
-	       :label "B",
-	       :data '({:value 145.0} {:value 87.0} {:value 61.0} {:value 46.0})}
-	      {:key "C",
-	       :label "C",
-	       :data '({:value 38.0} {:value 145.0} {:value 0} {:value 107.0})}
-	      {:key "A",
-	       :label "A",
-	       :data '({:value 0} {:value 52.0} {:value 40.0} {:value 60.0})}],
+	      :label "B",
+	      :data '({:value 145.0} {:value 87.0} {:value 61.0} {:value 46.0})}
+	     {:key "C",
+	      :label "C",
+	      :data '({:value 38.0} {:value 145.0} {:value 0} {:value 107.0})}
+	     {:key "A",
+	      :label "A",
+	      :data '({:value 0} {:value 52.0} {:value 40.0} {:value 60.0})}],
 	    :common
 	    {:metadata {:type "text"},
 	     :data
 	     '({:label "Agriculture", :key "Agriculture"}
-	      {:label "Education", :key "Education"}
-	      {:label "Other", :key "Other"}
-	      {:label "WASH", :key "WASH"})}}))))
+	       {:label "Education", :key "Education"}
+	       {:label "Other", :key "Other"}
+	       {:label "WASH", :key "WASH"})}}))))
 
-(deftest metrics-response-test
+(deftest ^:unit metrics-response-test
   (let [sql-data [["Agriculture"  183.0 167.0 167.0]
                   ["Education"  284.0 290.0 290.0]
                   ["Other"  101.0 87.0 87.0]
@@ -42,19 +42,18 @@
         bucket-column {:type "text"}
         metrics-columns [{:title "title 1"} {:title "title 2"}]]
     (is (= (bar/metrics-column-response sql-data bucket-column metrics-columns)
-           {:series	  
-	     [{:key "title 1",
-	       :label "title 1",
-	       :data '({:value 183.0} {:value 284.0} {:value 101.0} {:value 213.0})}
-	      {:key "title 2",
-	       :label "title 2",
-	       :data
-	       '({:value 167.0} {:value 290.0} {:value 87.0} {:value 219.0})}],
-	     :common
-	     {:metadata {:type "text"},
+           {:series
+	    [{:key "title 1",
+	      :label "title 1",
+	      :data '({:value 183.0} {:value 284.0} {:value 101.0} {:value 213.0})}
+	     {:key "title 2",
+	      :label "title 2",
 	      :data
-	      '({:key "Agriculture", :label "Agriculture"}
+	      '({:value 167.0} {:value 290.0} {:value 87.0} {:value 219.0})}],
+	    :common
+	    {:metadata {:type "text"},
+	     :data
+	     '({:key "Agriculture", :label "Agriculture"}
 	       {:key "Education", :label "Education"}
 	       {:key "Other", :label "Other"}
 	       {:key "WASH", :label "WASH"})}}))))
-

--- a/backend/test/akvo/lumen/lib/aggregation/commons_test.clj
+++ b/backend/test/akvo/lumen/lib/aggregation/commons_test.clj
@@ -19,7 +19,7 @@
    [
     {
      ;; geo location layer
-     "layerType" "geo-location", 
+     "layerType" "geo-location",
      "popup" (popup "p"),
      "longitude" nil,
      "pointSize" 3,
@@ -58,7 +58,7 @@
    "version" 1,
    "baseLayer" "street"})
 
-(deftest spec-columns-test
+(deftest ^:unit spec-columns-test
   (let [data
         [{:id "5e8c4554-e6ed-4c75-95b1-3d7d4eaea231",
           :visualisationType "map",
@@ -191,8 +191,8 @@
            "categoryColumn" "c2",
            "categoryTitle" nil}}]
         data (map (partial merge {:datasetId "5e8b13fe-2c7d-4478-b340-f8e0aba9ec2a"
-                              :name "name"
-                              :created 1586172976186
+                                  :name "name"
+                                  :created 1586172976186
                                   :modified 1586250225831}) data)
         expectations [["map" ["c1" "c2" "c3" "c4" "c5" "f1" "f2" "ff1" "ff2" "p1" "p2" "pp1" "pp2"]]
                       ["scatter" ["c1" "c2" "c3" "c4" "c5" "c6"]]
@@ -209,4 +209,3 @@
                             (vec (sort (vec (commons/spec-columns ::s.visualisation/visualisation (walk/keywordize-keys %))))))
                    data)
              expectations)))))
-

--- a/backend/test/akvo/lumen/lib/aggregation/map_test.clj
+++ b/backend/test/akvo/lumen/lib/aggregation/map_test.clj
@@ -4,7 +4,7 @@
             [clojure.walk :as w]
             [clojure.test :refer :all]))
 
-(deftest add-filters-test
+(deftest ^:unit add-filters-test
   (let [filter* {:datasetId "5e3303ab-9eb4-4216-b183-96998701d451"
                  :columns [{:value "Amsterdam", :column "c1", :strategy "is", :operation "keep", :columnType "text"}]}
         filters (w/stringify-keys (:columns filter*))

--- a/backend/test/akvo/lumen/lib/aggregation/scatter_test.clj
+++ b/backend/test/akvo/lumen/lib/aggregation/scatter_test.clj
@@ -3,7 +3,7 @@
             [clojure.tools.logging :as log]
             [clojure.test :refer :all]))
 
-(deftest serie-test
+(deftest ^:unit serie-test
   (let [sql-data [[:a0 :b0 :c0 :d0 :e0] [:a1 :b1 :c1 :d1 :e1]]
         column {:title "c1"
                 :type "text"}]

--- a/backend/test/akvo/lumen/lib/aggregation_test.clj
+++ b/backend/test/akvo/lumen/lib/aggregation_test.clj
@@ -24,7 +24,7 @@
       (is (= tag (or expected-tag ::lib/ok)))
       res)))
 
-(deftest pivot-tests
+(deftest ^:functional pivot-tests
   (let [columns [{:id "c1", :title "A", :type "text"}
                  {:id "c2", :title "B", :type "text"}
                  {:id "c3", :title "C", :type "number"}]
@@ -137,7 +137,7 @@
                 :rows [[]]
                 :metadata {:categoryColumnTitle "A"}}))))))
 
-(deftest pie-tests
+(deftest ^:functional pie-tests
   (let [data {:columns
               [{:id "c1", :title "A", :type "text"}
                {:id "c2", :title "B", :type "text"}],
@@ -169,7 +169,7 @@
                 {:data [{:key "b1", :label "b1"} {:key "b2", :label "b2"}],
                  :metadata {:type "text"}}}))))))
 
-(deftest bar-tests
+(deftest ^:functional bar-tests
   (let [data       {:columns [{:id "c1", :title "A", :type "text"}
                               {:id "c2", :title "B", :type "number"}
                               {:id "c3", :title "C", :type "number"}
@@ -269,7 +269,7 @@
                   {:label "b", :key "b"}
                   {:label "c", :key "c"}]}}))))))
 
-(deftest line-tests
+(deftest ^:functional line-tests
   (let [data {:columns [{:id "c1", :title "A", :type "text"}
                         {:id "c2", :title "B", :type "number"}
                         {:id "c3", :title "C", :type "date"}]
@@ -313,7 +313,7 @@
                     {:timestamp 1549152000000}
                     {:timestamp 1549238400000}]}})))))))
 
-(deftest scatter-tests
+(deftest ^:functional scatter-tests
   (let [data {:columns [{:id "c1", :title "A", :type "text"}
                         {:id "c2", :title "B", :type "number"}
                         {:id "c3", :title "C", :type "date"}]
@@ -353,7 +353,7 @@
                 {:metadata {:type nil, :sampled false},
                  :data [{:label nil :key nil} {:label nil :key nil} {:label nil :key nil} {:label nil :key nil}]}}))))))
 
-(deftest bubble-tests
+(deftest ^:functional bubble-tests
   (let [data {:columns [{:id "c1", :title "A", :type "text"}
                         {:id "c2", :title "B", :type "number"}
                         {:id "c3", :title "C", :type "number"}]

--- a/backend/test/akvo/lumen/lib/auth_test.clj
+++ b/backend/test/akvo/lumen/lib/auth_test.clj
@@ -8,7 +8,7 @@
 
 (declare author)
 
-(deftest ids-test
+(deftest ^:unit ids-test
   (testing "visualisation pie payload"
     (let [ds-id "5ca70f7a-3c66-45ac-a546-820dd55e3916"
           v-id "5caaf957-e5eb-47be-a807-65697536fa7e"
@@ -39,106 +39,106 @@
                  {:dashboard-ids #{}, :collection-ids #{}, :dataset-ids #{ds-id}, :visualisation-ids #{v-id}}))))))
   (testing "visualisation map types, could have datasetId(s) in layer collection"
     (let [ds-id  "5cbd79a7-ba3b-4443-8433-2d14639dd269"
-         ds2-id "5ca70f7a-3c66-45ac-a546-820dd55e3916"
-         vis-id "5cbda7e2-ff60-4ab8-87b3-34d60b6f4687"
-         data {:name "vis map name",
-               :visualisationType "map",
-               :type "visualisation",
-               :created 1555933154021,
-               :modified 1555933154021,
-               :author author,
-               :datasetId nil,
-               :spec
-               {:version 1,
-                :baseLayer "street",
-                :layers [{:aggregationMethod "avg",
-                          :popup [],
-                          :filters [],
-                          :layerType "geo-location",
-                          :legend {:title "latitude", :visible true},
-                          :rasterId nil,
-                          :pointSize 3,
-                          :pointColorMapping [],
-                          :longitude nil,
-                          :datasetId ds2-id,
-                          :title "Untitled layer 1",
-                          :geom "d1",
-                          :pointColorColumn "c2",
-                          :latitude nil,
-                          :visible true}
-                         {:aggregationMethod "avg",
-                          :popup [],
-                          :filters [],
-                          :layerType "geo-location",
-                          :legend {:title "latitude", :visible true},
-                          :rasterId nil,
-                          :pointSize 3,
-                          :pointColorMapping [],
-                          :longitude nil,
-                          :datasetId ds-id,
-                          :title "Untitled layer 1",
-                          :geom "d1",
-                          :pointColorColumn "c2",
-                          :latitude nil,
-                          :visible true}]},
-               :status "OK",
-               :id vis-id}]
-     (is (= (auth/ids ::visualisation.s/visualisation data)
-            {:collection-ids #{}, :dashboard-ids #{}, :dataset-ids #{ds-id ds2-id}, :visualisation-ids #{vis-id}}))
-     (is (s/valid? ::visualisation.s/visualisation data))))
+          ds2-id "5ca70f7a-3c66-45ac-a546-820dd55e3916"
+          vis-id "5cbda7e2-ff60-4ab8-87b3-34d60b6f4687"
+          data {:name "vis map name",
+                :visualisationType "map",
+                :type "visualisation",
+                :created 1555933154021,
+                :modified 1555933154021,
+                :author author,
+                :datasetId nil,
+                :spec
+                {:version 1,
+                 :baseLayer "street",
+                 :layers [{:aggregationMethod "avg",
+                           :popup [],
+                           :filters [],
+                           :layerType "geo-location",
+                           :legend {:title "latitude", :visible true},
+                           :rasterId nil,
+                           :pointSize 3,
+                           :pointColorMapping [],
+                           :longitude nil,
+                           :datasetId ds2-id,
+                           :title "Untitled layer 1",
+                           :geom "d1",
+                           :pointColorColumn "c2",
+                           :latitude nil,
+                           :visible true}
+                          {:aggregationMethod "avg",
+                           :popup [],
+                           :filters [],
+                           :layerType "geo-location",
+                           :legend {:title "latitude", :visible true},
+                           :rasterId nil,
+                           :pointSize 3,
+                           :pointColorMapping [],
+                           :longitude nil,
+                           :datasetId ds-id,
+                           :title "Untitled layer 1",
+                           :geom "d1",
+                           :pointColorColumn "c2",
+                           :latitude nil,
+                           :visible true}]},
+                :status "OK",
+                :id vis-id}]
+      (is (= (auth/ids ::visualisation.s/visualisation data)
+             {:collection-ids #{}, :dashboard-ids #{}, :dataset-ids #{ds-id ds2-id}, :visualisation-ids #{vis-id}}))
+      (is (s/valid? ::visualisation.s/visualisation data))))
   (testing "testing vis map layers"
     (let [ds-id "5cac541e-ba6c-4c78-969a-c55d624fc5ba"
-         data [{:aggregationMethod "avg",
-                :popup [],
-                :filters [],
-                :layerType "geo-location",
-                :legend {:title "latitude", :visible true},
-                :rasterId nil,
-                :pointSize 3,
-                :pointColorMapping [],
-                :longitude nil,
-                :datasetId ds-id,
-                :title "go1",
-                :geom "d1",
-                :pointColorColumn "c2",
-                :latitude nil,
-                :visible true}
-               {:aggregationMethod "avg",
-                :popup [],
-                :filters [],
-                :layerType "raster",
-                :legend {:title nil, :visible true},
-                :rasterId "5cac54fa-d93a-45d3-be6c-356f85559a9d",
-                :pointSize 3,
-                :pointColorMapping [],
-                :longitude nil,
-                :datasetId nil,
-                :title "Untitled layer 2",
-                :geom nil,
-                :pointColorColumn nil,
-                :latitude nil,
-                :visible true}
-               {:aggregationMethod "avg",
-                :popup [{:column "c2"}],
-                :filters [],
-                :layerType "geo-location",
-                :legend {:title "latitude", :visible true},
-                :rasterId nil,
-                :pointSize 3,
-                :pointColorMapping [],
-                :longitude nil,
-                :datasetId ds-id,
-                :title "Untitled layer 3",
-                :geom "d1",
-                :pointColorColumn "c2",
-                :latitude nil,
-                :visible true}]]
-     (is (= (auth/ids ::visualisation.maps.s/layers data)
-            {:dataset-ids #{ds-id},
-             :dashboard-ids #{}
-             :visualisation-ids #{},
-             :collection-ids #{}}))
-     (is (s/valid? ::visualisation.maps.s/layers data)))))
+          data [{:aggregationMethod "avg",
+                 :popup [],
+                 :filters [],
+                 :layerType "geo-location",
+                 :legend {:title "latitude", :visible true},
+                 :rasterId nil,
+                 :pointSize 3,
+                 :pointColorMapping [],
+                 :longitude nil,
+                 :datasetId ds-id,
+                 :title "go1",
+                 :geom "d1",
+                 :pointColorColumn "c2",
+                 :latitude nil,
+                 :visible true}
+                {:aggregationMethod "avg",
+                 :popup [],
+                 :filters [],
+                 :layerType "raster",
+                 :legend {:title nil, :visible true},
+                 :rasterId "5cac54fa-d93a-45d3-be6c-356f85559a9d",
+                 :pointSize 3,
+                 :pointColorMapping [],
+                 :longitude nil,
+                 :datasetId nil,
+                 :title "Untitled layer 2",
+                 :geom nil,
+                 :pointColorColumn nil,
+                 :latitude nil,
+                 :visible true}
+                {:aggregationMethod "avg",
+                 :popup [{:column "c2"}],
+                 :filters [],
+                 :layerType "geo-location",
+                 :legend {:title "latitude", :visible true},
+                 :rasterId nil,
+                 :pointSize 3,
+                 :pointColorMapping [],
+                 :longitude nil,
+                 :datasetId ds-id,
+                 :title "Untitled layer 3",
+                 :geom "d1",
+                 :pointColorColumn "c2",
+                 :latitude nil,
+                 :visible true}]]
+      (is (= (auth/ids ::visualisation.maps.s/layers data)
+             {:dataset-ids #{ds-id},
+              :dashboard-ids #{}
+              :visualisation-ids #{},
+              :collection-ids #{}}))
+      (is (s/valid? ::visualisation.maps.s/layers data)))))
 
 (def author {:given_name "Jerome",
              :email "jerome@t1.akvolumen.org",

--- a/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
+++ b/backend/test/akvo/lumen/lib/import/clj_data_importer_test.clj
@@ -23,9 +23,9 @@
 
 (use-fixtures :once system-fixture tenant-conn-fixture error-tracker-fixture tu/spec-instrument)
 
-(deftest test-import
+(deftest ^:functional test-import
   (testing "Testing import"
-    (let [dataset-id (import-file *tenant-conn* *error-tracker* 
+    (let [dataset-id (import-file *tenant-conn* *error-tracker*
                                   {:dataset-name "Padded titles"
                                    :kind "clj"
                                    :data (i-c/sample-imported-dataset [:text :number] 2) })
@@ -65,10 +65,10 @@
 
 (deftest ^:functional test-update
   (testing "Testing update"
-    (let [[job dataset] (import-file *tenant-conn* *error-tracker* 
+    (let [[job dataset] (import-file *tenant-conn* *error-tracker*
                                      {:dataset-name "Padded titles"
                                       :kind "clj"
-                                      :data (i-c/sample-imported-dataset [:text :number] 2) 
+                                      :data (i-c/sample-imported-dataset [:text :number] 2)
                                       :with-job? true})
           dataset-id (:dataset_id dataset)
           dataset (dataset-version-by-dataset-id *tenant-conn* {:dataset-id dataset-id
@@ -78,6 +78,6 @@
                            (get-data *tenant-conn*))
           updated-res (update-file *tenant-conn* (:akvo.lumen.component.caddisfly/caddisfly *system*)
                                    *error-tracker* (:dataset-id job) (:data-source-id job)
-                        {:kind "clj"
-                         :data (i-c/sample-imported-dataset [:text :number] 2)})]
+                                   {:kind "clj"
+                                    :data (i-c/sample-imported-dataset [:text :number] 2)})]
       (is (some? updated-res)))))

--- a/backend/test/akvo/lumen/lib/import/common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/common_test.clj
@@ -2,7 +2,7 @@
   (:require [akvo.lumen.lib.import.common :as common]
             [clojure.test :refer :all]))
 
-(deftest extract-first-and-merge-test
+(deftest ^:unit extract-first-and-merge-test
   (testing "extract every first ns-responses into one `main` response"
     (is (= {:main 1, :a 1, :b 3}
            (common/extract-first-and-merge [(with-meta {:main 1} {:ns "main"})

--- a/backend/test/akvo/lumen/lib/import/csv_test.clj
+++ b/backend/test/akvo/lumen/lib/import/csv_test.clj
@@ -71,7 +71,8 @@
       (is (every? trimmable? titles)))))
 
 
-(deftest valid-column-name
+;; This is really a unit test that lives in a functional namespace (due to fixture)
+(deftest ^:functional valid-column-name
   (testing "valid column name"
     (is (not (csv/valid-column-name? "d123123")))
     (is (not (csv/valid-column-name? "c")))

--- a/backend/test/akvo/lumen/lib/import/flow_common_test.clj
+++ b/backend/test/akvo/lumen/lib/import/flow_common_test.clj
@@ -2,7 +2,7 @@
   (:require [akvo.lumen.lib.import.flow-common :as flow-common]
             [clojure.test :refer :all]))
 
-(deftest form-submission-nulls-values
+(deftest ^:unit form-submission-nulls-values
   (testing "flow only send values for questions that are filled"
     (let [groups [{:id "1G"
                    :repeatable true}
@@ -17,7 +17,7 @@
                        "2G" [{"1" "A"
                               "2" "B"}]}]
         (is (= [{"1" "A"
-                 "2" "B"}          
+                 "2" "B"}
                 {"1G1Q" "A"
                  "1G2Q" [{"text" "yes", "code" "1"}]
                  "1G3Q" 36.0}]
@@ -29,7 +29,7 @@
                        "2G" [{"2G1Q" "A"
                               "2G2Q" "B"}]}]
         (is (= [{"2G1Q" "A"
-                 "2G2Q" "B"}          
+                 "2G2Q" "B"}
                 {"1G2Q" [{"text" "yes", "code" "1"}]
                  "1G3Q" 36.0}]
                (flow-common/question-responses groups responses))))

--- a/backend/test/akvo/lumen/lib/multiple_column_test.clj
+++ b/backend/test/akvo/lumen/lib/multiple_column_test.clj
@@ -3,7 +3,7 @@
             [akvo.lumen.component.caddisfly-test :refer (caddisfly)]
             [clojure.test :refer :all]))
 
-(deftest details-test
+(deftest ^:unit details-test
   (testing "get multiple column details"
     (let [multipleType "caddisfly"
           multipleId "0b4a0aaa-f556-4c11-a539-c4626582cca6"]

--- a/backend/test/akvo/lumen/lib/transformation/derive/js_engine_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation/derive/js_engine_test.clj
@@ -6,12 +6,12 @@
    [clojure.test :refer [deftest is]]))
 
 
-(deftest javascript-logic
+(deftest ^:unit javascript-logic
   (is (= (js-engine/eval* "1 + 1") 2))
   (is (= (js-engine/eval* "'akvo'.toUpperCase();") "AKVO"))
   (is (not (js-engine/eval* "NaN === NaN;"))))
 
-(deftest checking-valid-code
+(deftest ^:unit checking-valid-code
   (is (true? (js-engine/evaluable? "true")))
   (is (true? (js-engine/evaluable? "1+2")))
   (is (true? (js-engine/evaluable? "row[\"age\"].reduce((a,b) => (a+b))")))

--- a/backend/test/akvo/lumen/lib/transformation/derive_category_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation/derive_category_test.clj
@@ -4,7 +4,7 @@
             [clojure.test.check.clojure-test :refer (defspec)]
             [clojure.test :refer :all]))
 
-(deftest find-category-test
+(deftest ^:unit find-category-test
   (testing "mapping number type"
     (let [uncategorized-val "no-cat"
           cat-one           "one"
@@ -14,4 +14,3 @@
       (is (= cat-one (derive-category/find-number-cat mappings 1 uncategorized-val)))
       (is (= cat-two (derive-category/find-number-cat mappings 2 uncategorized-val)))
       (is (= uncategorized-val (derive-category/find-number-cat mappings 3 uncategorized-val))))))
-

--- a/backend/test/akvo/lumen/lib/transformation/derive_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation/derive_test.clj
@@ -29,7 +29,7 @@
                   (when-not res (log/error v expression res))
                   res)))
 
-(deftest parse-row-nested-object-references
+(deftest ^:unit parse-row-nested-object-references
   (is (= '(("row[\"g1\"][\"q2\"]" "g1" "q2"))
          (derive/parse-row-object-references  "row[\"g1\"][\"q2\"]")))
   (is (= '(("row['g1']['q2']" "g1" "q2"))
@@ -47,7 +47,7 @@
     (is (= '(("row.g1" "g1"))
            (derive/parse-row-object-references  "row.g1.g2")))))
 
-(deftest parse-row-object-references
+(deftest ^:unit parse-row-object-references
   (is (= '(["row.a" "a"])
          (derive/parse-row-object-references "row.a")))
 
@@ -93,7 +93,7 @@
   (is (= '(["row['e`']" "e`"])
          (derive/parse-row-object-references "row['e`']"))))
 
-(deftest computed
+(deftest ^:unit computed
   (let [t1 {"op" "core/derive"
             "args" {"newColumnTitle" "C"
                     "newColumnType" "text"
@@ -121,7 +121,7 @@
                first
                (get "column-name"))))))
 
-(deftest adapt-code-test
+(deftest ^:unit adapt-code-test
   (let [code_v1 "row.a_1+row.b_1"
         code_v2 "row['a_2']+row['b_2']"
         t1 {"op" "core/derive"
@@ -160,15 +160,15 @@
     (is (= (update-in t1 ["args" "code"] (constantly code_v2))
            (engine/adapt-transformation t1 older-columns new-columns)))))
 
-(deftest row-template-format-test
+(deftest ^:unit row-template-format-test
   (is (= "row['%s']"
          (derive/row-template-format "row.hi")))
   (is (= "row[\"%s\"]"
          (derive/row-template-format "row[\"hi\"]")))
   (is (= "row['%s']"
-       (derive/row-template-format "row['hi']"))))
+         (derive/row-template-format "row['hi']"))))
 
-(deftest column-groups-test
+(deftest ^:unit column-groups-test
   (let [columns (walk/keywordize-keys
                  [{"sort" nil
                    "type" "text"

--- a/backend/test/akvo/lumen/lib/transformation/merge_datasets_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation/merge_datasets_test.clj
@@ -2,7 +2,7 @@
   (:require [akvo.lumen.lib.transformation.merge-datasets :refer :all]
             [clojure.test :refer :all]))
 
-(deftest distinct-columns-test
+(deftest ^:unit distinct-columns-test
   (is (= '("c1" "c2" "c3" "identifier")
          (distinct-columns {:datasetId "uuid",
                             :mergeColumn "identifier",

--- a/backend/test/akvo/lumen/lib/transformation/split_column_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation/split_column_test.clj
@@ -3,27 +3,27 @@
             [akvo.lumen.lib.transformation.split-column :as split-column]
             [clojure.test :refer :all]))
 
-(deftest pattern-test  
+(deftest ^:unit pattern-test
   (is (= {"a" 1} (frequencies (re-seq (re-pattern "a") "a"))))
 
   (is (= {"a" 2, "b" 4} (frequencies (re-seq (re-pattern "a|b") "avalubbbbe")))))
 
-(deftest pattern-analysis-test
+(deftest ^:unit pattern-analysis-test
   (let [res (split-column/pattern-analysis (re-pattern "a|b") ["avalubbbbe" "avalue" "avalaaauasabe"])
         analysis (:analysis res)
         rows (:rows res)]
-    (is (= {"a"	    
-	     {:max-coincidences-in-one-row 7,
-	      :total-row-coincidences 3,
-	      :total-column-coincidences 11},
-	     "b"
-	     {:max-coincidences-in-one-row 4,
-	      :total-row-coincidences 2,
-	      :total-column-coincidences 5}} (:analysis res)))
+    (is (= {"a"
+	    {:max-coincidences-in-one-row 7,
+	     :total-row-coincidences 3,
+	     :total-column-coincidences 11},
+	    "b"
+	    {:max-coincidences-in-one-row 4,
+	     :total-row-coincidences 2,
+	     :total-column-coincidences 5}} (:analysis res)))
     (is (= '["a" "b"] (e.split-column/sort-pattern-analysis-by res :total-row-coincidences)))))
 
 
-(deftest split-test
+(deftest ^:unit split-test
   (is (= '("" "" "") (split-column/split nil (re-pattern "a") 3)))
   (is (= '("" "" "") (split-column/split "" (re-pattern "a") 3)))
   (is (= '("" "" "") (split-column/split "a" (re-pattern "a") 3)))

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -91,7 +91,7 @@
                     vec
                     (update-in [1 "args"] dissoc "parseFormat")))
 
-(deftest op-validation
+(deftest ^:functional op-validation
   (testing "op validation"
     (doseq [op ops]
       (is (engine/valid? op) (str op)))
@@ -858,7 +858,7 @@
         (is (= "New Title" (get after "title")))))))
 
 ;; Regression #808
-(deftest valid-column-names
+(deftest ^:functional valid-column-names
   (is (engine/valid?
        (gen-transformation "core/sort-column"
                            {::transformation.sort-column.s/sortDirection "ASC"

--- a/backend/test/akvo/lumen/lib/update_test.clj
+++ b/backend/test/akvo/lumen/lib/update_test.clj
@@ -4,7 +4,7 @@
             [clojure.data :as d]
             [clojure.string :as str]))
 
-(deftest compatible-columns-errors
+(deftest ^:unit compatible-columns-errors
   (let [dict {"c1" "year", "c2" "dd/mm/yyyy", "c3" "yyyy-mm-dd", "c4" "name"}]
     (let [imported-columns [{:id "c1", :type "number"} {:id "c2", :type "text"} {:id "c3", :type "text"} {:id "c4", :type "text"}]
           columns [{:id "c1", :type "text"} {:id "c2", :type "text"} {:id "c3", :type "text"} {:id "c4", :type "number"}]]
@@ -23,7 +23,7 @@
       (is (= [{:title "name", :id "c4"}]
              (:missed-columns (update/compatible-columns-errors dict imported-columns columns)))))))
 
-(deftest compatible-columns
+(deftest ^:unit compatible-columns
   (let [imported-columns [{"sort" nil,
                            "type" "text",
                            "title" "A",

--- a/backend/test/akvo/lumen/lib/visualisation/maps_test.clj
+++ b/backend/test/akvo/lumen/lib/visualisation/maps_test.clj
@@ -5,13 +5,13 @@
             [akvo.lumen.lib.visualisation.map-config :as map-config]
             [clojure.test :refer :all]))
 
-(deftest hue-color
+(deftest ^:unit hue-color
   (is (= "0" (map-config/color-to-hue "#FF0000" )))
   (is (= "120" (map-config/color-to-hue "#00FF00")))
   (is (= "240" (map-config/color-to-hue "#0000FF")))
   (is (= "282" (map-config/color-to-hue "#7b1fa2"))))
 
-(deftest invalid-location-spec?
+(deftest ^:unit invalid-location-spec?
 
   (let [p util/valid-column-name?]
 

--- a/backend/test/akvo/lumen/migrate_test.clj
+++ b/backend/test/akvo/lumen/migrate_test.clj
@@ -2,10 +2,10 @@
   (:require [clojure.test :refer :all]
             [akvo.lumen.migrate :as migrate]))
 
-(deftest migration-strategy
+(deftest ^:unit migration-strategy
   (testing "happy path migrations"
     (are [applied-already all-migrations expected-result]
-      (= (migrate/ignore-future-migrations applied-already all-migrations) expected-result)
+        (= (migrate/ignore-future-migrations applied-already all-migrations) expected-result)
 
       [:a] [:a] []
       [] [] []
@@ -15,7 +15,7 @@
       [] [:a :b] [[:migrate :a] [:migrate :b]]))
   (testing "Future migrations are ok"
     (are [applied-already all-migrations expected-result]
-      (= (migrate/ignore-future-migrations applied-already all-migrations) expected-result)
+        (= (migrate/ignore-future-migrations applied-already all-migrations) expected-result)
       [:a :b :c] [:a] []))
   (testing "incompatible changes"
     (are [applied-already all-migrations] (thrown? Exception (migrate/ignore-future-migrations applied-already all-migrations))

--- a/backend/test/akvo/lumen/postgres/filter_test.clj
+++ b/backend/test/akvo/lumen/postgres/filter_test.clj
@@ -87,7 +87,7 @@
      :direction nil,
      :columnName "d1"}))
 
-(deftest sql-str
+(deftest ^:unit sql-str
   (testing "filter value not nil"
     (let [filters [{:value "South",
                     :column "c4",

--- a/backend/test/akvo/lumen/util_test.clj
+++ b/backend/test/akvo/lumen/util_test.clj
@@ -2,6 +2,6 @@
   (:require [akvo.lumen.util :as u]
             [clojure.test :refer [deftest is]]))
 
-(deftest split-with-non-stop
+(deftest ^:unit split-with-non-stop
   (is (= [[1 2 2 0 0] [3 10]] (u/split-with-non-stop (partial > 3) [1 2 3 2 0 10 0] )))
   (is (= [[:c] [:a :b :d]] (u/split-with-non-stop (partial = :c) [:a :b :c :d]))))

--- a/backend/tests.edn
+++ b/backend/tests.edn
@@ -1,0 +1,13 @@
+#kaocha/v1
+{:tests
+ [{:id :all
+   :source-paths ["src"]
+   :test-paths ["test"]}
+  {:id :unit
+   :focus-meta [:unit]
+   :source-paths ["src"]
+   :test-paths ["test"]}
+  {:id :functional
+   :focus-meta [:functional]
+   :source-paths ["src"]
+   :test-paths ["test"]}]}


### PR DESCRIPTION
Added new test runner under the kaocha alias. The recommended bin/kaocha
uses this to run tests. In Kaocha (and other test runners) test fixtures loaded with :once will be evaluated even if there is no tests to be executed. This becomes problematic when trying to run unit tests that are mixed with functional tests (marked with meta data). Then the functional fixture would get evaled even if there was no tests to be run. Hence all unit tests are marked with meta data to allow focusing test runs. Further improvements would be to seperate unit and functional tests into different directories.

To run unit tests issue 
```
bin/kaocha :unit
```

This PR does not change any existing functionality but future build system changes will use this.
