### PR TITLE
[#2865] -  stop data groups from auto-selecting metadata

### DIFF
--- a/client/src/containers/Dataset.jsx
+++ b/client/src/containers/Dataset.jsx
@@ -164,8 +164,6 @@ function Dataset(props) {
       if (currentGroup && currentGroup.get('groupId') === groupId) {
         resolve();
       } else {
-        changeCurrentGroup(null);
-
         api
           .get(`/api/datasets/${datasetId}/group/${groupId}`)
           .then((response) => {


### PR DESCRIPTION
When other groups are clicked, stop the selecting metadata

- [ ] **Update release notes if necessary**
