### PR TITLE
[#2905] Adopt-schema spec

### DIFF
--- a/backend/specs/akvo/lumen/specs/caddisfly.clj
+++ b/backend/specs/akvo/lumen/specs/caddisfly.clj
@@ -35,6 +35,9 @@
   :ret any?)
 
 
+(s/def ::columns (s/coll-of any?))
+(s/def ::adapted-schema (s/keys :req-un [::hasImage ::columns]))
+
 (s/fdef  lib.multiple-column/adapt-schema
   :args (s/cat :schema ::schema)
-  :ret ::schema)
+  :ret ::adapted-schema)


### PR DESCRIPTION
This PR fixes the return spec by not stating it will return a caddisfly spec but is fairly open with a list of any?'s but is not super stringent. What's returned is {:keys [hasImage :id :name :type]} described at
 https://github.com/akvo/akvo-lumen/blob/9e4aadb28f57fdae55a56b609266056c910f70cf/backend/src/akvo/lumen/lib/multiple_column.clj#L11-L17.
