### PR TITLE
[#1098] Setup local-admin using an @akvo.org email address

### DIFF
--- a/backend/dev_helpers/local-admin.sh
+++ b/backend/dev_helpers/local-admin.sh
@@ -82,7 +82,7 @@ cat <<EOF > /tmp/new-user.json
 EOF
 
 email="${1}"
-sed -i "s/xxxxx/${email}/" /tmp/new-user.json
+sed -i".bak" -e "s/xxxxx/${email}/" /tmp/new-user.json
 new_user
 uid=$(user_id "${email}")
 gid=$(group_id)

--- a/backend/dev_helpers/local-admin.sh
+++ b/backend/dev_helpers/local-admin.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -eu
+
+token() {
+    curl --verbose \
+	 --location \
+	 --request POST \
+	 --data "grant_type=password" \
+	 --data "client_id=admin-cli" \
+	 --data "username=admin" \
+	 --data "password=password" \
+	 --url "http://auth.lumen.local:8080/auth/realms/master/protocol/openid-connect/token" \
+	| jq -M -r '.access_token'
+}
+
+group_id() {
+    bearer=$(token)
+    curl --verbose \
+	 --location \
+	 --header "Authorization: Bearer ${bearer}" \
+	 --header "Content-Type: application/json" \
+	 --url "http://auth.lumen.local:8080/auth/admin/realms/akvo/groups" \
+	| jq -M -r '.[0] | recurse(.subGroups[]) | select(.path == "/akvo/lumen/t1/admin") | .id'
+}
+
+user_id() {
+    bearer=$(token)
+    curl --verbose \
+	 --location \
+	 --header "Authorization: Bearer ${bearer}" \
+	 --header "Content-Type: application/json" \
+	 --url "http://auth.lumen.local:8080/auth/admin/realms/akvo/users" \
+	| jq -M -r ".[] | select( .email == \"${1}\" ) | .id"
+}
+
+assign_group() {
+    bearer=$(token)
+    curl --verbose \
+	 --location \
+	 --request PUT \
+	 --header "Authorization: Bearer ${bearer}" \
+	 --header "Content-Type: application/json" \
+	 --url "http://auth.lumen.local:8080/auth/admin/realms/akvo/users/${1}/groups/${2}"
+}
+
+new_user() {
+    bearer=$(token)
+    curl --verbose \
+	 --location \
+	 --request POST \
+	 --header "Authorization: Bearer ${bearer}" \
+	 --header "Content-Type: application/json" \
+	 --data @/tmp/new-user.json \
+	 --url "http://auth.lumen.local:8080/auth/admin/realms/akvo/users"
+}
+
+# main
+
+cat <<EOF > /tmp/new-user.json
+{
+    "access": {
+        "manage": true,
+        "impersonate": true,
+        "mapRoles": true,
+        "view": true,
+        "manageGroupMembership": true
+    },
+    "notBefore": 0,
+    "requiredActions": [],
+    "disableableCredentialTypes": [
+        "password"
+    ],
+    "email": "xxxxx",
+    "lastName": "Admin",
+    "firstName": "Local",
+    "emailVerified": true,
+    "totp": false,
+    "enabled": true,
+    "username": "local-admin"
+}
+EOF
+
+email="${1}"
+sed -i "s/xxxxx/${email}/" /tmp/new-user.json
+new_user
+uid=$(user_id "${email}")
+gid=$(group_id)
+assign_group "${uid}" "${gid}"

--- a/backend/dev_helpers/local-admin.sh
+++ b/backend/dev_helpers/local-admin.sh
@@ -3,7 +3,7 @@
 set -eu
 
 token() {
-    curl --verbose \
+    curl --silent \
 	 --location \
 	 --request POST \
 	 --data "grant_type=password" \
@@ -16,7 +16,7 @@ token() {
 
 group_id() {
     bearer=$(token)
-    curl --verbose \
+    curl --silent \
 	 --location \
 	 --header "Authorization: Bearer ${bearer}" \
 	 --header "Content-Type: application/json" \
@@ -26,7 +26,7 @@ group_id() {
 
 user_id() {
     bearer=$(token)
-    curl --verbose \
+    curl --silent \
 	 --location \
 	 --header "Authorization: Bearer ${bearer}" \
 	 --header "Content-Type: application/json" \
@@ -36,7 +36,7 @@ user_id() {
 
 assign_group() {
     bearer=$(token)
-    curl --verbose \
+    curl --silent \
 	 --location \
 	 --request PUT \
 	 --header "Authorization: Bearer ${bearer}" \
@@ -46,7 +46,7 @@ assign_group() {
 
 new_user() {
     bearer=$(token)
-    curl --verbose \
+    curl --silent \
 	 --location \
 	 --request POST \
 	 --header "Authorization: Bearer ${bearer}" \
@@ -73,7 +73,7 @@ cat <<EOF > /tmp/new-user.json
     ],
     "email": "xxxxx",
     "lastName": "Admin",
-    "firstName": "Local",
+    "firstName": "Akvo",
     "emailVerified": true,
     "totp": false,
     "enabled": true,


### PR DESCRIPTION
The scripts creates a new "Local Admin"  user in Keycloak, with the email address passed as argument. It configures the user to be *admin* of `t1` tenant.

Usage:

      ./backend/dev_helpers/local-admin.sh "<email>"

Example:

    ./backend/dev_helpers/local-admin.sh "bob@akvo.org"
