### PR TITLE
[#3045] Hide `Instance id` column from non-metadata groups

### DIFF
--- a/client/src/containers/Dataset.jsx
+++ b/client/src/containers/Dataset.jsx
@@ -297,6 +297,7 @@ function Dataset(props) {
     return <LoadingSpinner />;
   }
 
+
   return (
     <NavigationPrompt
       shouldPrompt={pendingSaving.savingFailed}
@@ -308,7 +309,7 @@ function Dataset(props) {
             history={history}
             datasetId={datasetId}
             group={currentGroup}
-            columns={currentGroup ? currentGroup.get('columns') : null}
+            columns={currentGroup ? currentGroup.get('columns').filter(c => !c.get('hidden')) : null}
             rows={currentGroup ? currentGroup.get('rows') : null}
             rowsCount={rowsCount}
             groups={dataset.get('groups') ? dataset.get('groups').filter(group => group.get(1).size) : null}


### PR DESCRIPTION
The `Instance id` column is a special column that serves as link
(internally a foreign key) for all data groups to the parent one
(metadata). The user must not be able to transform this
column. Initially we're going to hide it.

Since the column already has a property `hidden` we just use it to
include or not the column.

Closes #3045 