### PR TITLE
[#2964] Remove empty option value

### DIFF
--- a/backend/src/akvo/lumen/lib/aggregation/commons.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/commons.clj
@@ -49,7 +49,7 @@
 
 (defn sql-option-bucket-column [bucket-column]
   (if (= "option" (:type bucket-column))
-    (format "unnest(regexp_split_to_array(%1$s,'\\|'))" (:columnName bucket-column))
+    (format "unnest(array_remove(regexp_split_to_array(%1$s,'\\|'), ''))" (:columnName bucket-column))
     (:columnName bucket-column)))
 
 (defn data-groups-sql-template

--- a/backend/src/akvo/lumen/postgres/filter.clj
+++ b/backend/src/akvo/lumen/postgres/filter.clj
@@ -101,7 +101,7 @@
 
 (defmethod filter-sql "isEmpty"
   [{:keys [column operation]}]
-  (if (or (= (:type column) "option") (= (:type column) "text"))
+  (if (= (:type column) "text")
     (format "coalesce(%s, '') %s ''"
             (column :columnName)
             (if (= operation "keep") "=" "<>"))


### PR DESCRIPTION
relates #2964 and https://flowhelp.reamaze.com/admin/conversations/akvolumen-support-request-number-410009-from-irene-at-akvo-dot-org?action=show&controller=admin%2Fconversations&id=akvolumen-support-request-number-410009-from-irene-at-akvo-dot-org

dataset already in akvotest https://lumen.akvotest.org/dataset/5f86cd23-3afd-437b-8536-7546cc5d6c2e 

we can check that there is a option value that has this shape `Options Manual development|Biodiversity monitoring tool development|` 

the changes added in this commit fix this corner data case

PS: reverted this change https://github.com/akvo/akvo-lumen/pull/2966

<img width="1095" alt="Screenshot 2020-10-14 at 18 55 05" src="https://user-images.githubusercontent.com/731829/96020769-cfb64900-0e4e-11eb-84ca-ecdaacfc0853.png">



- [ ] **Update release notes if necessary**
