### PR TITLE
[#2944] Use chart/displayTextForNullValues instead of null

### DIFF
--- a/client/src/components/charts/LegendsSortable.jsx
+++ b/client/src/components/charts/LegendsSortable.jsx
@@ -10,6 +10,7 @@ import get from 'lodash/get';
 import arrayMove from 'array-move';
 
 import { sortAlphabetically, sortChronologically } from '../../utilities/utils';
+import { displayTextForNullValues } from '../../utilities/chart';
 import { palette } from '../../utilities/visualisationColors';
 import LegendShape from './LegendShape';
 
@@ -44,7 +45,7 @@ const getLegends = (specLegend, visualisation, hasSubbucket, noSort) => {
   const legends = noChanged
         ? specLegendsList
         : visLegendsList
-        .map(l => l.key);
+        .map(l => l.key || displayTextForNullValues);
   return noSort ? legends : legends.slice().sort(sortLegendsFunctionFactory(visualisation));
 };
 


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Sometimes backend aggregation series return "null" label series and client needs to adapt this null value to be able to sort it

<img width="825" alt="Screenshot 2020-10-05 at 11 42 48" src="https://user-images.githubusercontent.com/731829/95064443-05955800-0700-11eb-82e4-889fe70cbef1.png">
