### PR TITLE
[#3061] Restrict dropdown select columns to current data-groups in client side

### DIFF
--- a/client/src/components/dataset/DataTableSidebar.jsx
+++ b/client/src/components/dataset/DataTableSidebar.jsx
@@ -57,5 +57,7 @@ DataTableSidebar.propTypes = {
     ]
   ).isRequired,
   onClose: PropTypes.func.isRequired,
+  env: PropTypes.object,
+  group: PropTypes.object,
   intl: intlShape,
 };

--- a/client/src/components/dataset/DatasetTableV2.jsx
+++ b/client/src/components/dataset/DatasetTableV2.jsx
@@ -3,6 +3,7 @@ import React, { useRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Column, Cell, Table } from 'fixed-data-table-2';
 import moment from 'moment';
+import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { injectIntl, intlShape } from 'react-intl';
 import Immutable from 'immutable';
@@ -452,6 +453,7 @@ function DatasetTable(props) {
   };
 
   return (
+
     <React.Fragment>
       {renderHeader()}
 
@@ -484,6 +486,8 @@ function DatasetTable(props) {
                   isLockedFromTransformations={
                     props.isLockedFromTransformations
                   }
+                  env={props.env}
+                  group={props.group}
                   datasetId={props.datasetId}
                   pendingTransformations={props.pendingTransformations}
                 />
@@ -575,6 +579,7 @@ DatasetTable.propTypes = {
   rowsCount: PropTypes.number,
   transformations: PropTypes.object,
   dataSourceKind: PropTypes.string,
+  env: PropTypes.object,
 };
 
-export default withRouter(injectIntl(DatasetTable));
+export default withRouter(injectIntl(connect(state => ({ env: state.env }))(DatasetTable)));

--- a/client/src/components/dataset/sidebars/CombineColumns.jsx
+++ b/client/src/components/dataset/sidebars/CombineColumns.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'immutable';
+import { get } from 'lodash';
 import { FormattedMessage, intlShape } from 'react-intl';
 import SelectMenu from '../../common/SelectMenu';
 import SidebarHeader from './SidebarHeader';
@@ -63,8 +64,11 @@ export default class CombineColumns extends Component {
     const oppositeColumnId = selectId === 1 ? 0 : 1; // setting the id to check the opposite column
     const args = this.state.transformation.get('args');
     const oppositeColumnName = args.getIn(['columnNames', oppositeColumnId]);
-
-    return filterColumnsByDataGroupDimension(this.props.columns, oppositeColumnName);
+    let columns = this.props.columns;
+    if (get(this.props.env, 'environment.data-groups') && this.props.group) {
+      columns = columns.filter(x => x.get('groupId') === this.props.group.get('groupId'));
+    }
+    return filterColumnsByDataGroupDimension(columns, oppositeColumnName);
   }
 
   isValidTransformation() {
@@ -177,5 +181,7 @@ CombineColumns.propTypes = {
   onClose: PropTypes.func.isRequired,
   onApply: PropTypes.func.isRequired,
   columns: PropTypes.object.isRequired,
+  env: PropTypes.object,
+  group: PropTypes.object,
   intl: intlShape,
 };


### PR DESCRIPTION
UI parts to be accomplished:

- [x] combine-columns transformation
- [ ] extract-multiple transformation
- [ ] split-column transformation
- [ ] derive-category transformation
- [ ] merge-datasets transformation
- [ ] generate-geopoints transformation
- [ ] reverse-geocode transformation
