### PR TITLE
[#2756] Update data-groups sql select

### DIFF
--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -149,7 +149,7 @@ SELECT data_group.table_name AS "table-name",
    AND dataset_version_2.version=(SELECT max(version)
                                     FROM dataset_version_2
                                    WHERE dataset_id= :dataset-id)
-ORDER BY created;
+ORDER BY data_group.created;
 
 -- :name db-table-name-and-columns-by-dataset-id :? :1
 SELECT dataset_version.table_name AS "table-name",

--- a/backend/src/akvo/lumen/lib/dataset.sql
+++ b/backend/src/akvo/lumen/lib/dataset.sql
@@ -148,7 +148,8 @@ SELECT data_group.table_name AS "table-name",
    AND data_group.dataset_version_id = dataset_version_2.id
    AND dataset_version_2.version=(SELECT max(version)
                                     FROM dataset_version_2
-                                   WHERE dataset_id= :dataset-id);
+                                   WHERE dataset_id= :dataset-id)
+ORDER BY created;
 
 -- :name db-table-name-and-columns-by-dataset-id :? :1
 SELECT dataset_version.table_name AS "table-name",


### PR DESCRIPTION
order by created

```
tenant_lumen=> select  id, group_id, group_name, repeatable, table_name, created  from data_group where dataset_version_id='5f9bf41f-99b3-4716-a336-f2225e6cf7ca';
                  id                  | group_id  |            group_name             | repeatable |               table_name                |            created            
--------------------------------------+-----------+-----------------------------------+------------+-----------------------------------------+-------------------------------
 5f9bf41f-2c5e-4e05-a3bc-d3b40a9766dc | 563159117 | Media                             | f          | ds_3e7188e8_41e3_4d8e_be45_991e87ff070e | 2020-10-30 11:08:15.902322+00
 5f9bf41f-1e3f-4f21-aa49-8a99704cdee8 | 578759117 | Questions defining the data point | f          | ds_f35edaea_4bd4_427c_a3bd_8c877f17adcd | 2020-10-30 11:08:15.828146+00
 5f9bf41f-15c7-42c6-8b15-f2cfc773f97a | 584949117 | For those working on Saturday     | f          | ds_b7b02d9d_61da_4fd3_b487_3ef33bffaeae | 2020-10-30 11:08:15.871454+00
 5f9bf41f-47cd-4b21-b20f-ca660e8558fa | 601519116 | Group 2                           | f          | ds_a260f6d1_b388_4770_aacc_036c9f671632 | 2020-10-30 11:08:15.849386+00
 5f9bf41f-a4e5-4660-97af-237ad089b5fd | metadata  | metadata                          | f          | ds_0441b91b_a6c3_4d7b_a2e0_3c82b7df94e1 | 2020-10-30 11:08:15.803216+00
(5 rows)

tenant_lumen=> select  id, group_id, group_name, repeatable, table_name, created  from data_group where dataset_version_id='5f9bf41f-99b3-4716-a336-f2225e6cf7ca' order by created;
                  id                  | group_id  |            group_name             | repeatable |               table_name                |            created            
--------------------------------------+-----------+-----------------------------------+------------+-----------------------------------------+-------------------------------
 5f9bf41f-a4e5-4660-97af-237ad089b5fd | metadata  | metadata                          | f          | ds_0441b91b_a6c3_4d7b_a2e0_3c82b7df94e1 | 2020-10-30 11:08:15.803216+00
 5f9bf41f-1e3f-4f21-aa49-8a99704cdee8 | 578759117 | Questions defining the data point | f          | ds_f35edaea_4bd4_427c_a3bd_8c877f17adcd | 2020-10-30 11:08:15.828146+00
 5f9bf41f-47cd-4b21-b20f-ca660e8558fa | 601519116 | Group 2                           | f          | ds_a260f6d1_b388_4770_aacc_036c9f671632 | 2020-10-30 11:08:15.849386+00
 5f9bf41f-15c7-42c6-8b15-f2cfc773f97a | 584949117 | For those working on Saturday     | f          | ds_b7b02d9d_61da_4fd3_b487_3ef33bffaeae | 2020-10-30 11:08:15.871454+00
 5f9bf41f-2c5e-4e05-a3bc-d3b40a9766dc | 563159117 | Media                             | f          | ds_3e7188e8_41e3_4d8e_be45_991e87ff070e | 2020-10-30 11:08:15.902322+00
(5 rows)

```

![Screenshot 2020-10-30 at 12 11 21](https://user-images.githubusercontent.com/731829/97699349-450a5680-1aaa-11eb-83b5-1e117d25ceec.png)
