### PR TITLE
[#3007] Adapt logic to classic dataset view

### DIFF
--- a/client/src/containers/Dataset.jsx
+++ b/client/src/containers/Dataset.jsx
@@ -210,6 +210,7 @@ function Dataset(props) {
 
   useEffect(() => {
     if (!useDataGroups) {
+      setRowsCount(dataset && dataset.get('rows') && dataset.get('rows').size);
       return undefined; // exit early
     }
 


### PR DESCRIPTION
Fixing classical view. So setting rowsCount on data-groups=false

before the change
<img width="859" alt="Screenshot 2020-11-02 at 13 47 29" src="https://user-images.githubusercontent.com/731829/97869594-0c6cb600-1d12-11eb-99a4-bdecef9a564e.png">


After the change rows are shown

