### PR TITLE
[#3031] Adapt admin scripts to be executed with kubectl

### DIFF
--- a/NEW_TENANT.md
+++ b/NEW_TENANT.md
@@ -1,35 +1,33 @@
 # Setup new tenant
 
-When creating a new tenant, make sure to be at the corresponding branch to not
-get into issues. For production, make sure to be on the master branch!
 
-Creating a new tenant consists on one script ([akvo.lumen.admin.add-tenant](https://github.com/akvo/akvo-lumen/blob/master/backend/src/akvo/lumen/admin/add_tenant.clj). This script needs inputs (secrets & configs). The script
-includes comments on what env vars are needed and where to find them. Since there is issues running the script on a Mac (because of the encryption library used) we run the script on our docker container.
-
-## To create a new tenant
-```
-$ docker-compose exec backend run-as-user.sh env LUMEN_ENCRYPTION_KEY=... LUMEN_KEYCLOAK_URL=... LUMEN_KEYCLOAK_CLIENT_SECRET=... LUMEN_EMAIL_PASSWORD=... LUMEN_EMAIL_USER=... PG_HOST=... PG_DATABASE=... PG_USER=... PG_PASSWORD=... lein run -m akvo.lumen.admin.add-tenant "<FULL TENANT URL>" "<TENANT TITLE>" "<ADMIN EMAIL>" "<OPTIONAL AUTH TYPE>" "<OPTIONAL EDN FILE PATH>"
-```
-- LUMEN_KEYCLOAK_URL ends in /auth e.g: https://login.akvo.org/auth
-- LUMEN_ENCRYPTION_KEY is a key specific for the Kubernetes environment used for encrypting the db_uri which can be found in the lumen secret in K8s.
-Obtain it by first switch to correct gcloud env. For example:
-```
-$ gcloud container clusters get-credentials production --zone europe-west1-d --project akvo-lumen
-```
-Then (on mac):
-```
-$ kubectl get secret lumen -o yaml | grep 'encryption_key' | awk -F': ' '{print $2}' | base64 -D
-```
-(linux):
-```
-$ kubectl get secret lumen -o yaml | grep 'encryption_key' | awk -F': ' '{print $2}' | base64 -d
+```shell
+kubcetl gcloud container clusters get-credentials <KUBERNETES_ENV> --zone europe-west1-d --project akvo-lumen \
+  && kubectl exec <POD_ID> -c lumen-backend -- java -cp akvo-lumen.jar clojure.main -m akvo.lumen.admin.add-tenant <FULL_TENANT_URL> <TENANT_TITLE> <ADMIN_EMAIL>
 ```
 
+*Don't forget to add protocol* to `<FULL_TENANT_URL>`, that's to say `https://`
 
-More details in which values should we use for `KC_URL` and `KC_SECRET` can be found in [akvo.lumen.admin.add-tenant](https://github.com/akvo/akvo-lumen/blob/master/backend/src/akvo/lumen/admin/add_tenant.clj). You'll need to access [Keycloak admin console](https://login.akvo.org/auth/admin/akvo/console/)  to get `KC_SECRET`
+Example in test env: 
 
+```shell
+kubcetl gcloud container clusters get-credentials test --zone europe-west1-d --project akvo-lumen \
+  && kubectl exec <POD_ID> -c lumen-backend -- java -cp akvo-lumen.jar clojure.main -m akvo.lumen.admin.add-tenant https://testing.akvotest.org testing juan@akvo.org
 
-For `PG_HOST`,  `PG_DATABASE`, `PG_USER` and `PG_PASSWORD` go to [elephantsql](https://customer.elephantsql.com/login), click in `lumen-prod` or `lumen-dev` and following screen will show you the proper values. 
+```
 
+# Remove existent tenant
 
-*Don't forget to add protocol* to `<FULL TENANT URL>`, that's to say `http://` or `https://`
+```shell
+kubcetl gcloud container clusters get-credentials <KUBERNETES_ENV> --zone europe-west1-d --project akvo-lumen \
+  && kubectl exec <POD_ID> -c lumen-backend -- java -cp akvo-lumen.jar clojure.main -m akvo.lumen.admin.remove-tenant <TENANT_LABEL>
+
+```
+
+Example in test env:
+```shell
+kubcetl gcloud container clusters get-credentials test --zone europe-west1-d --project akvo-lumen \
+  && kubectl exec POD_ID -c lumen-backend -- java -cp akvo-lumen.jar clojure.main -m akvo.lumen.admin.remove-tenant testing
+
+```
+

--- a/backend/resources/akvo/lumen/prod.edn
+++ b/backend/resources/akvo/lumen/prod.edn
@@ -4,11 +4,9 @@
                                                        {:client_secret #duct/env "LUMEN_KEYCLOAK_CLIENT_SECRET"}}
  :akvo.lumen.component.emailer/mailjet-v3-emailer {:email-password #duct/env "LUMEN_EMAIL_PASSWORD"
                                                    :email-user #duct/env "LUMEN_EMAIL_USER"}
- :akvo.lumen.admin.db/config {:root {:password #duct/env "PG_PASSWORD" 
-                                     :database #duct/env "PG_DATABASE"
-                                     :user #duct/env "PG_USER" 
-                                     :host #duct/env "PG_HOST"}
-                              :lumen {:password #duct/env "PG_PASSWORD"}}
+ :akvo.lumen.admin.db/config {:config-adapter #ig/ref :akvo.lumen.admin.db/config-adapter}
+
+ :akvo.lumen.admin.db/config-adapter {:uri #duct/env [ "LUMEN_DB_URL" :or "jdbc:postgresql://postgres/lumen?user=lumen&password=password&ssl=true" ]}
 
  :akvo.lumen.component.error-tracker/config {:dsn "admin-sentry-client-dsn"
                                              :opts {:environment  "LUMEN_SENTRY_ENVIRONMENT"

--- a/backend/src/akvo/lumen/admin/add_tenant.clj
+++ b/backend/src/akvo/lumen/admin/add_tenant.clj
@@ -166,6 +166,7 @@
       (let [admin-system (admin.system/new-system (admin.system/new-config (or edn-file "akvo/lumen/prod.edn"))
                                                   (admin.system/ig-select-keys [:akvo.lumen.admin/add-tenant
                                                                                 :akvo.lumen.component.error-tracker/config
+                                                                                :akvo.lumen.admin.db/config-adapter
                                                                                 :akvo.lumen.component.error-tracker/prod]))
             administer (:akvo.lumen.admin/add-tenant admin-system)]
         (exec administer {:url url :title title :email email})))

--- a/backend/src/akvo/lumen/admin/remove_tenant.clj
+++ b/backend/src/akvo/lumen/admin/remove_tenant.clj
@@ -45,8 +45,11 @@
   (if (= (read-line) "Yes")    
     (binding [keycloak/http-client-req-defaults (http.client/req-opts 50000)]
       (admin.system/ig-derives)
-      (let [admin-system (admin.system/new-system (admin.system/new-config (or edn-file "prod.edn"))
-                                                  (admin.system/ig-select-keys [:akvo.lumen.admin/remove-tenant]))
+      (let [admin-system (admin.system/new-system (admin.system/new-config (or edn-file "akvo/lumen/prod.edn"))
+                                                  (admin.system/ig-select-keys [:akvo.lumen.admin/remove-tenant
+                                                                                :akvo.lumen.component.error-tracker/prod
+                                                                                :akvo.lumen.component.error-tracker/config
+                                                                                :akvo.lumen.admin.db/config-adapter]))
             administer (:akvo.lumen.admin/remove-tenant admin-system)]
         (exec administer label)
         (println "Ok")

--- a/backend/test/akvo/lumen/admin/db_test.clj
+++ b/backend/test/akvo/lumen/admin/db_test.clj
@@ -1,0 +1,17 @@
+(ns akvo.lumen.admin.db-test
+  (:require [akvo.lumen.admin.db :as a.db]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest ^:unit coerce-jdbc-url-test
+  (testing "coerce-jdbc-url"
+    (is (= {:user "user1"
+            :password "password"
+            :database "db1"
+            :host "localhost:5432"}
+           (a.db/coerce-jdbc-url "jdbc:postgresql://localhost:5432/db1?user=user1&password=password")))
+    (is (= {:user "lumen"
+            :password "password"
+            :ssl "true"
+            :database "lumen"
+            :host "postgres"}
+           (a.db/coerce-jdbc-url "jdbc:postgresql://postgres/lumen?user=lumen&password=password&ssl=true")))))


### PR DESCRIPTION
- Add a [config-adapter](https://github.com/akvo/akvo-lumen/pull/3032/files?file-filters%5B%5D=.clj&file-filters%5B%5D=.edn#diff-c64b11f481cc621606409b80009a080ba39863225c4293d755ae743b56a08795R9) admin component to reuse current `LUMEN_DB_URL` env var

- Adapt add-tenant and remove-tenant scripts

- docs updated => https://github.com/akvo/akvo-lumen/blob/e3c4670103060c5902971624ffd971e9bf1f6372/NEW_TENANT.md

Relates #3031 

tested locally (tenant:tangrammer)
<img width="908" alt="Screenshot 2020-11-05 at 18 35 50" src="https://user-images.githubusercontent.com/731829/98276123-cfb0f100-1f95-11eb-8bb6-4041e92e75ed.png">
