### PR TITLE
[#2954] - remove invalid fetchColumn call in dashboard filters

### DIFF
--- a/client/src/components/dashboard/DashboardEditor.jsx
+++ b/client/src/components/dashboard/DashboardEditor.jsx
@@ -324,7 +324,6 @@ class DashboardEditor extends Component {
           style={{ position: 'absolute', right: 0, top: 0, height: '2rem', width: '2rem' }}
           onClick={() => {
             filter.columns.splice(idx, 1);
-            this.props.dispatch(fetchColumn(filter.datasetId, null));
             onFilterChange(filter, true);
           }}
         >


### PR DESCRIPTION
Removing the fetchColumn call when a dashboard filter is removed, because it's being called with a null value

- [ ] **Update release notes if necessary**
