### PR TITLE
[#3110] Add support for multiple to multiple using js derivation

### DIFF
--- a/backend/specs/akvo/lumen/specs/transformation.clj
+++ b/backend/specs/akvo/lumen/specs/transformation.clj
@@ -128,7 +128,7 @@
 
 (s/def ::transformation.derive/code string?) ;; improve js validation
 
-(s/def ::transformation.derive/newColumnType #{"number" "text" "date"})
+(s/def ::transformation.derive/newColumnType #{"number" "text" "date" "option"})
 
 (s/def ::transformation.derive/args
   (s/keys :req-un [::transformation.derive/newColumnTitle

--- a/backend/src/akvo/lumen/lib/transformation/derive.clj
+++ b/backend/src/akvo/lumen/lib/transformation/derive.clj
@@ -108,7 +108,8 @@
   (condp = type
     "text"   "text"
     "number" "double precision"
-    "date"   "timestamptz"))
+    "date"   "timestamptz"
+    "option" "text"))
 
 (defn args [op-spec]
   (let [{code         "code"

--- a/backend/src/akvo/lumen/util.clj
+++ b/backend/src/akvo/lumen/util.clj
@@ -76,7 +76,7 @@
        (boolean (re-find #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" s))))
 
 (defn valid-type? [s]
-  (#{"text" "number" "date" "geopoint"} s))
+  (#{"text" "number" "date" "geopoint" "option"} s))
 
 (defn conform
   ([s d]

--- a/client/src/components/dataset/sidebars/DeriveColumnJavascript.jsx
+++ b/client/src/components/dataset/sidebars/DeriveColumnJavascript.jsx
@@ -23,6 +23,9 @@ const typeOptions = [
   }, {
     label: <FormattedMessage id="date" />,
     value: 'date',
+  }, {
+    label: <FormattedMessage id="option" />,
+    value: 'option',
   },
 ];
 


### PR DESCRIPTION
- Now js derivation can output a `option` type column too

- added js function: `akvoMultipleToMultiple(valuesToKeep, uncategorizedValue, v)`
eg: `akvoMultipleToMultiple(['opt1','opt2'], 'others', row['col title'])`


<img width="529" alt="Screenshot 2021-05-06 at 15 04 58" src="https://user-images.githubusercontent.com/731829/117303034-8d9d3500-ae7c-11eb-9671-4320f30eb2ee.png">

<img width="436" alt="Screenshot 2021-05-06 at 15 05 07" src="https://user-images.githubusercontent.com/731829/117303025-8bd37180-ae7c-11eb-8bc5-4c51b974f688.png">
