### PR TITLE
[#2740] Only show icon if data-groups flag

### DIFF
--- a/client/src/components/dataset/ColumnHeader.jsx
+++ b/client/src/components/dataset/ColumnHeader.jsx
@@ -65,8 +65,7 @@ class ColumnHeader extends Component {
   }
 
   render() {
-    const { column, disabled } = this.props;
-
+    const { column, disabled, env } = this.props;
     return (
       <div
         className={`ColumnHeader ${disabled ? '' : 'clickable'}
@@ -117,7 +116,7 @@ class ColumnHeader extends Component {
             </span>
           }
           <ConditionalTooltip>
-            {isTransformationColumn(column.get('columnName')) && <span className="fxColumn">fx</span>}
+            {env.environment['data-groups'] && isTransformationColumn(column.get('columnName')) && <span className="fxColumn">fx</span>}
             {column.get('title')}
           </ConditionalTooltip>
         </span>
@@ -171,4 +170,5 @@ ColumnHeader.propTypes = {
   columnMenuActive: PropTypes.bool.isRequired,
   disabled: PropTypes.bool,
   intl: intlShape.isRequired,
+  env: PropTypes.object.isRequired,
 };

--- a/client/src/components/dataset/DatasetTable.jsx
+++ b/client/src/components/dataset/DatasetTable.jsx
@@ -424,6 +424,7 @@ class DatasetTable extends Component {
       const columnHeader = (
         <ColumnHeader
           key={index}
+          env={this.props.env}
           column={column}
           onToggleDataTypeContextMenu={this.handleToggleDataTypeContextMenu}
           onToggleColumnContextMenu={this.handleToggleColumnContextMenu}
@@ -594,6 +595,7 @@ DatasetTable.propTypes = {
   Header: PropTypes.any,
   headerProps: PropTypes.object,
   datasetRowAvailable: PropTypes.bool,
+  env: PropTypes.object.isRequired,
 };
 
 export default withRouter(injectIntl(DatasetTable));

--- a/client/src/components/dataset/DatasetTableV2.jsx
+++ b/client/src/components/dataset/DatasetTableV2.jsx
@@ -369,6 +369,7 @@ function DatasetTable(props) {
     const columnHeader = (
       <ColumnHeader
         key={index}
+        env={props.env}
         column={column}
         onToggleDataTypeContextMenu={handleToggleDataTypeContextMenu}
         onToggleColumnContextMenu={handleToggleColumnContextMenu}
@@ -575,6 +576,7 @@ DatasetTable.propTypes = {
   rowsCount: PropTypes.number,
   transformations: PropTypes.object,
   dataSourceKind: PropTypes.string,
+  env: PropTypes.object.isRequired,
 };
 
 export default withRouter(injectIntl(DatasetTable));

--- a/client/src/containers/Dataset.jsx
+++ b/client/src/containers/Dataset.jsx
@@ -309,6 +309,7 @@ function Dataset(props) {
           <DatasetTableV2
             history={history}
             datasetId={datasetId}
+            env={props.env}
             group={currentGroup}
             columns={currentGroup ? currentGroup.get('columns') : null}
             rows={currentGroup ? currentGroup.get('rows') : null}
@@ -343,6 +344,7 @@ function Dataset(props) {
         ) : (
           <DatasetTableV1
             history={history}
+            env={props.env}
             datasetId={datasetId}
             columns={getColumns(dataset)}
             rows={getRows(dataset)}
@@ -381,7 +383,8 @@ Dataset.propTypes = {
   params: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired,
   history: PropTypes.object.isRequired,
+  env: PropTypes.object.isRequired,
 };
 
 // // Just inject `dispatch`
-export default withRouter(connect()(Dataset));
+export default withRouter(connect(state => state)(Dataset));


### PR DESCRIPTION
Thus, on the contrary we'll have in transformatios group every column
with the icon

to avoid https://github.com/akvo/akvo-lumen/issues/2740#issuecomment-654152490

- [ ] **Update release notes if necessary**
