### PR TITLE
[#2901] - show transformations on CSV datasets

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14797,8 +14797,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14819,14 +14818,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14841,20 +14838,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14971,8 +14965,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14984,7 +14977,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14999,7 +14991,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -15007,14 +14998,12 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -15033,7 +15022,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -15095,8 +15083,7 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -15124,8 +15111,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -15137,7 +15123,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -15215,8 +15200,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -15252,7 +15236,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -15272,7 +15255,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -15316,14 +15298,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -15608,8 +15588,7 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -15630,8 +15609,7 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",

--- a/client/src/components/dataset/DatasetTableV2.jsx
+++ b/client/src/components/dataset/DatasetTableV2.jsx
@@ -80,6 +80,7 @@ function DatasetTable(props) {
     });
   };
 
+  // handle intro
   useEffect(() => {
     if (window.localStorage.getItem('done-intro')) {
       return undefined;
@@ -131,10 +132,10 @@ function DatasetTable(props) {
       ],
     });
 
-    const datasetHasQuestionGroups = props.groups && !props.groups.get('main');
+    const datasetHasGroups = props.groups && props.groups.size > 1;
     if (
       isMounted.current &&
-      (props.datasetGroupsAvailable && datasetHasQuestionGroups) &&
+      (props.datasetGroupsAvailable && datasetHasGroups) &&
       (sidebarProps || {}).type === 'groupsList') {
       intro.start();
     }
@@ -144,6 +145,7 @@ function DatasetTable(props) {
     };
   }, [props.datasetGroupsAvailable, props.groups, isMounted.current, sidebarProps]);
 
+  // handle resize
   useEffect(() => {
     if (isMounted.current) {
       handleResize();
@@ -155,19 +157,15 @@ function DatasetTable(props) {
     };
   }, [isMounted.current, props.groupAvailable]);
 
-  useEffect(() => {
-    const datasetHasQuestionGroups = props.groups && !props.groups.get('main');
-    if (props.datasetGroupsAvailable && datasetHasQuestionGroups) {
-      handleGroupsSidebar();
-    }
-  }, []);
-
+  // handle group sidebar
   useEffect(() => {
     if (isMounted.current) {
-      const datasetHasQuestionGroups = props.groups && !props.groups.get('main');
+      const datasetHasGroups = props.groups && props.groups.size > 1;
 
-      if (props.datasetGroupsAvailable && datasetHasQuestionGroups) {
+      if (props.datasetGroupsAvailable && datasetHasGroups) {
         handleGroupsSidebar();
+      } else if (sidebarProps && sidebarProps.type === 'groupsList') {
+        hideSidebar();
       }
     } else {
       isMounted.current = true;
@@ -486,7 +484,7 @@ function DatasetTable(props) {
               )}
             </div>
 
-            {!sidebarProps && !props.groups.get('main') && (
+            {!sidebarProps && props.groups.size > 1 && (
               <div className="toggle-groups">
                 <span
                   onClick={() => handleGroupsSidebar()}

--- a/client/src/containers/Dataset.jsx
+++ b/client/src/containers/Dataset.jsx
@@ -302,7 +302,7 @@ function Dataset(props) {
             group={currentGroup}
             columns={currentGroup ? currentGroup.get('columns') : null}
             rows={currentGroup ? currentGroup.get('rows') : null}
-            groups={dataset.get('groups')}
+            groups={dataset.get('groups') ? dataset.get('groups').filter(group => group.size) : null}
             Header={DatasetHeader}
             headerProps={{
               onShowDatasetSettings,

--- a/client/src/utilities/dataset.js
+++ b/client/src/utilities/dataset.js
@@ -23,23 +23,22 @@ export const getDatasetGroups = (groups, datasetGroupsAvailable) => {
   const groupsObject = groups.toJS();
   let groupNames = [];
 
-  // trying to keep metadata at the top
-  // refactor if you can think of a better implementation
-  const withoutMetadata = Object.keys(groupsObject).filter(group => group !== 'metadata');
-
-  groupNames = withoutMetadata
+  // keep metadata at the top
+  groupNames = Object.keys(groupsObject)
     .reduce((acc, curr) => {
       const column = groups.toJS()[curr][0];
-      const isRqg = groups.toJS()[curr].some(col => col.type === 'rqg');
 
       if (column) {
-        acc.push({ id: column.groupId, name: column.groupName, isRqg });
+        acc.push({ id: column.groupId, name: column.groupName, isRqg: false });
       }
 
       return acc;
-    }, []);
+    }, []).sort((x, y) => {
+      if (x.id === 'metadata') return -1;
+      if (y.id === 'metadata') return -1;
 
-  groupNames.unshift({ id: 'metadata', name: 'metadata', isRqg: false });
+      return 0;
+    });
 
   return groupNames;
 };

--- a/client/src/utilities/dataset.js
+++ b/client/src/utilities/dataset.js
@@ -34,8 +34,13 @@ export const getDatasetGroups = (groups, datasetGroupsAvailable) => {
 
       return acc;
     }, []).sort((x, y) => {
-      if (x.id === 'metadata') return -1;
-      if (y.id === 'metadata') return -1;
+      if (x.id === 'metadata') {
+        return -1;
+      }
+
+      if (y.id === 'metadata') {
+        return 1;
+      }
 
       return 0;
     });


### PR DESCRIPTION
When doing transformations on CSV based datasets, show the sidebar when there's a transformation group available and remove it when there's no transformations

- [ ] **Update release notes if necessary**
