### PR TITLE
[#3158] Aggregation temp views (except map types)

### DIFF
--- a/backend/src/akvo/lumen/lib/aggregation.clj
+++ b/backend/src/akvo/lumen/lib/aggregation.clj
@@ -2,10 +2,11 @@
   (:require [akvo.lumen.db.dataset :as db.dataset]
             [akvo.lumen.lib :as lib]
             [akvo.lumen.util :as util]
+            [akvo.lumen.specs.db.dataset-version.column :as db.dsv.column.s]
             [akvo.lumen.lib.dataset :as dataset]
             [akvo.lumen.lib.visualisation :as visualisation]
             [akvo.lumen.lib.visualisation.maps :as maps]
-            [akvo.lumen.lib.aggregation.commons :as commons]
+            [akvo.lumen.lib.aggregation.commons :as commons :refer (cols*)]
             [akvo.lumen.lib.aggregation.pie :as pie]
             [akvo.lumen.lib.aggregation.maps :as a.maps]
             [akvo.lumen.lib.aggregation.line :as line]
@@ -16,9 +17,9 @@
             [akvo.lumen.lib.data-group :as data-group]
             [akvo.lumen.lib.env :as env]
             [clojure.tools.logging :as log]
+            [clojure.spec.alpha :as s]
             [clojure.java.jdbc :as jdbc]
             [clojure.walk :as walk]))
-
 
 (defmulti query*
   (fn [tenant-conn dataset visualisation-type query]
@@ -32,7 +33,7 @@
 
 (defn data-groups-query [tenant-conn dataset-id visualisation-type query]
   (jdbc/with-db-transaction [tenant-tx-conn tenant-conn]
-    (if-let [data (data-group/create-view-from-data-groups tenant-tx-conn dataset-id) ]
+    (if-let [{:keys [table-name columns] :as data} (data-group/create-view-from-data-groups tenant-tx-conn dataset-id (util/squuid) (cols* visualisation-type query))]
       (query* tenant-tx-conn (select-keys data [:table-name :columns]) visualisation-type query)
       (lib/not-found {"datasetId" dataset-id}))))
 
@@ -143,7 +144,7 @@
     (merge-dashboard-filters visualisation filters)))
 
 (defn visualisation-response-data [tenant-conn id windshaft-url filters counter]
-  (log/info (format "Before! Counter %s - Vis id: %s" @counter id ))
+  (log/debug (format "Before! Counter %s - Vis id: %s" @counter id ))
   (swap! counter inc)
   (util/time-with-log
    (format "Vis id: %s" id)
@@ -196,3 +197,42 @@
 (defmethod query* "bubble"
     [tenant-conn dataset _ query]
     (bubble/query tenant-conn dataset query))
+
+(defn cols-ids
+  "extract columns ids from data using specs"
+  [spec data]
+  (let [ids    (atom #{})
+        add-id (fn [id]
+                 (when id
+                   (swap! ids conj id)))]
+    (binding [db.dsv.column.s/*columnName?* add-id]
+      (s/explain-str spec data)
+      (deref ids))))
+
+(defmethod cols* "pivot"
+  [_ query]
+  (cols-ids :akvo.lumen.lib.aggregation.pivot/query query))
+
+(defmethod cols* "pie"
+  [_ query]
+  (cols-ids :akvo.lumen.lib.aggregation.pie/query query))
+
+(defmethod cols* "donut"
+  [_ query]
+  (cols-ids :akvo.lumen.lib.aggregation.donut/query query))
+
+(defmethod cols* "line"
+  [_ query]
+  (cols-ids :akvo.lumen.lib.aggregation.line/query query))
+
+(defmethod cols* "bar"
+  [_ query]
+  (cols-ids :akvo.lumen.lib.aggregation.bar/query query))
+
+(defmethod cols* "scatter"
+  [_ query]
+  (cols-ids :akvo.lumen.lib.aggregation.scatter/query query))
+
+(defmethod cols* "bubble"
+  [_ query]
+  (cols-ids :akvo.lumen.lib.aggregation.bubble/query query))

--- a/backend/src/akvo/lumen/lib/aggregation/commons.clj
+++ b/backend/src/akvo/lumen/lib/aggregation/commons.clj
@@ -8,6 +8,10 @@
             [clojure.string :as str]
             [clojure.walk :as walk]))
 
+(defmulti cols*
+  (fn [visualisation-type query]
+    visualisation-type))
+
 (defn run-query [tenant-conn sql]
   (log/debug :run-query sql)
   (rest (jdbc/query tenant-conn [sql] {:as-arrays? true})))

--- a/backend/src/akvo/lumen/lib/data_group.clj
+++ b/backend/src/akvo/lumen/lib/data_group.clj
@@ -88,7 +88,6 @@
     {:table-name t-name :columns (or all-columns columns)}))
 
 (defn- main-metadata
-  "data-groups persistent view needs at least metadata or main for the following joins"
   [all-data-groups]
   (first (or (seq (filter #(= "metadata" (:group-id %)) all-data-groups))
              (seq (filter #(= "main" (:group-id %)) all-data-groups)))))
@@ -99,7 +98,7 @@
   (into #{(main-metadata all-data-groups)}
         (mapv (partial datagroup-by-column all-data-groups) cols)))
 
-(defn- response-with-updated-persisted-view
+(defn- temp-view-response-with-selected-data-groups
   [tenant-conn viz-id dataset-version-id all-data-groups cols]
   (let [data-groups-selected* (data-groups-selected all-data-groups cols)]
     (response tenant-conn
@@ -114,6 +113,6 @@
                                        (map #(update % :columns (comp walk/keywordize-keys vec)))))]
     (let [dataset-version-id (:dataset-version-id (first all-data-groups))]
       (if viz-id
-        (response-with-updated-persisted-view tenant-conn viz-id dataset-version-id all-data-groups cols)
+        (temp-view-response-with-selected-data-groups tenant-conn viz-id dataset-version-id all-data-groups cols)
         (response tenant-conn all-data-groups
                   (view-table-name (:dataset-version-id (first all-data-groups))))))))

--- a/backend/src/akvo/lumen/lib/data_group.clj
+++ b/backend/src/akvo/lumen/lib/data_group.clj
@@ -61,7 +61,7 @@
     (jdbc/execute! conn [(format "DROP VIEW IF EXISTS %s" view-name)])))
 
 (defn log** [x]
-  (log/error x)
+  (log/debug x)
   x)
 
 (defn- all-dg-columns [data-groups]

--- a/backend/test/akvo/lumen/lib/data_group_test.clj
+++ b/backend/test/akvo/lumen/lib/data_group_test.clj
@@ -45,4 +45,4 @@
 
 (deftest ^:unit data-groups-view
   (let [expected "CREATE TEMP VIEW foo AS SELECT * FROM bar"]
-    (is (= expected (str/trim (data-group/data-groups-view "foo" true false "SELECT * FROM bar"))))))
+    (is (= expected (str/trim (data-group/data-groups-view "foo" true "SELECT * FROM bar"))))))


### PR DESCRIPTION
This approach is to use temporary and dynamic db views for all aggregations but map types.

Using specs to extrac col-names from aggregation query payload (Follows same auth approach https://github.com/akvo/akvo-lumen/blob/master/backend/src/akvo/lumen/lib/auth.clj#L215-L231) we derive the data-groups used in the aggregation and then build a temp view (previously we changed temp views to persisted views thus map aggregations needs to be called from external windshaft service) 
Map aggregations keeps the same (persistent and complete dataset db views) ... perhaps we'd need to change the approach in the future too

