### PR TITLE
[#2997] Docker Hub authentication as part of the build process

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,6 +4,12 @@ agent:
   machine:
     type: e1-standard-2
     os_image: ubuntu1804
+global_job_config:
+  secrets:
+    - name: docker-hub-credentials
+  prologue:
+    commands:
+      - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
 blocks:
   - name: 'Lumen: Build, test & deploy'
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,7 +9,7 @@ global_job_config:
     - name: docker-hub-credentials
   prologue:
     commands:
-      - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
+      - echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
 blocks:
   - name: 'Lumen: Build, test & deploy'
     task:


### PR DESCRIPTION
* Authenticate with the credentials already defined in SemaphoreCI

Docs: https://docs.semaphoreci.com/ci-cd-environment/docker-authentication/#how-to-authenticate-docker-pulls

Closes #2997 
