### PR TITLE
[#2940] Use the same image for building and functional tests

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -36,7 +36,7 @@ services:
    image: "eu.gcr.io/${PROJECT_NAME}/lumen-maps:${CI_COMMIT}"
 
  backend-functional-tests:
-   image: akvo/akvo-lumen-backend-dev:20191001.144150.7c1e95e
+   image: akvo/akvo-lumen-backend-dev:20200610.033159.f413ba3
    environment:
      - PGSSLMODE=require
      - PGSSLROOTCERT=/pg-certs/server.crt


### PR DESCRIPTION
The build.sh script uses the image declared in
`docker-compose.override.yml` to run the initial checks.

```
backend_image_version=$(awk -F':' '/backend-dev/ {print $3}' docker-compose.override.yml)
```

If we use a different (outdated) image for functional tests (in
`docker-compose.ci.yml`), we're wasting network and space in CI
environment.


