### PR TITLE
[#3036] Preserve columns order after transformation

### DIFF
--- a/backend/src/akvo/lumen/lib/transformation/engine.clj
+++ b/backend/src/akvo/lumen/lib/transformation/engine.clj
@@ -158,7 +158,11 @@
         previous-columns (into (vec (:columns data-group)) other-dgs-columns)]
     (let [{:keys [success? message columns execution-log error-data]}
           (try-apply-operation deps source-table previous-columns (assoc transformation :dataset-id dataset-id))
-          columns (vec (set/difference (set columns) (set other-dgs-columns)))]
+          columns (let [other-dgs-columns-set (set other-dgs-columns)]
+                    (reduce (fn [container column]
+                              (if (contains? other-dgs-columns-set column)
+                                container
+                                (conj container column))) [] columns))]
       (when-not success?
         (log/errorf "Failed to transform: %s, columns: %s, execution-log: %s, data: %s" message columns execution-log error-data)
         (throw (ex-info (or message "") {})))


### PR DESCRIPTION
- [ ] **Update release notes if necessary**

Using set/difference we lost the original columns order

previous result (derived column is "test combine column")
![Screenshot 2020-11-30 at 10 57 15](https://user-images.githubusercontent.com/731829/100600527-b0418580-3301-11eb-89e3-e5cc786889be.png)


result with this PR changes (order is preserved and new derived column is places at the end)
![Screenshot 2020-11-30 at 11 47 13](https://user-images.githubusercontent.com/731829/100600661-dbc47000-3301-11eb-8408-922b3877bed0.png)


