### PR TITLE
[#2964] Use count(*) instead of count(col_name)

### DIFF
--- a/backend/src/akvo/lumen/lib/aggregation/bar.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/bar.clj
@@ -67,7 +67,8 @@
     (format
      (case aggregation-method
        nil                         "NULL"
-       ("min" "max" "count" "sum") (str aggregation-method  "(%s)")
+       ("min" "max" "sum")         (str aggregation-method  "(%s)")
+       "count"                     (str aggregation-method  "(*)")
        "mean"                      "avg(%s)"
        "median"                    "percentile_cont(0.5) WITHIN GROUP (ORDER BY %s)"
        "distinct"                  "COUNT(DISTINCT %s)"


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Example viz showing proper count vs [dark-demo issue](https://dark-demo.akvolumen.org/visualisation/5f8841c5-9226-4dc7-b2e2-271ec3571e5d)
<img width="654" alt="Screenshot 2020-10-15 at 18 09 17" src="https://user-images.githubusercontent.com/731829/96156617-8f6bcf00-0f11-11eb-99ba-410dd26432d4.png">


<img width="1280" alt="Screenshot 2020-10-15 at 18 09 01" src="https://user-images.githubusercontent.com/731829/96156578-867afd80-0f11-11eb-8f20-9e7249c6f54a.png">
