### PR TITLE
[#2748] Use new property to set a repeatable icon

### DIFF
--- a/client/src/utilities/dataset.js
+++ b/client/src/utilities/dataset.js
@@ -22,7 +22,7 @@ export const getDatasetGroups = (groupsList) => {
   const groupNames = groups.reduce((acc, curr) => acc.concat({
     id: curr.get(1).get(0).get('groupId'),
     name: curr.get(1).get(0).get('groupName'),
-    isRqg: curr.get(1).get(0).get('repeatable'),
+    isRqg: (curr.get(2) || false),
   }), []).sort((x, y) => {
     if (x.id === 'metadata') {
       return -1;


### PR DESCRIPTION
In previous iterations the `repeatable` property was set in the
column, now we have it at group level, in the 3rd position:

```
["<group-name">, [<columns definition>], <is_repeatable>, [...]]
```

Example:

```
["group name", [{col1},{col2},{col2}], true]
```

Closes #2748 