### PR TITLE
[#2964] Filter isEmpty option column as text type

### DIFF
--- a/backend/src/akvo/lumen/postgres/filter.clj
+++ b/backend/src/akvo/lumen/postgres/filter.clj
@@ -101,7 +101,7 @@
 
 (defmethod filter-sql "isEmpty"
   [{:keys [column operation]}]
-  (if (= (:type column) "text")
+  (if (or (= (:type column) "option") (= (:type column) "text"))
     (format "coalesce(%s, '') %s ''"
             (column :columnName)
             (if (= operation "keep") "=" "<>"))


### PR DESCRIPTION
Option column types are stored as text, so empty value in option column types means "" instead of NULL

Relates #2964 

