### PR TITLE
[#2909] Use proper language labels

### DIFF
--- a/client/src/containers/IntlWrapper.jsx
+++ b/client/src/containers/IntlWrapper.jsx
@@ -17,10 +17,10 @@ export const availableLocales = [{
   label: 'English',
   tag: 'en',
 }, {
-  label: 'Espanol',
+  label: 'Español',
   tag: 'es',
 }, {
-  label: 'Francais',
+  label: 'Français',
   tag: 'fr',
 }];
 


### PR DESCRIPTION
Use `Español` and `Français` for language labels.

Closes #2909 