### PR TITLE
[#2861] Add transformation "created" timestamp

### DIFF
--- a/backend/specs/akvo/lumen/specs/import/column.clj
+++ b/backend/specs/akvo/lumen/specs/import/column.clj
@@ -1,16 +1,16 @@
 (ns akvo.lumen.specs.import.column
-  (:require [akvo.lumen.specs :as lumen.s]
-            [akvo.lumen.specs.import.values :as v]
-            [akvo.lumen.util :refer (squuid)]
-            [clj-time.coerce :as tcc]
-            [clj-time.core :as tc]
-            [clojure.spec.alpha :as s]
-            [clojure.spec.gen.alpha :as gen]
-            [clojure.string :as string]
-            [clojure.test.check.generators :as tgen]
-            [clojure.tools.logging :as log])
-  (:import [akvo.lumen.postgres Geoshape Geopoint]
-           [java.time Instant]))
+     (:require [akvo.lumen.specs :as lumen.s]
+               [akvo.lumen.specs.import.values :as v]
+               [akvo.lumen.util :refer (squuid)]
+               [clj-time.coerce :as tcc]
+               [clj-time.core :as tc]
+               [clojure.spec.alpha :as s]
+               [clojure.spec.gen.alpha :as gen]
+               [clojure.string :as string]
+               [clojure.test.check.generators :as tgen]
+               [clojure.tools.logging :as log])
+     (:import [akvo.lumen.postgres Geoshape Geopoint]
+              [java.time Instant]))
 
 (create-ns  'akvo.lumen.specs.import.column.text)
 (create-ns  'akvo.lumen.specs.import.column.number)
@@ -98,33 +98,8 @@
 
 (s/def ::c.number/value double?)
 
-(def year-gen (tgen/choose 1976 2018))
-
-(def month-gen (tgen/choose 1 12))
-
-(def day-gen (tgen/choose 1 31))
-
-(def date-gen (tgen/such-that (fn [t]
-                                (try
-                                  (apply tc/date-time t)
-                                  (catch Exception e false)))
-                              (tgen/tuple year-gen month-gen day-gen)))
-
-(def instant-gen (tgen/fmap (fn [e] (Instant/ofEpochMilli (tcc/to-long (apply tc/date-time e)))) date-gen))
-
-(gen/sample date-gen 10)
-
-(gen/sample instant-gen 10)
-
-(def false-gen (gen/return false))
-
-(def text-year-gen (tgen/fmap str year-gen))
-
-(defn date-format-gen [fun] (tgen/fmap fun date-gen))
-
-(gen/sample (date-format-gen (fn [[y _ _]] (str y))) 10)
-
-(s/def ::c.date/value (s/with-gen #(instance? Instant %) (fn [] instant-gen)))
+(s/def ::c.date/value (s/with-gen #(instance? Instant %)
+                        (fn [] lumen.s/instant-gen)))
 
 (lumen.s/sample ::c.date/value)
 

--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -11,7 +11,8 @@
             [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
             [clojure.string :as string]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log])
+  (:import [java.time Instant]))
 
 (def columnName? string?)
 
@@ -29,6 +30,8 @@
 
 (create-ns 'akvo.lumen.specs.transformation.engine)
 (alias 'transformation.engine.s 'akvo.lumen.specs.transformation.engine)
+
+(s/def ::transformation.engine.s/created (s/with-gen #(instance? Instant %) (fn [] lumen.s/instant-gen)))
 
 (s/def ::transformation.engine.s/onError #{"leave-empty" "fail" "delete-row" "default-value"})
 
@@ -63,11 +66,17 @@
 (s/def ::transformation.delete-column/args
   (s/keys :req-un [::db.dsv.column.s/columnName]))
 
+
+(s/def ::transformation.delete-column/args
+  (s/keys :req-un [::db.dsv.column.s/columnName]))
+
+
 (defmethod op-spec "core/delete-column"  [_]
   (s/keys
    :req-un [::transformation.delete-column/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 
 (create-ns  'akvo.lumen.specs.transformation.change-datatype)
@@ -87,7 +96,8 @@
   (s/keys
    :req-un [::transformation.change-datatype/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 (create-ns  'akvo.lumen.specs.transformation.combine)
 (alias 'transformation.combine 'akvo.lumen.specs.transformation.combine)
@@ -106,7 +116,8 @@
   (s/keys
    :req-un [::transformation.combine/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 
 (create-ns  'akvo.lumen.specs.transformation.derive)
@@ -127,7 +138,8 @@
   (s/keys
    :req-un [::transformation.derive/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 
 (create-ns  'akvo.lumen.specs.transformation.filter-column)
@@ -147,7 +159,8 @@
   (s/keys
    :req-un [::transformation.filter-column/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 
 (create-ns  'akvo.lumen.specs.transformation.generate-geopoints)
@@ -167,7 +180,8 @@
   (s/keys
    :req-un [::transformation.generate-geopoints/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 (create-ns  'akvo.lumen.specs.transformation.merge-datasets)
 (alias 'transformation.merge-datasets 'akvo.lumen.specs.transformation.merge-datasets)
@@ -315,7 +329,8 @@
   (s/keys
    :req-un [::transformation.extract-multiple/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 
 (create-ns  'akvo.lumen.specs.transformation.rename-column)
@@ -332,7 +347,8 @@
   (s/keys
    :req-un [::transformation.rename-column/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 
 
@@ -386,7 +402,8 @@
   (s/keys
    :req-un [::transformation.sort-column/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 (create-ns  'akvo.lumen.specs.transformation.remove-sort)
 (alias 'transformation.remove-sort 'akvo.lumen.specs.transformation.remove-sort)
@@ -400,7 +417,8 @@
   (s/keys
    :req-un [::transformation.remove-sort/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 (create-ns  'akvo.lumen.specs.transformation.split-column)
 (alias 'transformation.split-column 'akvo.lumen.specs.transformation.split-column)
@@ -421,7 +439,8 @@
   (s/keys
    :req-un [::transformation.split-column/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 (create-ns  'akvo.lumen.specs.transformation.trim)
 (alias 'transformation.trim 'akvo.lumen.specs.transformation.trim)
@@ -433,7 +452,8 @@
   (s/keys
    :req-un [::transformation.trim/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 (create-ns  'akvo.lumen.specs.transformation.to-lowercase)
 (alias 'transformation.to-lowercase 'akvo.lumen.specs.transformation.to-lowercase)
@@ -445,7 +465,8 @@
   (s/keys
    :req-un [::transformation.to-lowercase/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 (create-ns  'akvo.lumen.specs.transformation.to-uppercase)
 (alias 'transformation.to-uppercase 'akvo.lumen.specs.transformation.to-uppercase)
@@ -457,7 +478,8 @@
   (s/keys
    :req-un [::transformation.to-uppercase/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 (create-ns  'akvo.lumen.specs.transformation.to-titlecase)
 (alias 'transformation.to-titlecase 'akvo.lumen.specs.transformation.to-titlecase)
@@ -469,7 +491,8 @@
   (s/keys
    :req-un [::transformation.to-titlecase/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 (create-ns  'akvo.lumen.specs.transformation.trim-doublespace)
 (alias 'transformation.trim-doublespace 'akvo.lumen.specs.transformation.trim-doublespace)
@@ -481,7 +504,8 @@
   (s/keys
    :req-un [::transformation.trim-doublespace/args
             ::transformation.engine.s/onError
-            ::transformation.engine.s/op]))
+            ::transformation.engine.s/op]
+   :opt-un [::transformation.engine.s/created]))
 
 (create-ns  'akvo.lumen.specs.dataset-version.transformation)
 (alias 'db.dsv.transformation 'akvo.lumen.specs.dataset-version.transformation)

--- a/backend/src/akvo/lumen/lib/transformation/engine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/engine.clj
@@ -6,7 +6,8 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [clojure.walk :as w]))
+            [clojure.walk :as w])
+  (:import [java.time Instant]))
 
 (defmulti columns-used
   (fn [applied-transformation columns]
@@ -162,7 +163,7 @@
                                     :transformations (w/keywordize-keys
                                                       (conj (vec (:transformations dataset-version))
                                                             (assoc transformation
-                                                                   "created" (System/currentTimeMillis)
+                                                                   "created" (Instant/ofEpochMilli (System/currentTimeMillis))
                                                                    "changedColumns" (diff-columns previous-columns
                                                                                                   columns))))
                                     :columns (w/keywordize-keys columns)}]

--- a/backend/src/akvo/lumen/lib/transformation/engine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/engine.clj
@@ -162,6 +162,7 @@
                                     :transformations (w/keywordize-keys
                                                       (conj (vec (:transformations dataset-version))
                                                             (assoc transformation
+                                                                   "created" (System/currentTimeMillis)
                                                                    "changedColumns" (diff-columns previous-columns
                                                                                                   columns))))
                                     :columns (w/keywordize-keys columns)}]

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -27,6 +27,7 @@
             [akvo.lumen.test-utils :refer [update-file import-file at-least-one-true retry-job-execution] :as tu]
             [akvo.lumen.util :refer [conform squuid]]
             [cheshire.core :as json]
+            [cheshire.generate :as ches.generate]
             [clj-time.coerce :as tcc]
             [clj-time.core :as tc]
             [clj-time.format :as timef]
@@ -39,6 +40,8 @@
             [clojure.walk :refer (stringify-keys keywordize-keys)]
             [hugsql.core :as hugsql])
   (:import [akvo.lumen.postgres Geoshape Geopoint]))
+
+(ches.generate/add-encoder java.time.Instant (fn [obj jsonGenerator] (.writeString jsonGenerator (str obj))))
 
 (alias 'import.column.text.s                    'akvo.lumen.specs.import.column.text)
 (alias 'import.column.number.s                    'akvo.lumen.specs.import.column.number)

--- a/backend/test/akvo/lumen/lib/transformation_test.clj
+++ b/backend/test/akvo/lumen/lib/transformation_test.clj
@@ -268,18 +268,18 @@
                                                        ::transformation.engine.s/onError "fail"}
                                 :parseFormat format*)})
         data                (import.s/sample-imported-dataset [:text
-                                                          [:text {::import.column.text.s/value (fn [] (import.column.s/date-format-gen
+                                                          [:text {::import.column.text.s/value (fn [] (lumen.s/date-format-gen
                                                                                          (fn [[y _ _ :as date]]
                                                                                            (str y))))
-                                                                  ::import.values.s/key (fn [] import.column.s/false-gen)}]
-                                                          [:text {::import.column.text.s/value (fn [] (import.column.s/date-format-gen
+                                                                  ::import.values.s/key (fn [] lumen.s/false-gen)}]
+                                                          [:text {::import.column.text.s/value (fn [] (lumen.s/date-format-gen
                                                                                          (fn [[y m d :as date]]
                                                                                            (str d "/" m "/" y))))
-                                                                  ::import.values.s/key (fn [] import.column.s/false-gen)}]
-                                                          [:text {::import.column.text.s/value (fn [] (import.column.s/date-format-gen
+                                                                  ::import.values.s/key (fn [] lumen.s/false-gen)}]
+                                                          [:text {::import.column.text.s/value (fn [] (lumen.s/date-format-gen
                                                                                          (fn [date]
                                                                                            (string/join "-" date))))
-                                                                  ::import.values.s/key (fn [] import.column.s/false-gen)}]]
+                                                                  ::import.values.s/key (fn [] lumen.s/false-gen)}]]
                                                          10)
         years               (map (comp :value second) (:rows data))
         years-slash         (map (comp (partial timef/parse (timef/formatter "dd/MM/yyyy")) :value first next next) (:rows data))


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Having a `created` transformation timestamp we could generate a history transformation list indexed by that value when we'll have transformations spread in N dataset-versions

Relates to #2861 but could be merged directly against the master branch without more dependencies